### PR TITLE
Add badges contract (#10)

### DIFF
--- a/apps/contracts/README.md
+++ b/apps/contracts/README.md
@@ -5,6 +5,7 @@ This package contains the on-chain proof layer for Chesscito on Celo.
 ## Contracts
 
 - `Scoreboard.sol`: event-based score submission with anti-spam controls
+- `Badges.sol`: ERC-1155 badge claims with one mint per wallet and level
 
 ## Local workflow
 
@@ -19,12 +20,16 @@ pnpm --filter hardhat test
 pnpm --filter hardhat deploy
 pnpm --filter hardhat deploy:celo-sepolia
 pnpm --filter hardhat deploy:celo
+pnpm --filter hardhat deploy:badges
+pnpm --filter hardhat deploy:badges:celo-sepolia
+pnpm --filter hardhat deploy:badges:celo
 ```
 
 Default ignition parameters:
 - `submitCooldown=60`
 - `maxSubmissionsPerDay=20`
 - `initialOwner=deployer`
+- `baseURI=ipfs://chesscito/badges/`
 
 ## Environment
 
@@ -42,3 +47,4 @@ CELO_SEPOLIA_RPC_URL=https://forno.celo-sepolia.celo-testnet.org/
 - Never commit `.env` with real keys
 - Use Celo Sepolia before Celo Mainnet
 - The Scoreboard contract emits `ScoreSubmitted` and enforces cooldown plus max submissions per day
+- The Badges contract exposes `claimBadge(levelId)` and serves metadata as `baseURI + tokenId + .json`

--- a/apps/contracts/contracts/Badges.sol
+++ b/apps/contracts/contracts/Badges.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract Badges is ERC1155, Ownable {
+    error BadgeAlreadyClaimed(address player, uint256 levelId);
+
+    event BadgeClaimed(address indexed player, uint256 indexed levelId, uint256 indexed tokenId);
+    event BaseURIUpdated(string baseURI);
+
+    mapping(address => mapping(uint256 => bool)) public hasClaimedBadge;
+
+    string private baseMetadataURI;
+
+    constructor(string memory initialBaseURI, address initialOwner) ERC1155("") Ownable(initialOwner) {
+        baseMetadataURI = initialBaseURI;
+    }
+
+    function claimBadge(uint256 levelId) external {
+        if (hasClaimedBadge[msg.sender][levelId]) {
+            revert BadgeAlreadyClaimed(msg.sender, levelId);
+        }
+
+        uint256 tokenId = tokenIdForLevel(levelId);
+        hasClaimedBadge[msg.sender][levelId] = true;
+        _mint(msg.sender, tokenId, 1, "");
+
+        emit BadgeClaimed(msg.sender, levelId, tokenId);
+    }
+
+    function tokenIdForLevel(uint256 levelId) public pure returns (uint256) {
+        return levelId;
+    }
+
+    function setBaseURI(string memory nextBaseURI) external onlyOwner {
+        baseMetadataURI = nextBaseURI;
+        emit BaseURIUpdated(nextBaseURI);
+    }
+
+    function uri(uint256 tokenId) public view override returns (string memory) {
+        return string.concat(baseMetadataURI, Strings.toString(tokenId), ".json");
+    }
+}

--- a/apps/contracts/hardhat.config.ts
+++ b/apps/contracts/hardhat.config.ts
@@ -5,6 +5,7 @@ const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.28",
     settings: {
+      evmVersion: "cancun",
       optimizer: {
         enabled: true,
         runs: 200,

--- a/apps/contracts/ignition/modules/Badges.ts
+++ b/apps/contracts/ignition/modules/Badges.ts
@@ -1,0 +1,12 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+
+const BadgesModule = buildModule("BadgesModule", (m) => {
+  const baseURI = m.getParameter("baseURI", "ipfs://chesscito/badges/");
+  const initialOwner = m.getAccount(0);
+
+  const badges = m.contract("Badges", [baseURI, initialOwner]);
+
+  return { badges };
+});
+
+export default BadgesModule;

--- a/apps/contracts/package.json
+++ b/apps/contracts/package.json
@@ -10,6 +10,9 @@
     "deploy": "hardhat ignition deploy ignition/modules/Scoreboard.ts",
     "deploy:celo-sepolia": "hardhat ignition deploy ignition/modules/Scoreboard.ts --network celo-sepolia",
     "deploy:celo": "hardhat ignition deploy ignition/modules/Scoreboard.ts --network celo",
+    "deploy:badges": "hardhat ignition deploy ignition/modules/Badges.ts",
+    "deploy:badges:celo-sepolia": "hardhat ignition deploy ignition/modules/Badges.ts --network celo-sepolia",
+    "deploy:badges:celo": "hardhat ignition deploy ignition/modules/Badges.ts --network celo",
     "verify": "hardhat verify",
     "clean": "hardhat clean",
     "typechain": "hardhat typechain"

--- a/apps/contracts/test/Badges.ts
+++ b/apps/contracts/test/Badges.ts
@@ -1,0 +1,84 @@
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
+import { expect } from "chai";
+import hre from "hardhat";
+import { getAddress } from "viem";
+
+describe("Badges", function () {
+  async function deployBadgesFixture() {
+    const [owner, player, otherPlayer] = await hre.viem.getWalletClients();
+    const publicClient = await hre.viem.getPublicClient();
+    const badges = await hre.viem.deployContract("Badges", [
+      "ipfs://chesscito/badges/",
+      owner.account.address,
+    ]);
+
+    return {
+      owner,
+      player,
+      otherPlayer,
+      publicClient,
+      badges,
+    };
+  }
+
+  it("sets owner and metadata uri scheme", async function () {
+    const { owner, badges } = await loadFixture(deployBadgesFixture);
+
+    expect(await badges.read.owner()).to.equal(getAddress(owner.account.address));
+    expect(await badges.read.uri([3n])).to.equal("ipfs://chesscito/badges/3.json");
+  });
+
+  it("mints one badge per wallet and level", async function () {
+    const { player, publicClient, badges } = await loadFixture(deployBadgesFixture);
+    const badgesAsPlayer = await hre.viem.getContractAt("Badges", badges.address, {
+      client: { wallet: player },
+    });
+
+    const hash = await badgesAsPlayer.write.claimBadge([1n]);
+    await publicClient.waitForTransactionReceipt({ hash });
+
+    expect(await badges.read.hasClaimedBadge([getAddress(player.account.address), 1n])).to.equal(true);
+    expect(await badges.read.balanceOf([getAddress(player.account.address), 1n])).to.equal(1n);
+
+    const events = await badges.getEvents.BadgeClaimed();
+    expect(events).to.have.length(1);
+    expect(events[0].args.player).to.equal(getAddress(player.account.address));
+    expect(events[0].args.levelId).to.equal(1n);
+    expect(events[0].args.tokenId).to.equal(1n);
+  });
+
+  it("prevents claiming the same level twice for the same wallet", async function () {
+    const { player, badges } = await loadFixture(deployBadgesFixture);
+    const badgesAsPlayer = await hre.viem.getContractAt("Badges", badges.address, {
+      client: { wallet: player },
+    });
+
+    await badgesAsPlayer.write.claimBadge([2n]);
+
+    await expect(badgesAsPlayer.write.claimBadge([2n])).to.be.rejectedWith("BadgeAlreadyClaimed");
+  });
+
+  it("allows different wallets to claim the same level", async function () {
+    const { player, otherPlayer, badges } = await loadFixture(deployBadgesFixture);
+    const badgesAsPlayer = await hre.viem.getContractAt("Badges", badges.address, {
+      client: { wallet: player },
+    });
+    const badgesAsOtherPlayer = await hre.viem.getContractAt("Badges", badges.address, {
+      client: { wallet: otherPlayer },
+    });
+
+    await badgesAsPlayer.write.claimBadge([4n]);
+    await badgesAsOtherPlayer.write.claimBadge([4n]);
+
+    expect(await badges.read.balanceOf([getAddress(player.account.address), 4n])).to.equal(1n);
+    expect(await badges.read.balanceOf([getAddress(otherPlayer.account.address), 4n])).to.equal(1n);
+  });
+
+  it("lets the owner update the base uri", async function () {
+    const { badges } = await loadFixture(deployBadgesFixture);
+
+    await badges.write.setBaseURI(["https://assets.chesscito.xyz/badges/"]);
+
+    expect(await badges.read.uri([7n])).to.equal("https://assets.chesscito.xyz/badges/7.json");
+  });
+});


### PR DESCRIPTION
## Summary
- add the Badges ERC-1155 contract with one claim per wallet and level
- add Hardhat tests for claim, duplicate prevention and metadata URI
- add an Ignition deploy module and package scripts for Badges deploys

## Validation
- pnpm --filter hardhat compile
- pnpm --filter hardhat test
- cd apps/contracts && pnpm run deploy:badges

## Notes
- hardhat config now targets  because OpenZeppelin 5 ERC-1155 utilities require 
- the claim flow is user-driven through  so it stays compatible with the upcoming MiniPay tx slice