### PR TITLE
feat(builder): soft-delete (disable/enable) exercises + labyrinths

### DIFF
--- a/apps/web/scripts/__tests__/import-puzzles.test.ts
+++ b/apps/web/scripts/__tests__/import-puzzles.test.ts
@@ -154,6 +154,47 @@ describe("buildCatalog — labyrinths.json", () => {
     expect(forward).toEqual(["lab-a", "lab-b"]);
   });
 
+  it("excludes a soft-disabled record from the built catalog (both buckets)", () => {
+    const labs: LabyrinthRecord[] = [
+      {
+        id: "lab-live",
+        piece: "rook",
+        fen: "8/8/8/8/8/8/8/R6R w - - 0 1",
+        target: "a8",
+        mover: "a1",
+        order: 0,
+      },
+      {
+        id: "lab-off",
+        piece: "rook",
+        fen: "8/8/8/8/8/8/8/R6R w - - 0 1",
+        target: "h8",
+        mover: "h1",
+        order: 1,
+        disabled: true,
+      },
+    ];
+    const exercises: LabyrinthRecord[] = [
+      {
+        id: "ex-off",
+        piece: "bishop",
+        fen: "8/8/8/8/8/8/8/2B5 w - - 0 1",
+        target: "h6",
+        mover: "c1",
+        order: 0,
+        disabled: true,
+        explanation: "should not appear",
+      },
+    ];
+    const cat = buildCatalog([], labs, exercises);
+    expect(cat.errors).toEqual([]);
+    // Disabled records are absent from the generated catalog…
+    expect(cat.labyrinths.rook.map((e) => e.id)).toEqual(["lab-live"]);
+    expect(cat.exercises.bishop).toEqual([]);
+    // …and so is a disabled record's description.
+    expect(cat.descriptions["ex-off"]).toBeUndefined();
+  });
+
   it("rejects a record with a bad piece", () => {
     const cat = buildCatalog([], [
       {

--- a/apps/web/scripts/import-puzzles.ts
+++ b/apps/web/scripts/import-puzzles.ts
@@ -27,6 +27,10 @@ const TIERS: ExerciseTier[] = ["easy", "medium", "hard"];
 export type LabyrinthRecord = {
   id?: string; piece: PieceId; fen: string; target: string; mover?: string;
   tier?: ExerciseTier; tags?: string[]; explanation?: string; order: number;
+  /** Soft-delete flag. A disabled record stays in content/*.json (so it can
+   *  be re-enabled from the builder) but is excluded from the generated
+   *  catalog, so the game never surfaces it. Absent/false → live. */
+  disabled?: boolean;
 };
 
 // content/exercises.json shares the labyrinth record shape; the only
@@ -109,6 +113,7 @@ export function buildCatalog(
   });
 
   for (const rec of labRecords) {
+    if (rec.disabled) continue; // soft-deleted → excluded from the catalog
     if (!PIECES.includes(rec.piece)) { errors.push(`labyrinths.json '${rec.id ?? rec.fen}': bad piece`); continue; }
     addPuzzle({
       kind: "labyrinth", piece: rec.piece, tier: rec.tier ?? "medium", fen: rec.fen,
@@ -117,6 +122,7 @@ export function buildCatalog(
   }
 
   for (const rec of exerciseRecords) {
+    if (rec.disabled) continue; // soft-deleted → excluded from the catalog
     if (!PIECES.includes(rec.piece)) { errors.push(`exercises.json '${rec.id ?? rec.fen}': bad piece`); continue; }
     addPuzzle({
       kind: "exercise", piece: rec.piece, tier: rec.tier ?? "medium", fen: rec.fen,

--- a/apps/web/src/app/api/dev/labyrinth/__tests__/route.test.ts
+++ b/apps/web/src/app/api/dev/labyrinth/__tests__/route.test.ts
@@ -159,6 +159,24 @@ describe("POST /api/dev/labyrinth", () => {
     expect(payload[0].target).toBe("a8");
   });
 
+  it("persists a soft-disabled record but excludes it from the generated catalog", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const disabled = { ...VALID_ROOK_EXERCISE, disabled: true };
+    const res = await POST(postRequest(JSON.stringify(disabled)));
+    expect(res.status).toBe(200);
+    // The record is still written to exercises.json (so it can be re-enabled)…
+    const exWrite = fsMocks.writeFileSync.mock.calls.find((c) =>
+      String(c[0]).endsWith("content/exercises.json"),
+    );
+    const payload = JSON.parse(String(exWrite?.[1])) as Array<Record<string, unknown>>;
+    expect(payload.find((r) => r.id === "rook-ex")?.disabled).toBe(true);
+    // …but the regenerated catalog module does NOT carry its id.
+    const genWrite = fsMocks.writeFileSync.mock.calls.find((c) =>
+      String(c[0]).endsWith("src/lib/game/generated/puzzles.generated.ts"),
+    );
+    expect(String(genWrite?.[1])).not.toContain("rook-ex");
+  });
+
   it("auto-assigns a stable generated id when the record has none", async () => {
     vi.stubEnv("NODE_ENV", "development");
     const { id: _omit, ...noId } = VALID_ROOK;

--- a/apps/web/src/app/dev/labyrinth-builder/page.tsx
+++ b/apps/web/src/app/dev/labyrinth-builder/page.tsx
@@ -332,6 +332,35 @@ export default function LabyrinthBuilderPage() {
     }
   }
 
+  // Soft-delete toggle: flips a record's `disabled` flag via the normal Save
+  // path (no destructive removal). A disabled record stays in content/*.json
+  // for re-enabling but is excluded from the generated catalog. Operates on
+  // the list row directly so it never disturbs the current edit.
+  async function handleToggleDisabled(rec: LabyrinthRecord) {
+    try {
+      const res = await fetch("/api/dev/labyrinth", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...rec, kind, disabled: !rec.disabled }),
+      });
+      const data = await res.json();
+      if (data?.ok) {
+        setToast({
+          kind: "ok",
+          text: `${rec.id ?? "record"} ${rec.disabled ? "enabled" : "disabled"}`,
+        });
+        void refreshRecords();
+      } else {
+        const errs = Array.isArray(data?.errors)
+          ? data.errors.join("; ")
+          : "Toggle failed";
+        setToast({ kind: "err", text: errs });
+      }
+    } catch (e) {
+      setToast({ kind: "err", text: (e as Error).message });
+    }
+  }
+
   const generatedByKind =
     kind === "exercise" ? GENERATED_EXERCISES : GENERATED_LABYRINTHS;
   const existing = generatedByKind[state.piece] ?? [];
@@ -642,23 +671,47 @@ mover=${fenBlock.mover}`}
               <ul className="flex flex-col gap-1">
                 {pieceRecords.map((rec, i) => {
                   const active = !!rec.id && rec.id === state.id;
+                  const isDisabled = !!rec.disabled;
                   return (
                     <li
                       key={rec.id ?? `${rec.piece}-${rec.order}-${i}`}
                       className={`flex items-center justify-between gap-2 rounded px-2 py-1 ${
                         active ? "bg-sky-950/60" : "bg-slate-800/60"
-                      }`}
+                      } ${isDisabled ? "opacity-50" : ""}`}
                     >
                       <span className="truncate font-mono text-xs text-slate-300">
                         {rec.id ?? "(no id)"} · target {rec.target} · order {rec.order}
+                        {isDisabled ? (
+                          <span className="ml-1 rounded bg-amber-900/70 px-1 text-amber-300">
+                            disabled
+                          </span>
+                        ) : null}
                       </span>
-                      <button
-                        type="button"
-                        onClick={() => handleEditRecord(rec)}
-                        className="shrink-0 rounded bg-sky-600 px-2 py-0.5 text-xs font-semibold text-white hover:bg-sky-500"
-                      >
-                        Edit
-                      </button>
+                      <div className="flex shrink-0 gap-1">
+                        <button
+                          type="button"
+                          onClick={() => handleToggleDisabled(rec)}
+                          title={
+                            isDisabled
+                              ? "Re-enable (show in-game again)"
+                              : "Soft-delete (hide from the game, keep the record)"
+                          }
+                          className={`rounded px-2 py-0.5 text-xs font-semibold text-white ${
+                            isDisabled
+                              ? "bg-emerald-600 hover:bg-emerald-500"
+                              : "bg-amber-700 hover:bg-amber-600"
+                          }`}
+                        >
+                          {isDisabled ? "Enable" : "Disable"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleEditRecord(rec)}
+                          className="rounded bg-sky-600 px-2 py-0.5 text-xs font-semibold text-white hover:bg-sky-500"
+                        >
+                          Edit
+                        </button>
+                      </div>
                     </li>
                   );
                 })}


### PR DESCRIPTION
## Builder soft-delete (disable/enable)

Reversible soft-delete for exercises + labyrinths instead of a destructive remove.

A record gains an optional `disabled` flag: it stays in `content/*.json` (so it can be re-enabled), but `buildCatalog` excludes it from the generated catalog, so the game never surfaces it — **zero game-code change**.

### Changes
- **import-puzzles**: `disabled?: boolean` on `LabyrinthRecord`; `buildCatalog` skips disabled records in both the labyrinth and exercise loops (catalog + descriptions).
- **builder** (`/dev/labyrinth-builder`): each row in the Existing list gets a **Disable/Enable** toggle (dimmed + "disabled" badge when off) that flips the flag via the normal Save path — no new endpoint, no array splice, never disturbs the current edit.

### Why soft over hard
With id-keyed progress (PR #120), disabling a mid-pool exercise just drops it from view; remaining ids/stars are untouched. Reversible, preserves authoring, reuses the existing upsert path.

### Tests
- `buildCatalog` excludes a disabled record from both buckets + descriptions.
- Route persists `disabled` to json yet omits the id from the regenerated module.
- Full suite **3862/3862**; `tsc` clean.

Wolfcito 🐾 @akawolfcito
