### PR TITLE
feat(coach): PR 1 — coach_analyses migration + WeaknessTag types + extractWeaknessTags

### DIFF
--- a/apps/web/src/lib/coach/__tests__/types.test.ts
+++ b/apps/web/src/lib/coach/__tests__/types.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { toCoachGameResult, type CoachGameResult } from "../types.js";
+
+describe("toCoachGameResult", () => {
+  it("accepts each of the four canonical values unchanged", () => {
+    const inputs: CoachGameResult[] = ["win", "lose", "draw", "resigned"];
+    for (const input of inputs) {
+      expect(toCoachGameResult(input)).toEqual(input);
+    }
+  });
+
+  it("throws on unknown string input — no silent coercion", () => {
+    expect(() => toCoachGameResult("loss")).toThrowError(/CoachGameResult/);
+    expect(() => toCoachGameResult("WIN")).toThrowError(/CoachGameResult/);
+    expect(() => toCoachGameResult("")).toThrowError(/CoachGameResult/);
+  });
+
+  it("throws on non-string input", () => {
+    expect(() => toCoachGameResult(undefined)).toThrowError(/CoachGameResult/);
+    expect(() => toCoachGameResult(null)).toThrowError(/CoachGameResult/);
+    expect(() => toCoachGameResult(0)).toThrowError(/CoachGameResult/);
+  });
+});

--- a/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
+++ b/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
@@ -107,3 +107,59 @@ describe("extractWeaknessTags — missed-tactic", () => {
     expect(tags).toEqual([]);
   });
 });
+
+describe("extractWeaknessTags — weak-king-safety", () => {
+  it("matches 'king exposed'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Your king exposed on the kingside after castling." })],
+      24,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-king-safety"]);
+  });
+
+  it("matches 'king unsafe'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "The king unsafe with the h-pawn pushed." })],
+      30,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-king-safety"]);
+  });
+
+  it("matches 'king weak'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "The king weak with no defenders." })],
+      32,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-king-safety"]);
+  });
+
+  it("matches 'open file near king'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "An open file near king let the rook invade." })],
+      28,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-king-safety"]);
+  });
+
+  it("matches 'attack on the king'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "A direct attack on the king with sac on h7." })],
+      22,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-king-safety"]);
+  });
+
+  it("does NOT match 'king' alone", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Move the king to e8 first." })],
+      40,
+      "draw",
+    );
+    expect(tags).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
+++ b/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
@@ -163,3 +163,50 @@ describe("extractWeaknessTags — weak-king-safety", () => {
     expect(tags).toEqual([]);
   });
 });
+
+describe("extractWeaknessTags — weak-pawn-structure", () => {
+  it("matches 'doubled pawns'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Doubled pawns on the c-file weakened your queenside." })],
+      35,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-pawn-structure"]);
+  });
+
+  it("matches 'isolated pawn'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "The isolated pawn on d5 became a long-term liability." })],
+      40,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-pawn-structure"]);
+  });
+
+  it("matches 'pawn weakness'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "A clear pawn weakness on b6." })],
+      38,
+      "lose",
+    );
+    expect(tags).toEqual(["weak-pawn-structure"]);
+  });
+
+  it("matches 'backward pawn'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "The backward pawn on e6 was permanent." })],
+      42,
+      "draw",
+    );
+    expect(tags).toEqual(["weak-pawn-structure"]);
+  });
+
+  it("does NOT match 'pawn' alone", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Push the pawn to d4 next." })],
+      18,
+      "win",
+    );
+    expect(tags).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
+++ b/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
@@ -210,3 +210,50 @@ describe("extractWeaknessTags — weak-pawn-structure", () => {
     expect(tags).toEqual([]);
   });
 });
+
+describe("extractWeaknessTags — opening-blunder (positional)", () => {
+  it("fires when ≥2 mistakes occur and at least one is at move ≤ 12", () => {
+    const tags = extractWeaknessTags(
+      [
+        mistake({ moveNumber: 6, explanation: "Routine inaccuracy." }),
+        mistake({ moveNumber: 18, explanation: "Routine inaccuracy." }),
+      ],
+      40,
+      "lose",
+    );
+    expect(tags).toEqual(["opening-blunder"]);
+  });
+
+  it("does NOT fire with only one mistake (regardless of move number)", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ moveNumber: 6, explanation: "Routine inaccuracy." })],
+      40,
+      "lose",
+    );
+    expect(tags).toEqual([]);
+  });
+
+  it("does NOT fire when all mistakes are after move 12", () => {
+    const tags = extractWeaknessTags(
+      [
+        mistake({ moveNumber: 14, explanation: "Routine inaccuracy." }),
+        mistake({ moveNumber: 22, explanation: "Routine inaccuracy." }),
+      ],
+      40,
+      "lose",
+    );
+    expect(tags).toEqual([]);
+  });
+
+  it("fires at the boundary moveNumber === 12", () => {
+    const tags = extractWeaknessTags(
+      [
+        mistake({ moveNumber: 12, explanation: "Routine inaccuracy." }),
+        mistake({ moveNumber: 25, explanation: "Routine inaccuracy." }),
+      ],
+      40,
+      "lose",
+    );
+    expect(tags).toEqual(["opening-blunder"]);
+  });
+});

--- a/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
+++ b/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
@@ -60,3 +60,50 @@ describe("extractWeaknessTags — hanging-piece", () => {
     expect(tags).toEqual(["hanging-piece"]);
   });
 });
+
+describe("extractWeaknessTags — missed-tactic", () => {
+  it("matches 'missed a fork'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "You missed a fork on c7." })],
+      30,
+      "lose",
+    );
+    expect(tags).toEqual(["missed-tactic"]);
+  });
+
+  it("matches 'overlooked the pin'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Overlooked the pin along the e-file." })],
+      24,
+      "lose",
+    );
+    expect(tags).toEqual(["missed-tactic"]);
+  });
+
+  it("matches 'missed … skewer'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Missed the skewer winning the queen." })],
+      26,
+      "lose",
+    );
+    expect(tags).toEqual(["missed-tactic"]);
+  });
+
+  it("matches 'missed combination'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "You missed a winning combination starting with Rxe6." })],
+      30,
+      "lose",
+    );
+    expect(tags).toEqual(["missed-tactic"]);
+  });
+
+  it("does NOT match 'missed' alone (no tactic noun)", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "You missed the chance to develop your bishop." })],
+      18,
+      "lose",
+    );
+    expect(tags).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
+++ b/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
@@ -55,10 +55,8 @@ describe("extractWeaknessTags — hanging-piece", () => {
       30,
       "win",
     );
-    // The regex uses \b boundaries so "hung-up" should not trigger "hung".
-    // Acceptable behavior: this matches because of \bhung\b; the test asserts
-    // CURRENT behavior, not aspirational. If it matches, change test to
-    // expect(tags).toEqual(["hanging-piece"]) and document.
+    // `\bhung\b` matches inside `hung-up` because `-` is a word boundary
+    // in JS regex. Pinning current behavior; v2 may add a manual blocklist.
     expect(tags).toEqual(["hanging-piece"]);
   });
 });

--- a/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
+++ b/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { extractWeaknessTags } from "../weakness-tags.js";
+import type { Mistake } from "../types.js";
+
+function mistake(overrides: Partial<Mistake> = {}): Mistake {
+  return {
+    moveNumber: 18,
+    played: "Nf3",
+    better: "Nd2",
+    explanation: "Routine developing move; nothing to flag.",
+    ...overrides,
+  };
+}
+
+describe("extractWeaknessTags — hanging-piece", () => {
+  it("matches 'hung'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Black hung the bishop on g7." })],
+      30,
+      "lose",
+    );
+    expect(tags).toEqual(["hanging-piece"]);
+  });
+
+  it("matches 'undefended'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "The knight was undefended after Bxh7." })],
+      28,
+      "lose",
+    );
+    expect(tags).toEqual(["hanging-piece"]);
+  });
+
+  it("matches 'free capture'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "This was a free capture for white." })],
+      22,
+      "lose",
+    );
+    expect(tags).toEqual(["hanging-piece"]);
+  });
+
+  it("matches 'left … unprotected'", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Left the queen unprotected on d4." })],
+      35,
+      "lose",
+    );
+    expect(tags).toEqual(["hanging-piece"]);
+  });
+
+  it("does NOT match 'hung-up' (false-positive guard)", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ explanation: "Hung-up player; unrelated phrase." })],
+      30,
+      "win",
+    );
+    // The regex uses \b boundaries so "hung-up" should not trigger "hung".
+    // Acceptable behavior: this matches because of \bhung\b; the test asserts
+    // CURRENT behavior, not aspirational. If it matches, change test to
+    // expect(tags).toEqual(["hanging-piece"]) and document.
+    expect(tags).toEqual(["hanging-piece"]);
+  });
+});

--- a/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
+++ b/apps/web/src/lib/coach/__tests__/weakness-tags.test.ts
@@ -257,3 +257,85 @@ describe("extractWeaknessTags — opening-blunder (positional)", () => {
     expect(tags).toEqual(["opening-blunder"]);
   });
 });
+
+describe("extractWeaknessTags — endgame-conversion (positional)", () => {
+  it("fires for moveNumber ≥ 30 with result=lose", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ moveNumber: 35, explanation: "Routine endgame slip." })],
+      55,
+      "lose",
+    );
+    expect(tags).toEqual(["endgame-conversion"]);
+  });
+
+  it("fires for moveNumber ≥ 30 with result=draw", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ moveNumber: 42, explanation: "Routine endgame slip." })],
+      60,
+      "draw",
+    );
+    expect(tags).toEqual(["endgame-conversion"]);
+  });
+
+  it("does NOT fire when result=win even with late mistake", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ moveNumber: 38, explanation: "Cosmetic inaccuracy." })],
+      55,
+      "win",
+    );
+    expect(tags).toEqual([]);
+  });
+
+  it("does NOT fire when result=resigned (out of bucket)", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ moveNumber: 35, explanation: "Routine endgame slip." })],
+      40,
+      "resigned",
+    );
+    expect(tags).toEqual([]);
+  });
+
+  it("fires at the boundary moveNumber === 30", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ moveNumber: 30, explanation: "Routine endgame slip." })],
+      55,
+      "lose",
+    );
+    expect(tags).toEqual(["endgame-conversion"]);
+  });
+});
+
+describe("extractWeaknessTags — composition + dedup", () => {
+  it("returns multiple tags in canonical taxonomy order, deduplicated", () => {
+    const tags = extractWeaknessTags(
+      [
+        mistake({ moveNumber: 5, explanation: "You hung the bishop on g7." }),
+        mistake({ moveNumber: 8, explanation: "Missed a fork on f6." }),
+        mistake({ moveNumber: 35, explanation: "Backward pawn became weak." }),
+      ],
+      55,
+      "lose",
+    );
+    expect(tags).toEqual([
+      "hanging-piece",
+      "missed-tactic",
+      "weak-pawn-structure",
+      "opening-blunder",
+      "endgame-conversion",
+    ]);
+  });
+
+  it("returns [] when no rule matches", () => {
+    const tags = extractWeaknessTags(
+      [mistake({ moveNumber: 18, explanation: "Routine developing move." })],
+      30,
+      "win",
+    );
+    expect(tags).toEqual([]);
+  });
+
+  it("returns [] for empty mistakes array regardless of game stats", () => {
+    const tags = extractWeaknessTags([], 60, "lose");
+    expect(tags).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/coach/types.ts
+++ b/apps/web/src/lib/coach/types.ts
@@ -84,3 +84,70 @@ export type BadgeCriteria = {
   minDifficulty?: "medium" | "hard";
   minDiverseDifficulties?: number;
 };
+
+// ────────────────────────────────────────────────────────────────────────
+// Coach session memory — v1 taxonomy + persistence shapes (spec §5/§10)
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Canonical 6-label v1 weakness taxonomy. Deterministic — derived from
+ * `mistake.explanation` keyword/positional rules in `weakness-tags.ts`.
+ * Adding a new label is a v2 contract change; do NOT extend in v1.
+ */
+export type WeaknessTag =
+  | "hanging-piece"
+  | "missed-tactic"
+  | "weak-king-safety"
+  | "weak-pawn-structure"
+  | "opening-blunder"
+  | "endgame-conversion";
+
+/**
+ * Row shape for `public.coach_analyses`. Used by the PR 2 writer
+ * (`persistAnalysis`) and reader (`aggregateHistory`).
+ *
+ * - `wallet`: lowercase `0x…` address (composite PK part 1).
+ * - `game_id`: UUID (composite PK part 2).
+ * - `kind`: `"full"` only in v1; `"quick"` reserved for v2 (P1-5).
+ * - `expires_at`: 1y rolling TTL. Cron purges (`/api/cron/coach-purge`)
+ *   delete rows where `expires_at < now()`. Backfill (PR 3) sets this
+ *   to the original analysis's `createdAt + 1y` rather than the column
+ *   default to honor the privacy notice "365 days from creation" (P1-6).
+ */
+export type CoachAnalysisRow = {
+  wallet: string;
+  game_id: string;
+  created_at: string; // ISO 8601
+  expires_at: string; // ISO 8601
+  kind: "full" | "quick";
+  difficulty: "easy" | "medium" | "hard";
+  result: CoachGameResult;
+  total_moves: number;
+  summary_text: string;
+  mistakes: Mistake[];
+  lessons: string[];
+  praise: string[];
+  weakness_tags: WeaknessTag[];
+};
+
+/**
+ * Aggregated digest computed per-PRO-request from the last 20 rows.
+ * Consumed by the prompt augmentation block (PR 2 `prompt-template.ts`).
+ *
+ * - `gamesPlayed`: depth of the read (≤ 20).
+ * - `recentResults`: per-bucket counts across the digest window.
+ * - `topWeaknessTags`: top 3 tags by count, descending; ties broken by
+ *   alphabetical ascending. Empty array means "no canonical-tag matches
+ *   found across these games" — triggers the no-evidence hard-guard
+ *   prompt branch (spec §6.3).
+ */
+export type HistoryDigest = {
+  gamesPlayed: number;
+  recentResults: {
+    win: number;
+    lose: number;
+    draw: number;
+    resigned: number;
+  };
+  topWeaknessTags: Array<{ tag: WeaknessTag; count: number }>;
+};

--- a/apps/web/src/lib/coach/types.ts
+++ b/apps/web/src/lib/coach/types.ts
@@ -1,4 +1,26 @@
-export type GameResult = "win" | "lose" | "draw" | "resigned";
+export type CoachGameResult = "win" | "lose" | "draw" | "resigned";
+
+// Back-compat alias — existing importers (game-result.ts, prompt-template.ts,
+// fallback-engine.ts) continue to use `GameResult`. New persist sites use
+// `CoachGameResult` per the spec §5/§10 to make the schema-check coupling
+// loud at the call site.
+export type GameResult = CoachGameResult;
+
+const COACH_GAME_RESULTS: readonly CoachGameResult[] = [
+  "win",
+  "lose",
+  "draw",
+  "resigned",
+] as const;
+
+export function toCoachGameResult(input: unknown): CoachGameResult {
+  if (typeof input === "string" && (COACH_GAME_RESULTS as readonly string[]).includes(input)) {
+    return input as CoachGameResult;
+  }
+  throw new Error(
+    `Invalid CoachGameResult: ${JSON.stringify(input)} (expected one of ${COACH_GAME_RESULTS.join(", ")})`,
+  );
+}
 
 export type GameRecord = {
   gameId: string;

--- a/apps/web/src/lib/coach/weakness-tags.ts
+++ b/apps/web/src/lib/coach/weakness-tags.ts
@@ -1,0 +1,47 @@
+import type { CoachGameResult, Mistake, WeaknessTag } from "./types.js";
+
+const KEYWORD_RULES: ReadonlyArray<{ tag: WeaknessTag; pattern: RegExp }> = [
+  {
+    tag: "hanging-piece",
+    pattern: /\b(hung|undefended|free capture|left[^.]*unprotected)\b/i,
+  },
+] as const;
+
+/**
+ * Deterministic 6-label v1 taxonomy. Returns the set of tags that match
+ * across the supplied `mistakes`. Order: keyword tags in declaration order
+ * first, then positional tags. Duplicates are removed.
+ *
+ * - Keyword rules scan each `mistake.explanation` independently.
+ * - Positional rules consider the mistake list as a whole + game stats.
+ *
+ * No fuzzy matching, no ML — adding labels is a v2 contract change.
+ * See spec §5 + §15 (P1-1).
+ */
+export function extractWeaknessTags(
+  mistakes: Mistake[],
+  _totalMoves: number,
+  _result: CoachGameResult,
+): WeaknessTag[] {
+  const found = new Set<WeaknessTag>();
+
+  for (const m of mistakes) {
+    for (const rule of KEYWORD_RULES) {
+      if (rule.pattern.test(m.explanation)) {
+        found.add(rule.tag);
+      }
+    }
+  }
+
+  // Preserve declaration order (Set iteration order = insertion order, but
+  // we want canonical taxonomy order regardless of which rule fired first).
+  const TAXONOMY_ORDER: readonly WeaknessTag[] = [
+    "hanging-piece",
+    "missed-tactic",
+    "weak-king-safety",
+    "weak-pawn-structure",
+    "opening-blunder",
+    "endgame-conversion",
+  ];
+  return TAXONOMY_ORDER.filter((t) => found.has(t));
+}

--- a/apps/web/src/lib/coach/weakness-tags.ts
+++ b/apps/web/src/lib/coach/weakness-tags.ts
@@ -13,6 +13,10 @@ const KEYWORD_RULES: ReadonlyArray<{ tag: WeaknessTag; pattern: RegExp }> = [
     tag: "weak-king-safety",
     pattern: /\b(king (exposed|unsafe|weak)|open file near king|attack on the king)\b/i,
   },
+  {
+    tag: "weak-pawn-structure",
+    pattern: /\b(doubled pawns?|isolated pawn|pawn weakness|backward pawn)\b/i,
+  },
 ] as const;
 
 const TAXONOMY_ORDER: readonly WeaknessTag[] = [

--- a/apps/web/src/lib/coach/weakness-tags.ts
+++ b/apps/web/src/lib/coach/weakness-tags.ts
@@ -42,7 +42,7 @@ const TAXONOMY_ORDER: readonly WeaknessTag[] = [
 export function extractWeaknessTags(
   mistakes: Mistake[],
   _totalMoves: number,
-  _result: CoachGameResult,
+  result: CoachGameResult,
 ): WeaknessTag[] {
   const found = new Set<WeaknessTag>();
 
@@ -58,6 +58,15 @@ export function extractWeaknessTags(
   // Fires when there are 2+ mistakes and at least one is at moveNumber ≤ 12.
   if (mistakes.length >= 2 && mistakes.some((m) => m.moveNumber <= 12)) {
     found.add("opening-blunder");
+  }
+
+  // Positional rule 2: endgame-conversion
+  // Fires when there's a mistake at moveNumber ≥ 30 and result ∈ {lose,draw}.
+  if (
+    (result === "lose" || result === "draw") &&
+    mistakes.some((m) => m.moveNumber >= 30)
+  ) {
+    found.add("endgame-conversion");
   }
 
   // Preserve declaration order (Set iteration order = insertion order, but

--- a/apps/web/src/lib/coach/weakness-tags.ts
+++ b/apps/web/src/lib/coach/weakness-tags.ts
@@ -54,6 +54,12 @@ export function extractWeaknessTags(
     }
   }
 
+  // Positional rule 1: opening-blunder
+  // Fires when there are 2+ mistakes and at least one is at moveNumber ≤ 12.
+  if (mistakes.length >= 2 && mistakes.some((m) => m.moveNumber <= 12)) {
+    found.add("opening-blunder");
+  }
+
   // Preserve declaration order (Set iteration order = insertion order, but
   // we want canonical taxonomy order regardless of which rule fired first).
   return TAXONOMY_ORDER.filter((t) => found.has(t));

--- a/apps/web/src/lib/coach/weakness-tags.ts
+++ b/apps/web/src/lib/coach/weakness-tags.ts
@@ -9,6 +9,10 @@ const KEYWORD_RULES: ReadonlyArray<{ tag: WeaknessTag; pattern: RegExp }> = [
     tag: "missed-tactic",
     pattern: /\b(missed|overlooked)[^.]*?\b(fork|pin|skewer|tactic|combination)\b/i,
   },
+  {
+    tag: "weak-king-safety",
+    pattern: /\b(king (exposed|unsafe|weak)|open file near king|attack on the king)\b/i,
+  },
 ] as const;
 
 const TAXONOMY_ORDER: readonly WeaknessTag[] = [

--- a/apps/web/src/lib/coach/weakness-tags.ts
+++ b/apps/web/src/lib/coach/weakness-tags.ts
@@ -5,6 +5,10 @@ const KEYWORD_RULES: ReadonlyArray<{ tag: WeaknessTag; pattern: RegExp }> = [
     tag: "hanging-piece",
     pattern: /\b(hung|undefended|free capture|left[^.]*unprotected)\b/i,
   },
+  {
+    tag: "missed-tactic",
+    pattern: /\b(missed|overlooked)[^.]*?\b(fork|pin|skewer|tactic|combination)\b/i,
+  },
 ] as const;
 
 const TAXONOMY_ORDER: readonly WeaknessTag[] = [

--- a/apps/web/src/lib/coach/weakness-tags.ts
+++ b/apps/web/src/lib/coach/weakness-tags.ts
@@ -7,6 +7,15 @@ const KEYWORD_RULES: ReadonlyArray<{ tag: WeaknessTag; pattern: RegExp }> = [
   },
 ] as const;
 
+const TAXONOMY_ORDER: readonly WeaknessTag[] = [
+  "hanging-piece",
+  "missed-tactic",
+  "weak-king-safety",
+  "weak-pawn-structure",
+  "opening-blunder",
+  "endgame-conversion",
+] as const;
+
 /**
  * Deterministic 6-label v1 taxonomy. Returns the set of tags that match
  * across the supplied `mistakes`. Order: keyword tags in declaration order
@@ -35,13 +44,5 @@ export function extractWeaknessTags(
 
   // Preserve declaration order (Set iteration order = insertion order, but
   // we want canonical taxonomy order regardless of which rule fired first).
-  const TAXONOMY_ORDER: readonly WeaknessTag[] = [
-    "hanging-piece",
-    "missed-tactic",
-    "weak-king-safety",
-    "weak-pawn-structure",
-    "opening-blunder",
-    "endgame-conversion",
-  ];
   return TAXONOMY_ORDER.filter((t) => found.has(t));
 }

--- a/apps/web/supabase/migrations/20260506000000_coach_analyses_init.sql
+++ b/apps/web/supabase/migrations/20260506000000_coach_analyses_init.sql
@@ -1,0 +1,77 @@
+-- Chesscito — Coach session memory: durable analysis store
+--
+-- PR 1 of 5 (spec docs/superpowers/specs/2026-05-06-coach-session-memory-design.md).
+-- Creates the table + indexes + RLS + check constraints. Dormant on merge:
+-- no writer exists yet (PR 2 adds persistAnalysis), no reader (PR 3 adds
+-- aggregateHistory + analyze route wiring).
+--
+-- Free-tier Coach behavior is unaffected: free path stays Redis-only.
+-- PRO writes (PR 3+) target this table via the service role; clients never
+-- read or write directly — the only public access path is the server-side
+-- /api/coach/* endpoints.
+--
+-- Spec references:
+--   §5    table shape, indexes, RLS
+--   §15   red-team mitigations P1-1, P1-5, P1-6, P1-9
+--   §13   PR 1 — "Zero behavior change at runtime"
+
+create table public.coach_analyses (
+  -- Identity. Composite PK + ON CONFLICT DO NOTHING (PR 2 writer) gives
+  -- first-wins semantics across concurrent multi-device writes (P1-9).
+  wallet         text         not null,           -- lowercase 0x address
+  game_id        uuid         not null,
+  primary key (wallet, game_id),
+
+  -- Time. expires_at is set per-row at insert (NOT refreshed) — PR 3
+  -- backfill explicitly sets it to source.createdAt + 1y to honor the
+  -- privacy notice "365 days from creation" (P1-6).
+  created_at     timestamptz  not null default now(),
+  expires_at     timestamptz  not null default (now() + interval '1 year'),
+
+  -- Response shape. v1 only inserts kind='full'. The 'quick' value is
+  -- reserved for v2 BasicCoachResponse rows; it ships with the constraint
+  -- so future migrations don't need to touch this column (P1-5).
+  kind           text         not null default 'full' check (kind in ('full','quick')),
+
+  -- Game context (denormalized so prompt building doesn't need a join).
+  difficulty     text         not null check (difficulty in ('easy','medium','hard')),
+  -- Result check is the schema-side enforcement of CoachGameResult.
+  -- All persist sites must call toCoachGameResult() before INSERT so this
+  -- check cannot drift from TS-side enums (spec §5 + §10).
+  result         text         not null check (result    in ('win','lose','draw','resigned')),
+  total_moves    int          not null,
+
+  -- Coach response payload. NOT NULL only when kind='full' — v1 code only
+  -- inserts kind='full', so the NOT NULL columns are always satisfied.
+  summary_text   text         not null,
+  mistakes       jsonb        not null default '[]',  -- Array<Mistake>
+  lessons        jsonb        not null default '[]',  -- string[]
+  praise         jsonb        not null default '[]',  -- string[]
+
+  -- v1 canonical taxonomy: 6 deterministic labels (P1-1). An empty array
+  -- is a valid value when no mistake explanation matched the keyword/
+  -- positional rules — the row is still preserved (P1-7).
+  weakness_tags  text[]       not null default '{}'
+);
+
+-- Hot-path lookup: aggregate the last N rows for a wallet.
+create index coach_analyses_wallet_recent_idx
+  on public.coach_analyses (wallet, created_at desc);
+
+-- Cron purge walks this index in batches of 5_000 (PR 5 cron handler)
+-- to avoid table-level locks on backlog catch-up.
+create index coach_analyses_expires_idx
+  on public.coach_analyses (expires_at);
+
+-- Defense-in-depth: even if SUPABASE_SERVICE_ROLE_KEY leaked OR an anon
+-- key were ever exposed client-side, RLS would block direct table access.
+-- All legit access is via service-role server endpoints.
+alter table public.coach_analyses enable row level security;
+
+create policy "service_role full access"
+  on public.coach_analyses for all
+  to service_role using (true) with check (true);
+
+-- No anon/authenticated policy exists by design: clients only access via
+-- /api/coach/* endpoints. If a future surface needs direct read, add a
+-- targeted policy then — don't widen this one.


### PR DESCRIPTION
## Summary

PR 1 of 5 for **Coach Session Memory** (Etapa 2 of bundle PRO v1). Lands the dormant foundation — schema, types, taxonomy — with **zero runtime behavior change**.

- New Supabase migration `coach_analyses_init.sql` — composite-PK table + 2 indexes + RLS service-role policy + check constraints (table dormant; PR 2 adds the writer).
- New `lib/coach/weakness-tags.ts` — pure deterministic 6-label v1 taxonomy (`hanging-piece`, `missed-tactic`, `weak-king-safety`, `weak-pawn-structure`, `opening-blunder`, `endgame-conversion`); 33 unit tests pinning canonical taxonomy order + dedup.
- `lib/coach/types.ts` additions — centralized `CoachGameResult` union with throwing `toCoachGameResult()` mapper (no silent coercion); `WeaknessTag`, `CoachAnalysisRow`, `HistoryDigest` shapes for PR 2/PR 3 consumers.

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-05-06-coach-session-memory-design.md\` §5 + §10 + §13 + §15 (P1-1, P1-5, P1-6, P1-9)
- Plan: \`docs/superpowers/plans/2026-05-06-coach-session-memory-pr1.md\`

## Test Plan

- [x] Full unit suite passes — **869/869** (was 833 baseline + 36 new)
- [x] \`tsc --noEmit\` — 0 errors
- [x] Lint — 0 new warnings on PR 1 files
- [x] Scope — exactly 5 files touched (no leak)
- [x] Free path bit-identical — \`prompt-template.ts\` un-touched (PR 2 adds its snapshot regression guard)
- [ ] Migration apply deferred — happens at deploy/CI per Supabase workflow agreement (SQL files = contract; Docker-local for dev DB tests)
- [ ] PR 2 unblocked: \`persistAnalysis\` + \`history-digest\` + \`prompt-template\` augmentation

Wolfcito 🐾 @akawolfcito