### PR TITLE
Add rook challenge flow (#8)

### DIFF
--- a/apps/web/src/app/play/[piece]/page.tsx
+++ b/apps/web/src/app/play/[piece]/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 import { AppShell } from "@/components/app-shell";
 import { Board } from "@/components/board";
 import { TutorialPanel } from "@/components/tutorial-panel";
+import { recordLocalCompletion } from "@/lib/game/progress";
+import type { BoardPosition } from "@/lib/game/types";
+import { getPositionLabel } from "@/lib/game/board";
+import { rookChallenge } from "@/lib/levels/rook-challenge";
 import { rookTutorial } from "@/lib/levels/rook-tutorial";
 
 const pieceCopy: Record<
@@ -41,12 +46,46 @@ export default function PlayPiecePage({
 }: {
   params: { piece: string };
 }) {
-  const [isPracticeMode, setIsPracticeMode] = useState(false);
+  const router = useRouter();
+  const [phase, setPhase] = useState<"tutorial" | "challenge" | "success" | "failure">("tutorial");
+  const [boardKey, setBoardKey] = useState(0);
   const piece = pieceCopy[params.piece] ?? {
     title: "Pieza desconocida",
     description: "Esta ruta existe para soportar el esquema del juego, pero la pieza aun no esta configurada.",
     status: "Sin configurar",
     isPlayable: false,
+  };
+  const challengeTarget: BoardPosition = { file: 7, rank: 0 };
+
+  const handleChallengeMove = (position: BoardPosition) => {
+    const targetLabel = getPositionLabel(challengeTarget);
+    const selectedLabel = getPositionLabel(position);
+
+    if (selectedLabel === targetLabel) {
+      const payload = {
+        piece: "rook",
+        challenge: "capture-with-rooks",
+        score: rookChallenge.score,
+        status: "success" as const,
+        target: targetLabel,
+        moves: 1,
+        completedAt: new Date().toISOString(),
+      };
+
+      recordLocalCompletion(payload);
+      setPhase("success");
+      router.push(
+        `/result?piece=rook&status=success&score=${rookChallenge.score}&target=${targetLabel}&moves=1`
+      );
+      return;
+    }
+
+    setPhase("failure");
+  };
+
+  const handleRetry = () => {
+    setBoardKey((current) => current + 1);
+    setPhase("challenge");
   };
 
   return (
@@ -54,22 +93,68 @@ export default function PlayPiecePage({
       eyebrow="Play"
       title={piece.title}
       description={piece.description}
-      cta={piece.isPlayable ? { href: "/result", label: "Ver resultado placeholder" } : undefined}
       secondaryCta={{ href: "/levels", label: "Cambiar pieza" }}
     >
       {piece.isPlayable ? (
         <div className="space-y-4">
-          {!isPracticeMode ? (
+          {phase === "tutorial" ? (
             <TutorialPanel
               eyebrow={rookTutorial.eyebrow}
               title={rookTutorial.title}
               description={rookTutorial.description}
               cues={rookTutorial.cues}
               ctaLabel={rookTutorial.practiceLabel}
-              onStart={() => setIsPracticeMode(true)}
+              onStart={() => setPhase("challenge")}
             />
           ) : null}
-          <Board mode={isPracticeMode ? "practice" : "tutorial"} />
+          {phase !== "tutorial" ? (
+            <div className="space-y-3 rounded-[28px] border border-amber-200 bg-amber-50/80 p-5">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
+                  Challenge
+                </p>
+                <h2 className="text-2xl font-semibold tracking-tight text-slate-950">
+                  {rookChallenge.title}
+                </h2>
+                <p className="text-sm leading-6 text-slate-600">
+                  {rookChallenge.description}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-white px-4 py-3 text-sm text-slate-700">
+                Objetivo actual: capturar <span className="font-semibold">{rookChallenge.targetLabel}</span>
+              </div>
+            </div>
+          ) : null}
+          <Board
+            key={boardKey}
+            mode={phase === "tutorial" ? "tutorial" : "practice"}
+            targetPosition={phase === "tutorial" ? null : challengeTarget}
+            isLocked={phase === "failure"}
+            onMove={phase === "challenge" ? handleChallengeMove : undefined}
+          />
+          {phase === "failure" ? (
+            <div className="space-y-3 rounded-[28px] border border-rose-200 bg-rose-50/80 p-5">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-700">Fallo</p>
+              <p className="text-sm leading-6 text-slate-700">
+                Esa jugada no capturó el objetivo. Reinicia el tablero y prueba otra trayectoria recta.
+              </p>
+              <button
+                type="button"
+                onClick={handleRetry}
+                className="inline-flex w-full items-center justify-center rounded-xl bg-slate-950 px-4 py-3 text-sm font-semibold text-white sm:w-auto"
+              >
+                Retry
+              </button>
+            </div>
+          ) : null}
+          {phase === "success" ? (
+            <div className="rounded-[28px] border border-emerald-200 bg-emerald-50/80 p-5">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700">Success</p>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                Captura completada. Redirigiendo al resultado local para preparar el submit on-chain.
+              </p>
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="rounded-3xl border border-dashed border-primary/30 bg-primary/5 p-5">

--- a/apps/web/src/app/result/page.tsx
+++ b/apps/web/src/app/result/page.tsx
@@ -1,6 +1,22 @@
 import { AppShell } from "@/components/app-shell";
 
-export default function ResultPage() {
+type ResultPageProps = {
+  searchParams?: {
+    piece?: string;
+    score?: string;
+    status?: string;
+    target?: string;
+    moves?: string;
+  };
+};
+
+export default function ResultPage({ searchParams }: ResultPageProps) {
+  const piece = searchParams?.piece ?? "rook";
+  const score = searchParams?.score ?? "000";
+  const status = searchParams?.status ?? "pending";
+  const target = searchParams?.target ?? "n/a";
+  const moves = searchParams?.moves ?? "0";
+
   return (
     <AppShell
       eyebrow="Result"
@@ -12,15 +28,27 @@ export default function ResultPage() {
       <div className="grid gap-3 sm:grid-cols-3">
         <div className="rounded-2xl bg-slate-950 px-4 py-4 text-white">
           <p className="text-xs uppercase tracking-[0.2em] text-white/60">Pieza</p>
-          <p className="mt-2 text-lg font-semibold">Torre</p>
+          <p className="mt-2 text-lg font-semibold">{piece === "rook" ? "Torre" : piece}</p>
         </div>
         <div className="rounded-2xl bg-slate-100 px-4 py-4">
           <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Score</p>
-          <p className="mt-2 text-lg font-semibold text-slate-950">000</p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">{score}</p>
         </div>
         <div className="rounded-2xl bg-slate-100 px-4 py-4">
           <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Badge</p>
           <p className="mt-2 text-lg font-semibold text-slate-950">Pendiente</p>
+        </div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl bg-slate-100 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Status</p>
+          <p className="mt-2 text-lg font-semibold capitalize text-slate-950">{status}</p>
+        </div>
+        <div className="rounded-2xl bg-slate-100 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Objetivo</p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">
+            {target} en {moves} movimiento
+          </p>
         </div>
       </div>
     </AppShell>

--- a/apps/web/src/components/board-square.tsx
+++ b/apps/web/src/components/board-square.tsx
@@ -29,6 +29,14 @@ export function BoardSquare({ square, onPress }: BoardSquareProps) {
       {square.isHighlighted ? (
         <span className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-primary" />
       ) : null}
+      {square.isTarget && !square.piece ? (
+        <span
+          className="absolute inset-x-0 bottom-3 flex justify-center text-xl"
+          aria-hidden="true"
+        >
+          ◎
+        </span>
+      ) : null}
       {square.piece ? (
         <span className="flex h-full items-center justify-center text-3xl" aria-hidden="true">
           ♖

--- a/apps/web/src/components/board.tsx
+++ b/apps/web/src/components/board.tsx
@@ -22,9 +22,17 @@ function parseLabel(label: string): BoardPosition {
 
 type BoardProps = {
   mode?: "tutorial" | "practice";
+  targetPosition?: BoardPosition | null;
+  isLocked?: boolean;
+  onMove?: (position: BoardPosition) => void;
 };
 
-export function Board({ mode = "practice" }: BoardProps) {
+export function Board({
+  mode = "practice",
+  targetPosition = null,
+  isLocked = false,
+  onMove,
+}: BoardProps) {
   const [piece, setPiece] = useState(INITIAL_ROOK);
   const [selectedPosition, setSelectedPosition] = useState<BoardPosition | null>(
     mode === "tutorial" ? INITIAL_ROOK.position : null
@@ -48,12 +56,13 @@ export function Board({ mode = "practice" }: BoardProps) {
         selectedPosition,
         piece,
         validTargets,
+        targetPosition,
       }),
-    [piece, selectedPosition, validTargets]
+    [piece, selectedPosition, targetPosition, validTargets]
   );
 
   const handleSquarePress = (label: string) => {
-    if (mode !== "practice") {
+    if (mode !== "practice" || isLocked) {
       return;
     }
 
@@ -70,6 +79,7 @@ export function Board({ mode = "practice" }: BoardProps) {
     if (canMove) {
       setPiece((current) => movePiece(current, nextPosition));
       setSelectedPosition(null);
+      onMove?.(nextPosition);
       return;
     }
 
@@ -97,20 +107,28 @@ export function Board({ mode = "practice" }: BoardProps) {
           <p className="mt-1 text-sm text-white/75">
             {mode === "tutorial"
               ? "Las flechas verdes marcan la fila y la columna completas."
-              : "Toca la pieza para ver movimientos legales."}
+              : targetPosition
+                ? "Selecciona la Torre y captura el objetivo en un solo movimiento."
+                : "Toca la pieza para ver movimientos legales."}
           </p>
         </div>
         <div className="rounded-2xl bg-slate-100 px-4 py-4">
           <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
-            {mode === "tutorial" ? "Tutorial state" : "Current square"}
+            {mode === "tutorial" ? "Tutorial state" : targetPosition ? "Target square" : "Current square"}
           </p>
           <p className="mt-2 text-lg font-semibold text-slate-950">
-            {mode === "tutorial" ? "Trayectorias activas" : getPositionLabel(piece.position)}
+            {mode === "tutorial"
+              ? "Trayectorias activas"
+              : targetPosition
+                ? getPositionLabel(targetPosition)
+                : getPositionLabel(piece.position)}
           </p>
           <p className="mt-1 text-sm text-slate-600">
             {mode === "tutorial"
               ? "Pulsa Probar para convertir estas trayectorias en movimiento interactivo."
-              : "Toca una casilla marcada para mover la Torre."}
+              : targetPosition
+                ? "El circulo marca la captura objetivo."
+                : "Toca una casilla marcada para mover la Torre."}
           </p>
         </div>
       </div>

--- a/apps/web/src/lib/game/board.ts
+++ b/apps/web/src/lib/game/board.ts
@@ -46,10 +46,12 @@ export function buildBoardSquares({
   selectedPosition,
   piece,
   validTargets,
+  targetPosition = null,
 }: {
   selectedPosition: BoardPosition | null;
   piece: BoardPiece;
   validTargets: BoardPosition[];
+  targetPosition?: BoardPosition | null;
 }): SquareState[] {
   const squares: SquareState[] = [];
 
@@ -65,6 +67,7 @@ export function buildBoardSquares({
         isDark: (file + rank) % 2 === 1,
         isHighlighted: validTargets.some((target) => arePositionsEqual(target, position)),
         isSelected: selectedPosition ? arePositionsEqual(selectedPosition, position) : false,
+        isTarget: targetPosition ? arePositionsEqual(targetPosition, position) : false,
         piece: hasPiece ? piece : null,
       });
     }

--- a/apps/web/src/lib/game/progress.ts
+++ b/apps/web/src/lib/game/progress.ts
@@ -1,0 +1,28 @@
+const LOCAL_COMPLETION_KEY = "chesscito:last-completion";
+
+export type LocalCompletion = {
+  piece: string;
+  challenge: string;
+  score: number;
+  status: "success";
+  target: string;
+  moves: number;
+  completedAt: string;
+};
+
+export function recordLocalCompletion(payload: LocalCompletion) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(LOCAL_COMPLETION_KEY, JSON.stringify(payload));
+  window.dispatchEvent(
+    new CustomEvent("chesscito:challenge-complete", {
+      detail: payload,
+    })
+  );
+}
+
+export function getLocalCompletionKey() {
+  return LOCAL_COMPLETION_KEY;
+}

--- a/apps/web/src/lib/game/types.ts
+++ b/apps/web/src/lib/game/types.ts
@@ -18,5 +18,6 @@ export type SquareState = {
   isDark: boolean;
   isHighlighted: boolean;
   isSelected: boolean;
+  isTarget: boolean;
   piece: BoardPiece | null;
 };

--- a/apps/web/src/lib/levels/rook-challenge.ts
+++ b/apps/web/src/lib/levels/rook-challenge.ts
@@ -1,0 +1,7 @@
+export const rookChallenge = {
+  title: "Captura con Torres",
+  description:
+    "Captura el objetivo en un solo movimiento recto. Si eliges otra casilla, reinicia e intenta otra vez.",
+  targetLabel: "h1",
+  score: 100,
+};


### PR DESCRIPTION
## Summary
- add the local rook challenge with one-move success or failure states
- record a local completion event and redirect successful runs to the result page
- surface target and status details in the local result route

## Validation
- pnpm --filter web test:game
- pnpm --filter web type-check
- pnpm --filter web lint
- pnpm --filter web build

## QA MiniPay
- [ ] Desktop without wallet: /play/rook challenge loads after tutorial and does not crash
- [ ] MiniPay device + ngrok: /play/rook has visible target marker and tappable squares
- [ ] Correct move to h1 reaches /result with success state
- [ ] Wrong move shows failure state and Retry resets the board
- [ ] /result shows piece, score, status and target without horizontal scroll

## Risks
- local completion uses localStorage and a browser event, so it is MVP-only state
- the challenge is intentionally single-attempt to keep success and failure deterministic