### PR TITLE
Set up app skeleton and MiniPay gate

### DIFF
--- a/.claude/TODO.md
+++ b/.claude/TODO.md
@@ -1,0 +1,56 @@
+## Session Plan - 2026-03-04
+
+### Current State
+- ✅ **Completed**: Monorepo base generado con Celo Composer; app web y contracts separados en `apps/web` y `apps/contracts`.
+- 🚧 **In Progress**: Correcciones iniciales de wallet/navbar en `apps/web`; backlog y execution plan para Buildathon/MiniPay.
+- ⚠️ **Blockers**: No existen milestones/labels/issues de ejecución; no hay routes MVP, contracts productivos ni guía MiniPay en el repo.
+- 🔧 **Tech Debt**: README genérico, contrato ejemplo `Lock.sol`, sin leaderboard/indexing y sin estructura de submission pack.
+
+### Project Context
+- **Type**: Web + Smart Contracts monorepo
+- **Stack**: Next.js 14, TypeScript, Tailwind, wagmi/viem, RainbowKit, Hardhat, Turborepo
+- **Testing**: TypeScript type-check en web, Hardhat tests en contracts
+
+### Next Steps (Prioritized)
+
+#### Priority 1: Critical
+1. **Backlog operativo en GitHub** - M
+   - **Why**: Sin milestones/issues no hay ruta crítica visible ni ownership claro.
+   - **Acceptance**: Milestones M0-M4, labels por tipo/área/prioridad e issues creados con AC/DoD.
+   - **Notes**: Mantener títulos cortos y labels consistentes para PRs pequeños.
+
+2. **Baseline MiniPay + app skeleton** - M
+   - **Why**: Todo el MVP depende de rutas móviles, detección MiniPay y guía de prueba en device real.
+   - **Acceptance**: `/`, `/levels`, `/play/[piece]`, `/result`, `/leaderboard`; wallet UX compatible con MiniPay; README actualizado.
+
+3. **Gameplay Torre + contracts base** - L
+   - **Why**: La demo solo es creíble si el loop jugar -> score -> badge existe de punta a punta.
+   - **Acceptance**: Renderer 8x8, rules engine Torre, challenge local, `submitScore`, `claimBadge`, deploy scripts reproducibles.
+
+#### Priority 2: High
+1. **Leaderboard v1 por eventos** - M
+   - **Dependencies**: `ScoreSubmitted` desplegado en chain.
+   - **Acceptance**: API con cache 60s y top 10 visible en `/leaderboard`.
+
+2. **Submission pack** - M
+   - **Dependencies**: Demo funcional en mainnet.
+   - **Acceptance**: Deck, video, Karma GAP y links públicos listos.
+
+#### Priority 3: Medium
+1. **Passport gating** - M
+   - **Description**: Bonus bounty para ranked leaderboard o special badge.
+
+2. **Second/third pieces** - M
+   - **Description**: Alfil y Caballo solo después de cerrar M2/M3.
+
+### Technical Decisions Made
+- **Ruta crítica cerrada en Torre primero**: Evitar scope creep; Alfil/Caballo van después del loop on-chain completo.
+- **Leaderboard sin subgraph al inicio**: Leer eventos vía RPC para reducir complejidad y tiempo de integración.
+- **MiniPay como entorno primario**: UX debe ocultar connect redundante y usar transacciones legacy con `feeCurrency` solo cuando aplique.
+
+### Notes for Next Session
+- Validar en device real, nunca en emulador.
+- Documentar `ngrok` y Developer Mode en README.
+- Convertir `apps/contracts/contracts/Lock.sol` en contracts productivos de Scoreboard y Badges.
+
+---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+- 
+
+## Issue
+- Closes #
+
+## Validation
+- [ ] `pnpm --filter web type-check`
+- [ ] `pnpm --filter web lint`
+- [ ] `pnpm --filter web build`
+
+## MiniPay QA
+- [ ] Not applicable
+- [ ] Validated on real device
+- [ ] Validated via Developer Mode + Load Test Page
+- [ ] Validated using `ngrok`
+
+## Notes
+- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+## Working Rules
+
+- Work only on the next issue in the critical path unless scope is explicitly changed.
+- Keep changes as vertical slices with small diffs.
+- Avoid broad refactors unless they are required to complete the active issue.
+- Use TypeScript, Next.js, and viem/wagmi patterns already present in the repo.
+
+## Commit Policy
+
+- Make granular and frequent commits while implementing each issue.
+- Each commit should represent a single logical step that can be reviewed independently.
+- Do not batch unrelated changes into the same commit.
+- Prefer conventional commit messages such as `feat(web): add levels route skeleton`.
+
+## Pull Request Policy
+
+- All changes must land through pull requests, even when only one contributor is actively shipping.
+- Keep PRs scoped to one issue or one vertical slice.
+- Reference the issue number in the PR title or body.
+- Include exact validation commands and any MiniPay device validation notes.
+
+## Auto-merge Policy
+
+- PRs should be set to auto-merge after checks pass.
+- Prefer squash merge for small vertical slices unless there is a reason to preserve commit history in the final branch.
+- If auto-merge is blocked by repository settings, enable it at the repo level and continue using PRs as the default path to `main`.
+
+## QA Baseline
+
+- Run `pnpm --filter web type-check`
+- Run `pnpm --filter web lint`
+- Run `pnpm --filter web build`
+- For MiniPay-specific changes, validate on a real device with Developer Mode, Load Test Page, and `ngrok`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,40 @@
-# chesscito
+# Chesscito
 
-A new Celo blockchain project
+Chesscito is a MiniPay MiniApp for cognitive enrichment through short pre-chess challenges. The product direction is educational, playful, and measurable. It must not make medical claims.
 
-A modern Celo blockchain application built with Next.js, TypeScript, and Turborepo.
+## Submission Links
+
+- Live demo URL: `TBD`
+- Celo Mainnet deployment: `TBD`
+- Presentation deck: `TBD`
+- Demo video: `TBD`
+- Karma GAP project: `TBD`
+- Public GitHub repo: https://github.com/wolfcito/chesscito
+
+## North Star
+
+Ship a MiniPay MiniApp on Celo Mainnet with:
+- Gameplay MVP for Tower first, then Bishop/Knight if time remains
+- On-chain proof via `submitScore` and `claimBadge`
+- Functional Top 10 leaderboard
+- Submission pack complete in Karma GAP
+
+## Project Structure
+
+This monorepo is managed by Turborepo:
+
+- `apps/web` — Next.js 14 MiniApp frontend
+- `apps/contracts` — Hardhat contracts and deployment scripts
+- `docs/planning` — roadmap, backlog, and execution notes
+- `docs/submission` — deck outline and demo video script
+- `.github` — PR workflow defaults and templates
+
+## Workflow
+
+- Use granular, frequent commits during implementation.
+- Land changes through small PRs aligned to a single issue or vertical slice.
+- Enable auto-merge for PRs after checks pass.
+- Follow the project workflow in `CONTRIBUTING.md`.
 
 ## Getting Started
 
@@ -10,49 +42,64 @@ A modern Celo blockchain application built with Next.js, TypeScript, and Turbore
    ```bash
    pnpm install
    ```
-
 2. Start the development server:
    ```bash
    pnpm dev
    ```
-
-3. Open [http://localhost:3000](http://localhost:3000) in your browser.
-
-## Project Structure
-
-This is a monorepo managed by Turborepo with the following structure:
-
-- `apps/web` - Next.js application with embedded UI components and utilities
-- `apps/hardhat` - Smart contract development environment
+3. Open `http://localhost:3000`.
 
 ## Available Scripts
 
-- `pnpm dev` - Start development servers
-- `pnpm build` - Build all packages and apps
-- `pnpm lint` - Lint all packages and apps
-- `pnpm type-check` - Run TypeScript type checking
+- `pnpm dev` — start local development
+- `pnpm build` — build all workspaces
+- `pnpm lint` — lint all workspaces
+- `pnpm type-check` — type-check all workspaces
+- `pnpm contracts:compile` — compile contracts
+- `pnpm contracts:test` — run contract tests
+- `pnpm contracts:deploy` — deploy to local network
+- `pnpm contracts:deploy:celo-sepolia` — deploy to Celo Sepolia
+- `pnpm contracts:deploy:celo` — deploy to Celo Mainnet
 
-### Smart Contract Scripts
+## Testing in MiniPay (Device)
 
-- `pnpm contracts:compile` - Compile smart contracts
-- `pnpm contracts:test` - Run smart contract tests
-- `pnpm contracts:deploy` - Deploy contracts to local network
-- `pnpm contracts:deploy:celo-sepolia` - Deploy to Celo Sepolia Testnet
-- `pnpm contracts:deploy:celo` - Deploy to Celo Mainnet
+MiniPay validation must happen on a real mobile device. Do not use an emulator.
 
-## Tech Stack
+1. Start the web app:
+   ```bash
+   pnpm --filter web dev
+   ```
+2. Expose the local app:
+   ```bash
+   ngrok http 3000
+   ```
+3. On your phone, open MiniPay.
+4. Go to `Settings > About`.
+5. Tap the `Version` row repeatedly until Developer Mode is enabled.
+6. Open `Developer Settings`.
+7. Tap `Load Test Page`.
+8. Paste the current HTTPS `ngrok` URL and launch the app.
 
-- **Framework**: Next.js 14 with App Router
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS
-- **UI Components**: shadcn/ui
-- **Smart Contracts**: Hardhat with Viem
-- **Monorepo**: Turborepo
-- **Package Manager**: PNPM
+Compatibility rules:
+- Guard wallet initialization behind `window.provider` or `window.ethereum`.
+- Hide redundant connect-wallet UX inside MiniPay.
+- Assume legacy transactions only in MiniPay.
+- Treat `feeCurrency` as optional and validate support in the target environment before enabling it.
 
-## Learn More
+Troubleshooting:
+- If no provider appears, reload the page inside MiniPay and confirm you opened it from `Load Test Page`, not a normal browser tab.
+- If the connect button still shows inside MiniPay, verify `window.ethereum?.isMiniPay` is present in the device session and hard-refresh the page.
+- If the `ngrok` URL stops working, restart `ngrok`, copy the new HTTPS URL, and update `Load Test Page`.
 
-- [Next.js Documentation](https://nextjs.org/docs)
-- [Celo Documentation](https://docs.celo.org/)
-- [Turborepo Documentation](https://turbo.build/repo/docs)
-- [shadcn/ui Documentation](https://ui.shadcn.com/)
+References:
+- MiniPay quickstart: https://docs.celo.org/build/build-on-minipay/quickstart
+- MiniPay quickstart (current path): https://docs.celo.org/build-on-celo/build-on-minipay/quickstart
+- ngrok setup: https://docs.celo.org/build/build-on-minipay/prerequisites/ngrok-setup
+- viem on Celo: https://docs.celo.org/developer/viem
+
+## Delivery Definition
+
+- `pnpm lint` and `pnpm build` pass in `apps/web`
+- Contracts have reproducible testnet and mainnet deploy flows
+- Demo is recorded on a real mobile device inside MiniPay
+- No redundant wallet connect prompt is shown inside MiniPay
+- Basic anti-spam protections exist for score submission and badge claim

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,6 +2,11 @@
 const nextConfig = {
   reactStrictMode: true,
   webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@react-native-async-storage": false,
+      "@react-native-async-storage/async-storage": false,
+    }
     config.externals.push('pino-pretty', 'lokijs', 'encoding')
     return config
   },

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4,39 +4,36 @@
 
 @layer base {
   :root {
-    --border: 214.3 31.8% 91.4%;
-    --input: 216 33% 97%;
-    --ring: 215 20.2% 65.1%;
-
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 150 40% 98%;
+    --foreground: 222 33% 10%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 33% 10%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 222 33% 10%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 156 91% 31%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 219 20% 20%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 210 40% 96%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 210 29% 95%;
+    --muted-foreground: 215 16% 38%;
 
-    --accent: 210 40% 96%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 155 62% 92%;
+    --accent-foreground: 160 84% 18%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 76% 55%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 210 24% 90%;
+    --input: 210 24% 90%;
+    --ring: 156 91% 31%;
 
-    --radius: 0.5rem;
+    --radius: 1rem;
+    --app-max-width: 390px;
   }
 
   .dark {
@@ -74,7 +71,23 @@
   * {
     @apply border-border;
   }
+  html {
+    font-family: "SF Pro Display", "SF Pro Text", "Segoe UI", sans-serif;
+  }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+    background-image:
+      radial-gradient(circle at top, rgba(7, 149, 95, 0.18), transparent 32%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(240, 249, 244, 0.94));
+    min-height: 100vh;
+  }
+  main {
+    width: 100%;
+  }
+}
+
+@layer components {
+  .mobile-frame {
+    width: min(100%, var(--app-max-width));
   }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,15 +1,12 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import './globals.css';
 
 import { Navbar } from '@/components/navbar';
 import { WalletProvider } from "@/components/wallet-provider"
 
-const inter = Inter({ subsets: ['latin'] });
-
 export const metadata: Metadata = {
   title: 'chesscito',
-  description: 'A new Celo blockchain project',
+  description: 'MiniPay MiniApp for playful cognitive enrichment through pre-chess challenges.',
 };
 
 export default function RootLayout({
@@ -19,12 +16,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
-        {/* Navbar is included on all pages */}
-        <div className="relative flex min-h-screen flex-col">
+      <body>
+        <div className="relative flex min-h-screen flex-col bg-background text-foreground">
           <WalletProvider>
             <Navbar />
-            <main className="flex-1">
+            <main className="flex flex-1 flex-col">
               {children}
             </main>
           </WalletProvider>

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,0 +1,40 @@
+import { AppShell } from "@/components/app-shell";
+
+const rows = [
+  { rank: 1, player: "0x71...2d4c", score: 980, time: "18.4s" },
+  { rank: 2, player: "0x8a...96bb", score: 910, time: "20.1s" },
+  { rank: 3, player: "0x0f...cc31", score: 860, time: "22.7s" },
+];
+
+export default function LeaderboardPage() {
+  return (
+    <AppShell
+      eyebrow="Leaderboard"
+      title="Top 10"
+      description="Aqui se conectara el endpoint que leerá eventos on-chain. Por ahora dejamos la ruta y la estructura movil."
+      cta={{ href: "/levels", label: "Volver a jugar" }}
+      secondaryCta={{ href: "/result", label: "Ver resultado" }}
+    >
+      <div className="space-y-3">
+        {rows.map((row) => (
+          <div
+            key={row.rank}
+            className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-2xl border border-slate-200 px-4 py-4"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary text-sm font-semibold text-white">
+              {row.rank}
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-slate-950">{row.player}</p>
+              <p className="text-sm text-slate-500">Tiempo {row.time}</p>
+            </div>
+            <div className="text-right">
+              <p className="text-lg font-semibold text-slate-950">{row.score}</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">pts</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/app/levels/page.tsx
+++ b/apps/web/src/app/levels/page.tsx
@@ -1,0 +1,53 @@
+import { AppShell } from "@/components/app-shell";
+
+const levels = [
+  {
+    piece: "Torre",
+    href: "/play/rook",
+    status: "MVP",
+    description: "Aprende lineas rectas, control de columnas y capturas basicas.",
+  },
+  {
+    piece: "Alfil",
+    href: "/play/bishop",
+    status: "Stretch",
+    description: "Ruta reservada para diagonales en la siguiente fase.",
+  },
+  {
+    piece: "Caballo",
+    href: "/play/knight",
+    status: "Stretch",
+    description: "Ruta reservada para patrones en L y vision tactica.",
+  },
+];
+
+export default function LevelsPage() {
+  return (
+    <AppShell
+      eyebrow="Levels"
+      title="Escoge una pieza"
+      description="La ruta critica arranca con Torre. Alfil y Caballo quedan listos como placeholders para los siguientes vertical slices."
+      cta={{ href: "/play/rook", label: "Jugar Torre" }}
+      secondaryCta={{ href: "/", label: "Volver al inicio" }}
+    >
+      <div className="space-y-3">
+        {levels.map((level) => (
+          <div
+            key={level.piece}
+            className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-base font-semibold text-slate-950">{level.piece}</p>
+                <p className="mt-1 text-sm leading-6 text-slate-600">{level.description}</p>
+              </div>
+              <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                {level.status}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,53 +1,28 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { UserBalance } from "@/components/user-balance";
-import { Zap } from "lucide-react";
+import { AppShell } from "@/components/app-shell";
 
 export default function Home() {
   return (
-<main className="flex-1">
-  {/* Hero Section */}
-  <section className="relative py-20 lg:py-32">
-    <div className="container px-4 mx-auto max-w-7xl">
-      <div className="text-center max-w-4xl mx-auto">
-        {/* Badge */}
-        <div
-          className="inline-flex items-center gap-2 px-3 py-1 mb-8 text-sm font-medium bg-primary/10 text-primary rounded-full border border-primary/20"
-        >
-          <Zap className="h-4 w-4" />
-          Built on Celo
+    <AppShell
+      eyebrow="MiniPay MiniApp"
+      title="Chesscito"
+      description="Mini-juegos pre-ajedrecisticos para bienestar cognitivo: cortos, medibles y listos para llevar prueba on-chain en Celo."
+      cta={{ href: "/levels", label: "Ver niveles" }}
+      secondaryCta={{ href: "/leaderboard", label: "Leaderboard" }}
+    >
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-2xl bg-slate-950 px-4 py-4 text-white">
+          <p className="text-xs uppercase tracking-[0.2em] text-white/60">Focus</p>
+          <p className="mt-2 text-sm leading-6 text-white/90">Tower first. Bishop and Knight later.</p>
         </div>
-
-        {/* Main Heading */}
-        <h1
-          className="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6"
-        >
-          Welcome to{" "}
-          <span className="text-primary">chesscito</span>
-        </h1>
-
-        {/* Subtitle */}
-        <p
-          className="text-lg md:text-xl text-muted-foreground mb-8 max-w-2xl mx-auto leading-relaxed"
-        >
-          Start building your decentralized application on Celo. Fast and secure blockchain for everyone.
-        </p>
-
-        {/* User Balance Display */}
-        <UserBalance />
-
-        {/* CTA Buttons */}
-        <div
-          className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16"
-        >
-          <Button size="lg" className="px-8 py-3 text-base font-medium">
-            Get Started
-          </Button>
+        <div className="rounded-2xl bg-slate-100 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Proof</p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">submitScore + claimBadge live in the next slices.</p>
+        </div>
+        <div className="rounded-2xl bg-slate-100 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Mode</p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">Mobile-first routes ready for MiniPay device testing.</p>
         </div>
       </div>
-    </div>
-  </section>
-
-</main>
+    </AppShell>
   );
 }

--- a/apps/web/src/app/play/[piece]/page.tsx
+++ b/apps/web/src/app/play/[piece]/page.tsx
@@ -1,0 +1,50 @@
+import { AppShell } from "@/components/app-shell";
+
+const pieceCopy: Record<string, { title: string; description: string; status: string }> = {
+  rook: {
+    title: "Torre",
+    description: "Aqui viviran el tutorial y el challenge de Torre. En este slice solo dejamos el slot, la ruta y el framing movil.",
+    status: "Primera pieza jugable",
+  },
+  bishop: {
+    title: "Alfil",
+    description: "Ruta reservada para diagonales. Se implementa despues de cerrar Torre y on-chain proof.",
+    status: "Pendiente M4",
+  },
+  knight: {
+    title: "Caballo",
+    description: "Ruta reservada para movimientos en L. No se activa hasta cerrar la ruta critica principal.",
+    status: "Pendiente M4",
+  },
+};
+
+export default function PlayPiecePage({
+  params,
+}: {
+  params: { piece: string };
+}) {
+  const piece = pieceCopy[params.piece] ?? {
+    title: "Pieza desconocida",
+    description: "Esta ruta existe para soportar el esquema del juego, pero la pieza aun no esta configurada.",
+    status: "Sin configurar",
+  };
+
+  return (
+    <AppShell
+      eyebrow="Play"
+      title={piece.title}
+      description={piece.description}
+      cta={{ href: "/result", label: "Ver resultado placeholder" }}
+      secondaryCta={{ href: "/levels", label: "Cambiar pieza" }}
+    >
+      <div className="rounded-3xl border border-dashed border-primary/30 bg-primary/5 p-5">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary">
+          {piece.status}
+        </p>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          El board renderer, rules engine y challenge se agregan en los siguientes PRs.
+        </p>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/app/result/page.tsx
+++ b/apps/web/src/app/result/page.tsx
@@ -1,0 +1,28 @@
+import { AppShell } from "@/components/app-shell";
+
+export default function ResultPage() {
+  return (
+    <AppShell
+      eyebrow="Result"
+      title="Resultado local"
+      description="Este placeholder reserva el espacio para score, tiempo, CTA on-chain y badge state. Aun no hay integracion con contratos."
+      cta={{ href: "/leaderboard", label: "Ir al leaderboard" }}
+      secondaryCta={{ href: "/levels", label: "Jugar de nuevo" }}
+    >
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-2xl bg-slate-950 px-4 py-4 text-white">
+          <p className="text-xs uppercase tracking-[0.2em] text-white/60">Pieza</p>
+          <p className="mt-2 text-lg font-semibold">Torre</p>
+        </div>
+        <div className="rounded-2xl bg-slate-100 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Score</p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">000</p>
+        </div>
+        <div className="rounded-2xl bg-slate-100 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Badge</p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">Pendiente</p>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+type AppShellProps = {
+  eyebrow?: string;
+  title: string;
+  description: string;
+  cta?: {
+    href: string;
+    label: string;
+  };
+  secondaryCta?: {
+    href: string;
+    label: string;
+  };
+  children?: ReactNode;
+};
+
+export function AppShell({
+  eyebrow,
+  title,
+  description,
+  cta,
+  secondaryCta,
+  children,
+}: AppShellProps) {
+  return (
+    <section className="mx-auto flex w-full max-w-screen-sm flex-1 flex-col gap-4 px-4 pb-8 pt-6 sm:px-6">
+      <Card className="overflow-hidden border-white/60 bg-white/90 shadow-[0_20px_60px_rgba(8,15,31,0.08)] backdrop-blur">
+        <CardHeader className="gap-3">
+          {eyebrow ? (
+            <span className="inline-flex w-fit rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-primary">
+              {eyebrow}
+            </span>
+          ) : null}
+          <div className="space-y-2">
+            <CardTitle className="text-3xl font-semibold tracking-tight text-slate-950">
+              {title}
+            </CardTitle>
+            <CardDescription className="max-w-[32ch] text-sm leading-6 text-slate-600">
+              {description}
+            </CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {children}
+          {(cta || secondaryCta) ? (
+            <div className="flex flex-col gap-3 sm:flex-row">
+              {cta ? (
+                <Button asChild className="w-full sm:flex-1">
+                  <Link href={cta.href}>{cta.label}</Link>
+                </Button>
+              ) : null}
+              {secondaryCta ? (
+                <Button asChild variant="outline" className="w-full sm:flex-1">
+                  <Link href={secondaryCta.href}>{secondaryCta.label}</Link>
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/web/src/components/connect-button.tsx
+++ b/apps/web/src/components/connect-button.tsx
@@ -1,20 +1,36 @@
 "use client";
 
 import { ConnectButton as RainbowKitConnectButton } from "@rainbow-me/rainbowkit";
-import { useEffect, useState } from "react";
+import Link from "next/link";
+
+import { useMiniPay } from "@/hooks/use-minipay";
 
 export function ConnectButton() {
-  const [isMinipay, setIsMinipay] = useState(false);
+  const { hasProvider, isMiniPay, isReady } = useMiniPay();
 
-  useEffect(() => {
-    // @ts-ignore
-    if (window.ethereum?.isMiniPay) {
-      setIsMinipay(true);
-    }
-  }, []);
-
-  if (isMinipay) {
+  if (!isReady) {
     return null;
+  }
+
+  if (isMiniPay) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+        MiniPay detected
+      </span>
+    );
+  }
+
+  if (!hasProvider) {
+    return (
+      <Link
+        href="https://docs.celo.org/build/build-on-minipay/quickstart"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-600 transition-colors hover:border-primary/30 hover:text-primary"
+      >
+        Open in MiniPay
+      </Link>
+    );
   }
 
   return <RainbowKitConnectButton />;

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import Link from "next/link"
-import Image from "next/image"
 import { usePathname } from "next/navigation"
 import { Menu, ExternalLink } from "lucide-react"
 
@@ -15,6 +14,8 @@ import { ConnectButton } from "@/components/connect-button"
 
 const navLinks = [
   { name: "Home", href: "/" },
+  { name: "Levels", href: "/levels" },
+  { name: "Leaderboard", href: "/leaderboard" },
   { name: "Docs", href: "https://docs.celo.org", external: true },
 ]
 
@@ -23,7 +24,7 @@ export function Navbar() {
   
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur-md supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-16 max-w-screen-2xl items-center justify-between px-4">
+      <div className="mx-auto flex h-16 w-full max-w-screen-lg items-center justify-between px-4">
         <div className="flex items-center gap-2">
           {/* Mobile menu button */}
           <Sheet>
@@ -34,8 +35,7 @@ export function Navbar() {
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="w-80">
-              <div className="flex items-center gap-2 mb-8">
-
+              <div className="mb-8 flex items-center gap-2">
                 <span className="font-bold text-lg">
                   chesscito
                 </span>
@@ -55,18 +55,15 @@ export function Navbar() {
                     {link.external && <ExternalLink className="h-4 w-4" />}
                   </Link>
                 ))}
-                <div className="mt-6 pt-6 border-t">
-                  <Button asChild className="w-full">
-                    <WalletConnectButton />
-                  </Button>
+                <div className="mt-6 border-t pt-6">
+                  <ConnectButton />
                 </div>
               </nav>
             </SheetContent>
           </Sheet>
 
           {/* Logo */}
-          <Link href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
-
+          <Link href="/" className="flex items-center gap-3 transition-opacity hover:opacity-80">
             <span className="hidden font-bold text-xl sm:inline-block">
               chesscito
             </span>
@@ -93,7 +90,7 @@ export function Navbar() {
           ))}
           
           <div className="flex items-center gap-3">
-            <WalletConnectButton />
+            <ConnectButton />
           </div>
         </nav>
       </div>

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -4,10 +4,11 @@ import { RainbowKitProvider, connectorsForWallets } from "@rainbow-me/rainbowkit
 import "@rainbow-me/rainbowkit/styles.css";
 import { injectedWallet } from "@rainbow-me/rainbowkit/wallets";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 import { WagmiProvider, createConfig, http, useConnect } from "wagmi";
 import { celo, celoSepolia } from "wagmi/chains";
-import { ConnectButton } from "./connect-button";
+
+import { getInjectedProvider, isMiniPayEnv } from "@/lib/minipay";
 
 const connectors = connectorsForWallets(
   [
@@ -36,25 +37,31 @@ const queryClient = new QueryClient();
 
 function WalletProviderInner({ children }: { children: React.ReactNode }) {
   const { connect, connectors } = useConnect();
+  const attemptedMiniPayConnectRef = useRef(false);
 
   useEffect(() => {
-    // Check if the app is running inside MiniPay
-    if (window.ethereum && window.ethereum.isMiniPay) {
-      // Find the injected connector, which is what MiniPay uses
-      const injectedConnector = connectors.find((c) => c.id === "injected");
-      if (injectedConnector) {
-        connect({ connector: injectedConnector });
-      }
+    if (attemptedMiniPayConnectRef.current) {
+      return;
     }
+
+    if (!isMiniPayEnv() || getInjectedProvider() == null) {
+      return;
+    }
+
+    const injectedConnector = connectors.find((connector) => connector.id === "injected");
+
+    if (!injectedConnector) {
+      return;
+    }
+
+    attemptedMiniPayConnectRef.current = true;
+    connect({ connector: injectedConnector });
   }, [connect, connectors]);
 
   return <>{children}</>;
 }
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>

--- a/apps/web/src/hooks/use-minipay.ts
+++ b/apps/web/src/hooks/use-minipay.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getInjectedProvider, isMiniPayEnv } from "@/lib/minipay";
+
+type MiniPayState = {
+  hasProvider: boolean;
+  isMiniPay: boolean;
+  isReady: boolean;
+};
+
+export function useMiniPay(): MiniPayState {
+  const [state, setState] = useState<MiniPayState>({
+    hasProvider: false,
+    isMiniPay: false,
+    isReady: false,
+  });
+
+  useEffect(() => {
+    const provider = getInjectedProvider();
+
+    setState({
+      hasProvider: provider != null,
+      isMiniPay: isMiniPayEnv(),
+      isReady: true,
+    });
+  }, []);
+
+  return state;
+}

--- a/apps/web/src/lib/minipay.ts
+++ b/apps/web/src/lib/minipay.ts
@@ -1,0 +1,36 @@
+type BrowserProvider = {
+  isMiniPay?: boolean;
+};
+
+type MiniPayWindow = Window & {
+  ethereum?: BrowserProvider | null;
+  provider?: BrowserProvider | null;
+};
+
+function getBrowserWindow(): MiniPayWindow | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window as MiniPayWindow;
+}
+
+export function getInjectedProvider(): BrowserProvider | null {
+  const browserWindow = getBrowserWindow();
+
+  if (!browserWindow) {
+    return null;
+  }
+
+  return browserWindow.ethereum ?? browserWindow.provider ?? null;
+}
+
+export function isMiniPayEnv(): boolean {
+  const browserWindow = getBrowserWindow();
+
+  if (!browserWindow) {
+    return false;
+  }
+
+  return Boolean(browserWindow.ethereum?.isMiniPay ?? browserWindow.provider?.isMiniPay);
+}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -58,6 +58,9 @@ const config = {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
+      maxWidth: {
+        app: "var(--app-max-width)",
+      },
       keyframes: {
         "accordion-down": {
           from: { height: "0" },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,12 +1,25 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/docs/planning/buildathon-backlog.md
+++ b/docs/planning/buildathon-backlog.md
@@ -1,0 +1,73 @@
+# Chesscito Buildathon Backlog
+
+## North Star
+Ship a MiniPay MiniApp on Celo Mainnet with:
+- Gameplay MVP for Tower first, then Bishop/Knight if time remains
+- On-chain proof via `submitScore` and `claimBadge`
+- Functional Top 10 leaderboard
+- Submission pack: public repo, live demo, deck, demo video, Karma GAP
+
+## Milestones
+
+### M0 — Project Setup & Baseline
+- Define app skeleton + routes
+- MiniPay compatibility gate
+- Submission placeholders in repo
+- Stitch screen import plan
+
+### M1 — Gameplay MVP (Tower)
+- Board renderer + coordinates
+- Tower rules engine
+- Tutorial level
+- Tower challenge
+
+### M2 — On-chain Proof + Mainnet
+- Scoreboard contract
+- ERC-1155 badges contract
+- Submit score tx in MiniPay
+- Claim badge tx in MiniPay
+- Mainnet deploy + live demo
+
+### M3 — Leaderboard + Polish + Submission Pack
+- Event-based leaderboard
+- Share card
+- Demo video
+- Deck
+- Karma GAP finalize
+
+### M4 — Stretch
+- Human.Passport gating
+- Shop v0
+- Bishop
+- Knight
+- Achievements roadmap
+
+## PR Sequence
+1. `pr/m0-app-skeleton-routes`
+2. `pr/m0-minipay-gate-readme`
+3. `pr/m1-board-renderer`
+4. `pr/m1-rook-rules-and-tests`
+5. `pr/m1-rook-tutorial-and-challenge`
+6. `pr/m2-scoreboard-contract`
+7. `pr/m2-badges-contract`
+8. `pr/m2-submit-score-web`
+9. `pr/m2-claim-badge-web`
+10. `pr/m2-mainnet-deploy-config`
+11. `pr/m3-leaderboard-api-ui`
+12. `pr/m3-share-card`
+13. `pr/m3-submission-pack`
+14. `pr/m4-passport-gating`
+15. `pr/m4-extra-pieces-and-extras`
+
+## MiniPay Validation Rules
+- Test only on a physical device.
+- Enable Developer Mode and use Load Test Page.
+- Use `ngrok` when testing localhost.
+- Guard all wallet bootstrapping behind `window.provider` or `window.ethereum`.
+- Assume legacy transactions only.
+- Validate `feeCurrency` against the current supported stablecoin in the target environment before enabling it in UI.
+
+## References
+- Celo MiniPay quickstart: https://docs.celo.org/build/build-on-minipay/quickstart
+- Celo ngrok setup: https://docs.celo.org/build/build-on-minipay/prerequisites/ngrok-setup
+- Celo viem docs: https://docs.celo.org/developer/viem

--- a/docs/planning/p0-delivery-matrix.md
+++ b/docs/planning/p0-delivery-matrix.md
@@ -1,0 +1,222 @@
+# P0 Delivery Matrix
+
+## PR Sequence
+1. `pr/m0-app-skeleton-routes`
+2. `pr/m0-minipay-gate-readme`
+3. `pr/m0-submission-placeholders`
+4. `pr/m1-board-renderer`
+5. `pr/m1-rook-rules-engine`
+6. `pr/m1-rook-tutorial`
+7. `pr/m1-rook-challenge`
+8. `pr/m2-scoreboard-contract`
+9. `pr/m2-badges-contract`
+10. `pr/m2-submit-score-web`
+11. `pr/m2-claim-badge-web`
+12. `pr/m3-leaderboard-v1`
+13. `pr/m3-share-card`
+14. `pr/m3-demo-video-script`
+15. `pr/m3-deck`
+16. `pr/m3-karma-gap-finalize`
+
+## P0 Issues
+
+### #1 Define App Skeleton + Routes
+- Files to touch:
+  - `apps/web/src/app/layout.tsx`
+  - `apps/web/src/app/page.tsx`
+  - `apps/web/src/app/levels/page.tsx`
+  - `apps/web/src/app/play/[piece]/page.tsx`
+  - `apps/web/src/app/result/page.tsx`
+  - `apps/web/src/app/leaderboard/page.tsx`
+  - `apps/web/src/app/globals.css`
+  - `apps/web/tailwind.config.js`
+- Risks:
+  - Route scaffolding can leak placeholder UX into gameplay PRs.
+  - Mobile layout can break if desktop-first spacing remains.
+- MiniPay validation:
+  - Open each route inside MiniPay on a real device.
+  - Confirm no viewport overflow at roughly `390x844`.
+
+### #2 MiniPay Compatibility Gate
+- Files to touch:
+  - `apps/web/src/components/wallet-provider.tsx`
+  - `apps/web/src/components/connect-button.tsx`
+  - `apps/web/src/components/navbar.tsx`
+  - `apps/web/src/lib/minipay.ts` (new)
+  - `README.md`
+- Risks:
+  - Accessing `window` during SSR can crash the app.
+  - Wallet prompts can become redundant inside MiniPay.
+- MiniPay validation:
+  - Load the app via MiniPay Developer Mode on a phone.
+  - Confirm the app does not show a redundant connect button.
+  - Confirm a normal browser still shows wallet connect when needed.
+
+### #3 Create Karma GAP project placeholder + repo public
+- Files to touch:
+  - `README.md`
+  - `docs/submission/deck-outline.md`
+  - `docs/submission/demo-video-script.md`
+  - `docs/submission/karma-gap-checklist.md` (new)
+- Risks:
+  - Submission links can drift if there is no single source of truth.
+- MiniPay validation:
+  - None required beyond ensuring the live demo placeholder points to the MiniPay deployment target.
+
+### #5 Board Renderer + Coordinate System
+- Files to touch:
+  - `apps/web/src/components/board.tsx` (new)
+  - `apps/web/src/components/board-square.tsx` (new)
+  - `apps/web/src/lib/game/board.ts` (new)
+  - `apps/web/src/lib/game/types.ts` (new)
+  - `apps/web/src/app/play/[piece]/page.tsx`
+- Risks:
+  - Tap targets may be too small on device.
+  - Coordinate transforms can invert ranks/files on mobile rendering.
+- MiniPay validation:
+  - Test repeated taps and move highlights on a phone.
+  - Confirm the board remains fully visible without zoom.
+
+### #6 Rules Engine: Torre Moves
+- Files to touch:
+  - `apps/web/src/lib/game/rules/rook.ts` (new)
+  - `apps/web/src/lib/game/board.ts`
+  - `apps/web/src/lib/game/__tests__/rook.test.ts` (new)
+  - `apps/web/package.json` if a test runner is added
+- Risks:
+  - Rule logic can become coupled to UI state.
+  - Blocking rules can be incorrectly skipped when obstacles are introduced.
+- MiniPay validation:
+  - Not MiniPay-specific; validate by playing the Tower level inside MiniPay after merge.
+
+### #7 Level: Cinematica Torre (tutorial)
+- Files to touch:
+  - `apps/web/src/app/play/[piece]/page.tsx`
+  - `apps/web/src/components/tutorial-panel.tsx` (new)
+  - `apps/web/src/lib/levels/rook-tutorial.ts` (new)
+- Risks:
+  - Tutorial copy can become too long for the mobile viewport.
+  - Hint overlays can block taps on the board.
+- MiniPay validation:
+  - Confirm hints and CTA are readable inside MiniPay.
+  - Confirm transition into challenge mode is smooth on device.
+
+### #8 Challenge: Captura con Torres
+- Files to touch:
+  - `apps/web/src/app/play/[piece]/page.tsx`
+  - `apps/web/src/lib/levels/rook-challenge.ts` (new)
+  - `apps/web/src/lib/game/session.ts` (new)
+  - `apps/web/src/app/result/page.tsx`
+- Risks:
+  - Result payload can be lost across route transitions.
+  - Retry logic can leave stale board state behind.
+- MiniPay validation:
+  - Complete and fail the challenge on device.
+  - Confirm retry resets state without reload.
+
+### #9 Contract: Scoreboard (event-based)
+- Files to touch:
+  - `apps/contracts/contracts/Scoreboard.sol` (new)
+  - `apps/contracts/test/Scoreboard.ts` (new)
+  - `apps/contracts/ignition/modules/Scoreboard.ts` (new)
+  - `apps/contracts/hardhat.config.ts`
+  - `apps/contracts/.env.example`
+- Risks:
+  - Anti-spam logic can over-constrain legitimate submissions.
+  - Event schema changes will break leaderboard parsing later.
+- MiniPay validation:
+  - Deploy to Sepolia first and submit from MiniPay on a real phone.
+  - Confirm emitted event fields match the UI parsing assumptions.
+
+### #10 Contract: Badges ERC-1155
+- Files to touch:
+  - `apps/contracts/contracts/Badges.sol` (new)
+  - `apps/contracts/test/Badges.ts` (new)
+  - `apps/contracts/ignition/modules/Badges.ts` (new)
+  - `apps/contracts/.env.example`
+- Risks:
+  - Badge claim rules can drift from score eligibility logic.
+  - URI design can block metadata publishing later.
+- MiniPay validation:
+  - Claim from MiniPay on a phone after testnet deploy.
+  - Confirm second claim attempt is rejected cleanly.
+
+### #11 Integrate submitScore tx (MiniPay)
+- Files to touch:
+  - `apps/web/src/app/result/page.tsx`
+  - `apps/web/src/components/submit-score-button.tsx` (new)
+  - `apps/web/src/lib/contracts/scoreboard.ts` (new)
+  - `apps/web/src/lib/minipay.ts`
+  - `apps/web/src/components/wallet-provider.tsx`
+- Risks:
+  - Accidentally sending EIP-1559 fields will degrade MiniPay compatibility.
+  - Unsupported `feeCurrency` values can cause confusing failures.
+- MiniPay validation:
+  - Use a real MiniPay device on Sepolia, then on Mainnet.
+  - Confirm pending, success, and error states.
+  - Confirm transaction hash is visible and copyable.
+
+### #12 Integrate claimBadge tx (MiniPay)
+- Files to touch:
+  - `apps/web/src/app/result/page.tsx`
+  - `apps/web/src/components/claim-badge-button.tsx` (new)
+  - `apps/web/src/lib/contracts/badges.ts` (new)
+  - `apps/web/src/lib/minipay.ts`
+- Risks:
+  - Claimed state can desync from on-chain truth.
+  - Duplicate claim attempts can present poor UX if revert messages are not surfaced.
+- MiniPay validation:
+  - Claim once on a real device.
+  - Reload the result screen and confirm claimed state persists.
+
+### #14 Leaderboard v1 (read events)
+- Files to touch:
+  - `apps/web/src/app/api/leaderboard/route.ts` (new)
+  - `apps/web/src/app/leaderboard/page.tsx`
+  - `apps/web/src/lib/contracts/scoreboard.ts`
+  - `apps/web/src/lib/leaderboard.ts` (new)
+- Risks:
+  - RPC log scans can get expensive without block-range discipline.
+  - Sorting rules can create inconsistent ties if not specified.
+- MiniPay validation:
+  - Open `/leaderboard` inside MiniPay and confirm it renders from live chain data.
+  - Verify cached refresh behavior does not stale too long after a fresh score submit.
+
+### #15 Share Card (result screenshotable)
+- Files to touch:
+  - `apps/web/src/app/result/page.tsx`
+  - `apps/web/src/components/share-card.tsx` (new)
+  - `apps/web/src/lib/share.ts` (new)
+- Risks:
+  - Card height can exceed screen capture bounds.
+  - Permalink state can drift from actual result data if encoded poorly.
+- MiniPay validation:
+  - Capture a screenshot inside MiniPay and confirm legibility.
+  - Test the copied permalink on mobile.
+
+### #16 Demo Video Script + Recording Checklist
+- Files to touch:
+  - `docs/submission/demo-video-script.md`
+  - `README.md`
+- Risks:
+  - Script can drift from the actual shipped product.
+- MiniPay validation:
+  - Dry-run the full flow on a phone before recording.
+
+### #17 Deck (8-10 slides)
+- Files to touch:
+  - `docs/submission/deck-outline.md`
+  - `README.md`
+- Risks:
+  - Messaging can over-promise if it is not aligned with shipped scope.
+- MiniPay validation:
+  - Include only flows already validated on device.
+
+### #18 Karma GAP Finalize
+- Files to touch:
+  - `README.md`
+  - `docs/submission/karma-gap-checklist.md` (new)
+- Risks:
+  - Final links can be inconsistent across README, deck, and Karma GAP.
+- MiniPay validation:
+  - Final live URL must be the same URL validated in MiniPay on a real device.

--- a/docs/planning/route-inventory.md
+++ b/docs/planning/route-inventory.md
@@ -1,0 +1,19 @@
+# Route Inventory
+
+## M0 App Skeleton
+
+- `/`
+  - Home and product framing
+  - CTA to `/levels`
+- `/levels`
+  - Piece selection hub
+  - Tower active, Bishop/Knight reserved
+- `/play/[piece]`
+  - Piece-specific gameplay entry point
+  - Tutorial/challenge slot for future slices
+- `/result`
+  - Local result placeholder
+  - Future home for `submitScore` and `claimBadge`
+- `/leaderboard`
+  - Top 10 placeholder
+  - Future home for event-driven ranking

--- a/docs/submission/deck-outline.md
+++ b/docs/submission/deck-outline.md
@@ -1,0 +1,56 @@
+# Deck Outline
+
+## Slide 1 — Title
+- Chesscito
+- MiniPay MiniApp for cognitive enrichment through pre-chess mini-games
+- Team, repo, live demo URL
+
+## Slide 2 — Problem
+- Mobile users need short, measurable cognitive play loops
+- Existing chess learning flows are too heavy for casual daily use
+- Buildathon angle: educational, fun, measurable, on-chain proof
+
+## Slide 3 — Solution
+- Short piece-based challenges
+- Mobile-first MiniPay experience
+- On-chain score proof and collectible progression
+
+## Slide 4 — Product Demo
+- Home
+- Levels
+- Tower tutorial
+- Tower challenge
+- Result screen
+
+## Slide 5 — Why MiniPay
+- Embedded wallet UX
+- Celo fee abstraction support
+- Natural fit for mobile-first micro-interactions
+
+## Slide 6 — Architecture
+- Next.js MiniApp frontend
+- Hardhat contracts on Celo
+- viem/wagmi transaction layer
+- Event-based leaderboard API
+
+## Slide 7 — On-chain Proof
+- `submitScore(levelId, score, timeMs, nonce)`
+- `claimBadge(levelId)`
+- ERC-1155 badges
+- Anti-spam and one-badge-per-wallet-per-level
+
+## Slide 8 — Leaderboard + Retention Loop
+- Top 10 leaderboard
+- Shareable result card
+- Daily return loop and future achievements
+
+## Slide 9 — Traction / Validation
+- Real-device MiniPay testing
+- Mainnet deployment
+- Demo metrics captured during playtests
+
+## Slide 10 — Roadmap
+- Bishop and Knight levels
+- Passport-gated ranked rewards
+- Shop and achievements
+- Event-linked VIP perks

--- a/docs/submission/demo-video-script.md
+++ b/docs/submission/demo-video-script.md
@@ -1,0 +1,56 @@
+# Demo Video Script
+
+## Target
+- Length: 60 to 90 seconds
+- Device: real phone inside MiniPay
+- Goal: show full loop from play to on-chain proof to leaderboard
+
+## Shot List
+
+### Shot 1 — Hook (0s-8s)
+- Open MiniPay
+- Load Chesscito
+- Voiceover: "Chesscito is a MiniPay MiniApp for fast cognitive enrichment through pre-chess challenges."
+
+### Shot 2 — Home to Levels (8s-18s)
+- Show Home screen
+- Tap into Levels
+- Highlight Tower challenge as the first playable level
+
+### Shot 3 — Tutorial (18s-30s)
+- Open Tower tutorial
+- Show green move hints and short educational copy
+- Tap CTA to start challenge
+
+### Shot 4 — Challenge (30s-45s)
+- Play one valid Tower move sequence
+- Finish challenge
+- Show success state and score/time
+
+### Shot 5 — Submit Score On-chain (45s-60s)
+- Tap "Enviar puntaje"
+- Approve legacy transaction in MiniPay
+- Show pending to success state with transaction hash
+
+### Shot 6 — Claim Badge (60s-72s)
+- Tap "Reclamar badge"
+- Approve transaction
+- Show claimed badge state
+
+### Shot 7 — Leaderboard (72s-84s)
+- Open leaderboard
+- Show Top 10 entry populated from on-chain events
+
+### Shot 8 — Close (84s-90s)
+- Return to result/share card or home
+- Voiceover: "Playable, provable, and ready for Celo mainnet."
+
+## Recording Checklist
+- Phone brightness locked
+- Notifications off
+- Demo account funded
+- App already loaded in MiniPay Developer Mode
+- ngrok URL ready if local
+- Mainnet/testnet network confirmed before recording
+- Tx hashes visible in UI
+- No wallet connect prompt shown inside MiniPay

--- a/docs/submission/karma-gap-checklist.md
+++ b/docs/submission/karma-gap-checklist.md
@@ -1,0 +1,9 @@
+# Karma GAP Checklist
+
+- [ ] Public GitHub repository URL is final
+- [ ] Live demo URL points to Celo Mainnet deployment
+- [ ] Presentation deck link is final
+- [ ] Demo video link is final
+- [ ] README matches all submission links
+- [ ] Demo flow was recorded on a real device inside MiniPay
+- [ ] No medical claims appear in the submission copy


### PR DESCRIPTION
## Summary
- scaffold the mobile-first app shell and core routes for `#1`
- add MiniPay environment detection and wallet UI gating for `#2`
- document the repo workflow, device testing flow, and submission planning assets
- harden Next.js bundling against optional MetaMask SDK modules

## Issues
- Closes #1
- Closes #2

## Validation
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`

## MiniPay QA
- [ ] Desktop without wallet: `/`, `/levels`, `/play/rook`, `/result`, `/leaderboard`
- [ ] Desktop without wallet: fallback UI shows `Open in MiniPay`
- [ ] Desktop with wallet: `ConnectButton` renders normally
- [ ] MiniPay device + ngrok: same routes load without crash
- [ ] MiniPay device + ngrok: `Connect Wallet` is hidden
- [ ] MiniPay device + ngrok: `MiniPay detected` badge is visible
- [ ] MiniPay device + ngrok: no horizontal scroll, CTAs visible

## Notes
- MiniPay-specific testing still requires a real device.
- `window.ethereum` and `window.provider` access is now centralized in a client-safe helper.
