### PR TITLE
refactor(content): Phase 0 — prod-safe catalog builder in src/lib/content

### DIFF
--- a/apps/web/scripts/import-puzzles.ts
+++ b/apps/web/scripts/import-puzzles.ts
@@ -1,164 +1,23 @@
-import type { Exercise, ExerciseTier, PieceId } from "@/lib/game/types";
-import { mapFenPuzzle, puzzleId, posToSquare, type PuzzleInput, type MappedPuzzle } from "@/lib/game/fen-puzzle";
-import { computeExerciseBfs } from "@/lib/game/exercise-bfs";
+/**
+ * CLI entrypoint: regenerate src/lib/game/generated/puzzles.generated.ts from
+ * content/puzzles.csv + content/labyrinths.json + content/exercises.json.
+ * Run: `pnpm import-puzzles`.
+ *
+ * The pure FEN→catalog builder lives in src/lib/content/catalog.ts (prod-safe,
+ * importable by app/ routes). This file re-exports it for back-compat with the
+ * scripts + tests that import from "scripts/import-puzzles", and adds the
+ * node:fs CLI (`main()` below).
+ */
+export {
+  parseCsv,
+  buildCatalog,
+  renderGeneratedModule,
+  type LabyrinthRecord,
+  type ExerciseRecord,
+  type BuiltCatalog,
+} from "@/lib/content/catalog";
 
-export function parseCsv(text: string): string[][] {
-  const rows: string[][] = [];
-  let row: string[] = [];
-  let field = "";
-  let inQuotes = false;
-  for (let i = 0; i < text.length; i++) {
-    const c = text[i];
-    if (inQuotes) {
-      if (c === '"') { if (text[i + 1] === '"') { field += '"'; i++; } else inQuotes = false; }
-      else field += c;
-    } else if (c === '"') inQuotes = true;
-    else if (c === ",") { row.push(field); field = ""; }
-    else if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; }
-    else if (c !== "\r") field += c;
-  }
-  if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
-  return rows.filter((r) => r.some((f) => f.trim() !== ""));
-}
-
-const PIECES: PieceId[] = ["rook", "bishop", "knight", "pawn", "queen", "king"];
-const TIERS: ExerciseTier[] = ["easy", "medium", "hard"];
-
-export type LabyrinthRecord = {
-  id?: string; piece: PieceId; fen: string; target: string; mover?: string;
-  tier?: ExerciseTier; tags?: string[]; explanation?: string; order: number;
-  /** Soft-delete flag. A disabled record stays in content/*.json (so it can
-   *  be re-enabled from the builder) but is excluded from the generated
-   *  catalog, so the game never surfaces it. Absent/false → live. */
-  disabled?: boolean;
-};
-
-// content/exercises.json shares the labyrinth record shape; the only
-// difference is the bucket it routes to (`kind:"exercise"`).
-export type ExerciseRecord = LabyrinthRecord;
-
-export type BuiltCatalog = {
-  exercises: Record<PieceId, Exercise[]>;
-  labyrinths: Record<PieceId, Exercise[]>;
-  descriptions: Record<string, string>;
-  errors: string[];
-  warnings: string[];
-};
-
-function emptyByPiece(): Record<PieceId, Exercise[]> {
-  return { rook: [], bishop: [], knight: [], pawn: [], queen: [], king: [] };
-}
-function toExerciseFields(m: MappedPuzzle) {
-  // `kind` and `piece` are not part of `Exercise`: `kind` is split into the
-  // exercises/labyrinths buckets, and `piece` is encoded by the catalog key.
-  const { kind: _kind, piece: _piece, ...rest } = m;
-  return rest;
-}
-
-export function buildCatalog(
-  rows: string[][],
-  labRecords: LabyrinthRecord[] = [],
-  exerciseRecords: ExerciseRecord[] = [],
-): BuiltCatalog {
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  const exercises = emptyByPiece();
-  const labyrinths = emptyByPiece();
-  const descriptions: Record<string, string> = {};
-  const seenIds = new Set<string>();
-  const seenPositions = new Set<string>();
-
-  const [header = [], ...body] = rows;
-  const col = (name: string) => header.indexOf(name);
-  for (const n of ["kind", "piece", "fen", "target", "tier"]) {
-    if (header.length && col(n) < 0) errors.push(`missing required column '${n}'`);
-  }
-  if (errors.length) return { exercises, labyrinths, descriptions, errors, warnings };
-
-  const addPuzzle = (
-    input: PuzzleInput, label: string, idOverride: string | undefined, order: number,
-  ) => {
-    let mapped: MappedPuzzle;
-    try { mapped = mapFenPuzzle(input); } catch (e) { errors.push(`${label}: ${(e as Error).message}`); return; }
-    const probe: Exercise = { id: "probe", optimalMoves: 0, ...toExerciseFields(mapped) };
-    const bfs = computeExerciseBfs(input.piece, probe);
-    if (!bfs) { errors.push(`${label}: unsolvable (no path) from ${posToSquare(mapped.startPos)} to ${posToSquare(mapped.targetPos)}`); return; }
-    const id = idOverride || puzzleId(input.piece, `${input.kind}|${input.fen}|${input.target}|${input.mover ?? ""}`);
-    if (seenIds.has(id)) { errors.push(`${label}: duplicate id '${id}'`); return; }
-    seenIds.add(id);
-    const positionKey = `${input.piece.trim()}|${input.fen.trim()}|${input.target.trim()}`;
-    if (seenPositions.has(positionKey)) {
-      warnings.push(`${label}: duplicate position (same piece+fen+target as an earlier puzzle)`);
-    }
-    seenPositions.add(positionKey);
-    const exercise = { id, optimalMoves: bfs.optimalMoves, ...toExerciseFields(mapped) } as Exercise & { __order?: number };
-    exercise.__order = order;
-    if (input.kind === "labyrinth") labyrinths[input.piece].push(exercise);
-    else exercises[input.piece].push(exercise);
-    if (mapped.objective) descriptions[id] = mapped.objective;
-  };
-
-  body.forEach((r, i) => {
-    const line = i + 2;
-    const get = (n: string) => (col(n) >= 0 ? (r[col(n)] ?? "").trim() : "");
-    const kind = get("kind"); const piece = get("piece") as PieceId; const tier = get("tier") as ExerciseTier;
-    if (kind !== "exercise" && kind !== "labyrinth") { errors.push(`row ${line}: bad kind '${kind}'`); return; }
-    if (!PIECES.includes(piece)) { errors.push(`row ${line}: bad piece '${piece}'`); return; }
-    if (!TIERS.includes(tier)) { errors.push(`row ${line}: bad tier '${tier}'`); return; }
-    addPuzzle({
-      kind, piece, tier, fen: get("fen"), target: get("target"), mover: get("mover") || undefined,
-      tags: get("tags") ? get("tags").split(",").map((t) => t.trim()).filter(Boolean) : undefined,
-      explanation: get("explanation") || undefined,
-    }, `row ${line}`, get("id") || undefined, 0);
-  });
-
-  for (const rec of labRecords) {
-    if (rec.disabled) continue; // soft-deleted → excluded from the catalog
-    if (!PIECES.includes(rec.piece)) { errors.push(`labyrinths.json '${rec.id ?? rec.fen}': bad piece`); continue; }
-    addPuzzle({
-      kind: "labyrinth", piece: rec.piece, tier: rec.tier ?? "medium", fen: rec.fen,
-      target: rec.target, mover: rec.mover, tags: rec.tags, explanation: rec.explanation,
-    }, `labyrinths.json '${rec.id ?? rec.fen}'`, rec.id, rec.order);
-  }
-
-  for (const rec of exerciseRecords) {
-    if (rec.disabled) continue; // soft-deleted → excluded from the catalog
-    if (!PIECES.includes(rec.piece)) { errors.push(`exercises.json '${rec.id ?? rec.fen}': bad piece`); continue; }
-    addPuzzle({
-      kind: "exercise", piece: rec.piece, tier: rec.tier ?? "medium", fen: rec.fen,
-      target: rec.target, mover: rec.mover, tags: rec.tags, explanation: rec.explanation,
-    }, `exercises.json '${rec.id ?? rec.fen}'`, rec.id, rec.order);
-  }
-
-  // Both buckets sort by (order, id) then strip the __order sort key. order
-  // is the authored catalog index, so the round-trip preserves the live
-  // training-path order exactly (CSV/legacy callers pass order 0 → id-sort).
-  for (const p of PIECES) {
-    const byOrderThenId = (
-      a: Exercise & { __order?: number },
-      b: Exercise & { __order?: number },
-    ) => ((a.__order ?? 0) - (b.__order ?? 0)) || a.id.localeCompare(b.id);
-    (exercises[p] as (Exercise & { __order?: number })[]).sort(byOrderThenId);
-    (labyrinths[p] as (Exercise & { __order?: number })[]).sort(byOrderThenId);
-    for (const e of exercises[p] as (Exercise & { __order?: number })[]) delete e.__order;
-    for (const e of labyrinths[p] as (Exercise & { __order?: number })[]) delete e.__order;
-  }
-  return { exercises, labyrinths, descriptions, errors, warnings };
-}
-
-export function renderGeneratedModule(cat: BuiltCatalog): string {
-  const j = (v: unknown) => JSON.stringify(v, null, 2);
-  return `// AUTO-GENERATED by scripts/import-puzzles.ts — DO NOT EDIT by hand.
-// Source: content/puzzles.csv + content/labyrinths.json + content/exercises.json. Regenerate: pnpm import-puzzles
-import type { Exercise, PieceId } from "@/lib/game/types";
-
-export const GENERATED_EXERCISES: Record<PieceId, Exercise[]> = ${j(cat.exercises)};
-
-export const GENERATED_LABYRINTHS: Record<PieceId, Exercise[]> = ${j(cat.labyrinths)};
-
-export const GENERATED_EXERCISE_DESCRIPTIONS: Record<string, string> = ${j(cat.descriptions)};
-`;
-}
+import { parseCsv, buildCatalog, renderGeneratedModule } from "@/lib/content/catalog";
 
 async function main() {
   const { readFileSync, writeFileSync, mkdirSync, existsSync } = await import("node:fs");

--- a/apps/web/src/app/api/dev/labyrinth/route.ts
+++ b/apps/web/src/app/api/dev/labyrinth/route.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { upsertRecord, type LabyrinthRecord } from "@/lib/labyrinth-builder/store";
 import { puzzleId } from "@/lib/game/fen-puzzle";
-import { parseCsv, buildCatalog, renderGeneratedModule } from "../../../../../scripts/import-puzzles";
+import { parseCsv, buildCatalog, renderGeneratedModule } from "@/lib/content/catalog";
 
 export const runtime = "nodejs";
 

--- a/apps/web/src/lib/content/catalog.ts
+++ b/apps/web/src/lib/content/catalog.ts
@@ -1,0 +1,169 @@
+/**
+ * Prod-safe content catalog builder. Extracted from scripts/import-puzzles.ts
+ * (2026-06-17, db-backed-content Phase 0) so that `app/` routes — the dev
+ * builder route today, the DB-overlay write/read paths next — can import the
+ * FEN→catalog validator WITHOUT pulling the script's CLI/fs entrypoint into the
+ * prod bundle. Pure: no node:fs, no process side-effects. The CLI (`main()` +
+ * the argv guard) stays in scripts/import-puzzles.ts, which re-exports these.
+ */
+import type { Exercise, ExerciseTier, PieceId } from "@/lib/game/types";
+import { mapFenPuzzle, puzzleId, posToSquare, type PuzzleInput, type MappedPuzzle } from "@/lib/game/fen-puzzle";
+import { computeExerciseBfs } from "@/lib/game/exercise-bfs";
+
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') { if (text[i + 1] === '"') { field += '"'; i++; } else inQuotes = false; }
+      else field += c;
+    } else if (c === '"') inQuotes = true;
+    else if (c === ",") { row.push(field); field = ""; }
+    else if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; }
+    else if (c !== "\r") field += c;
+  }
+  if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
+  return rows.filter((r) => r.some((f) => f.trim() !== ""));
+}
+
+const PIECES: PieceId[] = ["rook", "bishop", "knight", "pawn", "queen", "king"];
+const TIERS: ExerciseTier[] = ["easy", "medium", "hard"];
+
+export type LabyrinthRecord = {
+  id?: string; piece: PieceId; fen: string; target: string; mover?: string;
+  tier?: ExerciseTier; tags?: string[]; explanation?: string; order: number;
+  /** Soft-delete flag. A disabled record stays in content/*.json (so it can
+   *  be re-enabled from the builder) but is excluded from the generated
+   *  catalog, so the game never surfaces it. Absent/false → live. */
+  disabled?: boolean;
+};
+
+// content/exercises.json shares the labyrinth record shape; the only
+// difference is the bucket it routes to (`kind:"exercise"`).
+export type ExerciseRecord = LabyrinthRecord;
+
+export type BuiltCatalog = {
+  exercises: Record<PieceId, Exercise[]>;
+  labyrinths: Record<PieceId, Exercise[]>;
+  descriptions: Record<string, string>;
+  errors: string[];
+  warnings: string[];
+};
+
+function emptyByPiece(): Record<PieceId, Exercise[]> {
+  return { rook: [], bishop: [], knight: [], pawn: [], queen: [], king: [] };
+}
+function toExerciseFields(m: MappedPuzzle) {
+  // `kind` and `piece` are not part of `Exercise`: `kind` is split into the
+  // exercises/labyrinths buckets, and `piece` is encoded by the catalog key.
+  const { kind: _kind, piece: _piece, ...rest } = m;
+  return rest;
+}
+
+export function buildCatalog(
+  rows: string[][],
+  labRecords: LabyrinthRecord[] = [],
+  exerciseRecords: ExerciseRecord[] = [],
+): BuiltCatalog {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const exercises = emptyByPiece();
+  const labyrinths = emptyByPiece();
+  const descriptions: Record<string, string> = {};
+  const seenIds = new Set<string>();
+  const seenPositions = new Set<string>();
+
+  const [header = [], ...body] = rows;
+  const col = (name: string) => header.indexOf(name);
+  for (const n of ["kind", "piece", "fen", "target", "tier"]) {
+    if (header.length && col(n) < 0) errors.push(`missing required column '${n}'`);
+  }
+  if (errors.length) return { exercises, labyrinths, descriptions, errors, warnings };
+
+  const addPuzzle = (
+    input: PuzzleInput, label: string, idOverride: string | undefined, order: number,
+  ) => {
+    let mapped: MappedPuzzle;
+    try { mapped = mapFenPuzzle(input); } catch (e) { errors.push(`${label}: ${(e as Error).message}`); return; }
+    const probe: Exercise = { id: "probe", optimalMoves: 0, ...toExerciseFields(mapped) };
+    const bfs = computeExerciseBfs(input.piece, probe);
+    if (!bfs) { errors.push(`${label}: unsolvable (no path) from ${posToSquare(mapped.startPos)} to ${posToSquare(mapped.targetPos)}`); return; }
+    const id = idOverride || puzzleId(input.piece, `${input.kind}|${input.fen}|${input.target}|${input.mover ?? ""}`);
+    if (seenIds.has(id)) { errors.push(`${label}: duplicate id '${id}'`); return; }
+    seenIds.add(id);
+    const positionKey = `${input.piece.trim()}|${input.fen.trim()}|${input.target.trim()}`;
+    if (seenPositions.has(positionKey)) {
+      warnings.push(`${label}: duplicate position (same piece+fen+target as an earlier puzzle)`);
+    }
+    seenPositions.add(positionKey);
+    const exercise = { id, optimalMoves: bfs.optimalMoves, ...toExerciseFields(mapped) } as Exercise & { __order?: number };
+    exercise.__order = order;
+    if (input.kind === "labyrinth") labyrinths[input.piece].push(exercise);
+    else exercises[input.piece].push(exercise);
+    if (mapped.objective) descriptions[id] = mapped.objective;
+  };
+
+  body.forEach((r, i) => {
+    const line = i + 2;
+    const get = (n: string) => (col(n) >= 0 ? (r[col(n)] ?? "").trim() : "");
+    const kind = get("kind"); const piece = get("piece") as PieceId; const tier = get("tier") as ExerciseTier;
+    if (kind !== "exercise" && kind !== "labyrinth") { errors.push(`row ${line}: bad kind '${kind}'`); return; }
+    if (!PIECES.includes(piece)) { errors.push(`row ${line}: bad piece '${piece}'`); return; }
+    if (!TIERS.includes(tier)) { errors.push(`row ${line}: bad tier '${tier}'`); return; }
+    addPuzzle({
+      kind, piece, tier, fen: get("fen"), target: get("target"), mover: get("mover") || undefined,
+      tags: get("tags") ? get("tags").split(",").map((t) => t.trim()).filter(Boolean) : undefined,
+      explanation: get("explanation") || undefined,
+    }, `row ${line}`, get("id") || undefined, 0);
+  });
+
+  for (const rec of labRecords) {
+    if (rec.disabled) continue; // soft-deleted → excluded from the catalog
+    if (!PIECES.includes(rec.piece)) { errors.push(`labyrinths.json '${rec.id ?? rec.fen}': bad piece`); continue; }
+    addPuzzle({
+      kind: "labyrinth", piece: rec.piece, tier: rec.tier ?? "medium", fen: rec.fen,
+      target: rec.target, mover: rec.mover, tags: rec.tags, explanation: rec.explanation,
+    }, `labyrinths.json '${rec.id ?? rec.fen}'`, rec.id, rec.order);
+  }
+
+  for (const rec of exerciseRecords) {
+    if (rec.disabled) continue; // soft-deleted → excluded from the catalog
+    if (!PIECES.includes(rec.piece)) { errors.push(`exercises.json '${rec.id ?? rec.fen}': bad piece`); continue; }
+    addPuzzle({
+      kind: "exercise", piece: rec.piece, tier: rec.tier ?? "medium", fen: rec.fen,
+      target: rec.target, mover: rec.mover, tags: rec.tags, explanation: rec.explanation,
+    }, `exercises.json '${rec.id ?? rec.fen}'`, rec.id, rec.order);
+  }
+
+  // Both buckets sort by (order, id) then strip the __order sort key. order
+  // is the authored catalog index, so the round-trip preserves the live
+  // training-path order exactly (CSV/legacy callers pass order 0 → id-sort).
+  for (const p of PIECES) {
+    const byOrderThenId = (
+      a: Exercise & { __order?: number },
+      b: Exercise & { __order?: number },
+    ) => ((a.__order ?? 0) - (b.__order ?? 0)) || a.id.localeCompare(b.id);
+    (exercises[p] as (Exercise & { __order?: number })[]).sort(byOrderThenId);
+    (labyrinths[p] as (Exercise & { __order?: number })[]).sort(byOrderThenId);
+    for (const e of exercises[p] as (Exercise & { __order?: number })[]) delete e.__order;
+    for (const e of labyrinths[p] as (Exercise & { __order?: number })[]) delete e.__order;
+  }
+  return { exercises, labyrinths, descriptions, errors, warnings };
+}
+
+export function renderGeneratedModule(cat: BuiltCatalog): string {
+  const j = (v: unknown) => JSON.stringify(v, null, 2);
+  return `// AUTO-GENERATED by scripts/import-puzzles.ts — DO NOT EDIT by hand.
+// Source: content/puzzles.csv + content/labyrinths.json + content/exercises.json. Regenerate: pnpm import-puzzles
+import type { Exercise, PieceId } from "@/lib/game/types";
+
+export const GENERATED_EXERCISES: Record<PieceId, Exercise[]> = ${j(cat.exercises)};
+
+export const GENERATED_LABYRINTHS: Record<PieceId, Exercise[]> = ${j(cat.labyrinths)};
+
+export const GENERATED_EXERCISE_DESCRIPTIONS: Record<string, string> = ${j(cat.descriptions)};
+`;
+}

--- a/apps/web/src/lib/labyrinth-builder/store.ts
+++ b/apps/web/src/lib/labyrinth-builder/store.ts
@@ -1,4 +1,4 @@
-import type { LabyrinthRecord } from "../../../scripts/import-puzzles";
+import type { LabyrinthRecord } from "@/lib/content/catalog";
 export type { LabyrinthRecord };
 
 /** Replace a record by id; otherwise append. */


### PR DESCRIPTION
## db-backed-content — Phase 0: prod-safe catalog builder

Red-team prerequisite for the DB-backed content feature (`docs/specs/db-backed-content.md`). Moves the FEN→catalog validator out of `scripts/import-puzzles.ts` into `src/lib/content/catalog.ts` so `app/` routes — the dev builder route today, the DB-overlay write/read paths next — can import it **without** pulling the script's `node:fs` CLI into the prod bundle.

### Changes
- **NEW** `src/lib/content/catalog.ts`: `parseCsv`, `buildCatalog`, `renderGeneratedModule` + record types (pure, no fs/process side-effects).
- `scripts/import-puzzles.ts`: re-exports from the new module + keeps only the CLI `main()` + argv guard.
- Dev builder route + labyrinth-builder store import from `@/lib/content/catalog`.

### Zero behavior change
- `tsc` clean, full suite **3862/3862**.
- `pnpm import-puzzles` regenerates `puzzles.generated.ts` **byte-identical** (no diff).
- The dev route (an `app/` handler) importing the relocated module + tsc passing is the proof that a prod route can import the validator with no `scripts/` dependency.

Next: Phase 1 (Supabase `content_overlay` table + `ADMIN_TOKEN`-gated write route + `revalidateTag`).

Wolfcito 🐾 @akawolfcito
