### PR TITLE
Add rook board renderer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "type-check": "tsc --noEmit"
+    "type-check": "next build >/dev/null && tsc --noEmit"
   },
   "dependencies": {
     "next": "^14.0.0",

--- a/apps/web/src/app/play/[piece]/page.tsx
+++ b/apps/web/src/app/play/[piece]/page.tsx
@@ -1,20 +1,32 @@
 import { AppShell } from "@/components/app-shell";
+import { Board } from "@/components/board";
 
-const pieceCopy: Record<string, { title: string; description: string; status: string }> = {
+const pieceCopy: Record<
+  string,
+  {
+    title: string;
+    description: string;
+    status: string;
+    isPlayable: boolean;
+  }
+> = {
   rook: {
     title: "Torre",
-    description: "Aqui viviran el tutorial y el challenge de Torre. En este slice solo dejamos el slot, la ruta y el framing movil.",
-    status: "Primera pieza jugable",
+    description: "Primer vertical slice jugable: tablero responsive, coordenadas y movimiento legal de Torre en tablero vacio.",
+    status: "Playable MVP",
+    isPlayable: true,
   },
   bishop: {
     title: "Alfil",
     description: "Ruta reservada para diagonales. Se implementa despues de cerrar Torre y on-chain proof.",
     status: "Pendiente M4",
+    isPlayable: false,
   },
   knight: {
     title: "Caballo",
     description: "Ruta reservada para movimientos en L. No se activa hasta cerrar la ruta critica principal.",
     status: "Pendiente M4",
+    isPlayable: false,
   },
 };
 
@@ -27,6 +39,7 @@ export default function PlayPiecePage({
     title: "Pieza desconocida",
     description: "Esta ruta existe para soportar el esquema del juego, pero la pieza aun no esta configurada.",
     status: "Sin configurar",
+    isPlayable: false,
   };
 
   return (
@@ -34,17 +47,21 @@ export default function PlayPiecePage({
       eyebrow="Play"
       title={piece.title}
       description={piece.description}
-      cta={{ href: "/result", label: "Ver resultado placeholder" }}
+      cta={piece.isPlayable ? { href: "/result", label: "Ver resultado placeholder" } : undefined}
       secondaryCta={{ href: "/levels", label: "Cambiar pieza" }}
     >
-      <div className="rounded-3xl border border-dashed border-primary/30 bg-primary/5 p-5">
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary">
-          {piece.status}
-        </p>
-        <p className="mt-3 text-sm leading-6 text-slate-600">
-          El board renderer, rules engine y challenge se agregan en los siguientes PRs.
-        </p>
-      </div>
+      {piece.isPlayable ? (
+        <Board />
+      ) : (
+        <div className="rounded-3xl border border-dashed border-primary/30 bg-primary/5 p-5">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary">
+            {piece.status}
+          </p>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            El board renderer jugable se activa primero para Torre. Esta pieza sigue reservada para un slice posterior.
+          </p>
+        </div>
+      )}
     </AppShell>
   );
 }

--- a/apps/web/src/components/board-square.tsx
+++ b/apps/web/src/components/board-square.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { SquareState } from "@/lib/game/types";
+import { cn } from "@/lib/utils";
+
+type BoardSquareProps = {
+  square: SquareState;
+  onPress: (label: string) => void;
+};
+
+export function BoardSquare({ square, onPress }: BoardSquareProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onPress(square.label)}
+      className={cn(
+        "relative aspect-square w-full rounded-xl border text-left transition-transform active:scale-[0.98]",
+        square.isDark
+          ? "border-slate-300 bg-slate-300/90 text-slate-900"
+          : "border-emerald-100 bg-emerald-50 text-slate-900",
+        square.isHighlighted && "ring-2 ring-primary/80 ring-offset-1",
+        square.isSelected && "border-primary bg-primary/10 ring-2 ring-primary/30"
+      )}
+      aria-label={`Square ${square.label}`}
+    >
+      <span className="absolute left-2 top-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+        {square.label}
+      </span>
+      {square.isHighlighted ? (
+        <span className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-primary" />
+      ) : null}
+      {square.piece ? (
+        <span className="flex h-full items-center justify-center text-3xl" aria-hidden="true">
+          ♖
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/web/src/components/board.tsx
+++ b/apps/web/src/components/board.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { BoardSquare } from "@/components/board-square";
+import {
+  INITIAL_ROOK,
+  arePositionsEqual,
+  buildBoardSquares,
+  getPositionLabel,
+  getRookTargets,
+  movePiece,
+} from "@/lib/game/board";
+import type { BoardPosition } from "@/lib/game/types";
+
+function parseLabel(label: string): BoardPosition {
+  const file = label.charCodeAt(0) - 97;
+  const rank = Number(label.slice(1)) - 1;
+
+  return { file, rank };
+}
+
+export function Board() {
+  const [piece, setPiece] = useState(INITIAL_ROOK);
+  const [selectedPosition, setSelectedPosition] = useState<BoardPosition | null>(null);
+
+  const validTargets = useMemo(() => {
+    if (!selectedPosition) {
+      return [];
+    }
+
+    return getRookTargets(selectedPosition);
+  }, [selectedPosition]);
+
+  const squares = useMemo(
+    () =>
+      buildBoardSquares({
+        selectedPosition,
+        piece,
+        validTargets,
+      }),
+    [piece, selectedPosition, validTargets]
+  );
+
+  const handleSquarePress = (label: string) => {
+    const nextPosition = parseLabel(label);
+    const piecePosition = piece.position;
+
+    if (arePositionsEqual(piecePosition, nextPosition)) {
+      setSelectedPosition((current) => (current ? null : piecePosition));
+      return;
+    }
+
+    const canMove = validTargets.some((target) => arePositionsEqual(target, nextPosition));
+
+    if (canMove) {
+      setPiece((current) => movePiece(current, nextPosition));
+      setSelectedPosition(null);
+      return;
+    }
+
+    setSelectedPosition(null);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-[28px] border border-slate-200 bg-white p-3 shadow-[0_24px_48px_rgba(15,23,42,0.08)]">
+        <div className="grid grid-cols-8 gap-2">
+          {squares.map((square) => (
+            <BoardSquare
+              key={square.label}
+              square={square}
+              onPress={handleSquarePress}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl bg-slate-950 px-4 py-4 text-white">
+          <p className="text-xs uppercase tracking-[0.2em] text-white/60">Piece</p>
+          <p className="mt-2 text-lg font-semibold">Torre</p>
+          <p className="mt-1 text-sm text-white/75">Toca la pieza para ver movimientos legales.</p>
+        </div>
+        <div className="rounded-2xl bg-slate-100 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Current square</p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">
+            {getPositionLabel(piece.position)}
+          </p>
+          <p className="mt-1 text-sm text-slate-600">
+            Toca una casilla marcada para mover la Torre.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/game/board.ts
+++ b/apps/web/src/lib/game/board.ts
@@ -1,0 +1,87 @@
+import type { BoardPiece, BoardPosition, SquareState } from "@/lib/game/types";
+
+const BOARD_SIZE = 8;
+const FILE_LABELS = ["a", "b", "c", "d", "e", "f", "g", "h"];
+
+export const INITIAL_ROOK: BoardPiece = {
+  id: "rook-1",
+  type: "rook",
+  position: { file: 0, rank: 0 },
+};
+
+export function arePositionsEqual(a: BoardPosition, b: BoardPosition) {
+  return a.file === b.file && a.rank === b.rank;
+}
+
+export function isInsideBoard(position: BoardPosition) {
+  return (
+    position.file >= 0 &&
+    position.file < BOARD_SIZE &&
+    position.rank >= 0 &&
+    position.rank < BOARD_SIZE
+  );
+}
+
+export function getPositionLabel(position: BoardPosition) {
+  return `${FILE_LABELS[position.file]}${position.rank + 1}`;
+}
+
+export function getRookTargets(position: BoardPosition) {
+  const targets: BoardPosition[] = [];
+
+  for (let file = 0; file < BOARD_SIZE; file += 1) {
+    if (file !== position.file) {
+      targets.push({ file, rank: position.rank });
+    }
+  }
+
+  for (let rank = 0; rank < BOARD_SIZE; rank += 1) {
+    if (rank !== position.rank) {
+      targets.push({ file: position.file, rank });
+    }
+  }
+
+  return targets;
+}
+
+export function movePiece(piece: BoardPiece, nextPosition: BoardPosition): BoardPiece {
+  if (!isInsideBoard(nextPosition)) {
+    return piece;
+  }
+
+  return {
+    ...piece,
+    position: nextPosition,
+  };
+}
+
+export function buildBoardSquares({
+  selectedPosition,
+  piece,
+  validTargets,
+}: {
+  selectedPosition: BoardPosition | null;
+  piece: BoardPiece;
+  validTargets: BoardPosition[];
+}): SquareState[] {
+  const squares: SquareState[] = [];
+
+  for (let rank = BOARD_SIZE - 1; rank >= 0; rank -= 1) {
+    for (let file = 0; file < BOARD_SIZE; file += 1) {
+      const position = { file, rank };
+      const hasPiece = arePositionsEqual(piece.position, position);
+
+      squares.push({
+        file,
+        rank,
+        label: getPositionLabel(position),
+        isDark: (file + rank) % 2 === 1,
+        isHighlighted: validTargets.some((target) => arePositionsEqual(target, position)),
+        isSelected: selectedPosition ? arePositionsEqual(selectedPosition, position) : false,
+        piece: hasPiece ? piece : null,
+      });
+    }
+  }
+
+  return squares;
+}

--- a/apps/web/src/lib/game/types.ts
+++ b/apps/web/src/lib/game/types.ts
@@ -1,0 +1,22 @@
+export type PieceId = "rook";
+
+export type BoardPosition = {
+  file: number;
+  rank: number;
+};
+
+export type BoardPiece = {
+  id: string;
+  type: PieceId;
+  position: BoardPosition;
+};
+
+export type SquareState = {
+  file: number;
+  rank: number;
+  label: string;
+  isDark: boolean;
+  isHighlighted: boolean;
+  isSelected: boolean;
+  piece: BoardPiece | null;
+};


### PR DESCRIPTION
## Summary
- add the first playable board renderer for the rook route
- introduce board coordinate helpers and square rendering primitives
- keep the slice limited to local board interaction without challenge or on-chain logic
- stabilize `type-check` so App Router types exist before `tsc`

## Issue
- Closes #5

## Validation
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`

## MiniPay QA
- [ ] Desktop: `/play/rook` renders without crash
- [ ] Desktop: tap rook to reveal legal row/column targets
- [ ] Desktop: tap highlighted square to move the rook
- [ ] MiniPay device + ngrok: `/play/rook` loads without horizontal scroll
- [ ] MiniPay device + ngrok: highlighted targets are visible and tappable
- [ ] MiniPay device + ngrok: rook movement works by tap only

## Notes
- This PR intentionally does not add blocking, captures, challenge state, or result persistence.
- Those stay in the next slices for rules, tutorial, and challenge flow.
