### PR TITLE
feat(db-content): Phase 1 — write-side overlay (table + ADMIN_TOKEN route)

### DIFF
--- a/apps/web/src/app/api/admin/content/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/content/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+/**
+ * POST /api/admin/content — db-backed-content Phase 1 (write side only).
+ *
+ * The ADMIN_TOKEN-gated write route: gate on a server-only shared secret,
+ * rate-limit, BFS-validate the record (reusing buildCatalog), upsert a
+ * content_overlay row keyed by (kind, id), then revalidateTag("content").
+ * The read path still serves the baseline this phase — these tests assert the
+ * write contract only.
+ *
+ * Fail-closed proof: 503 when ADMIN_TOKEN unset, 403 on a bad token, 400 on an
+ * unsolvable/malformed record, 503 when Supabase is unconfigured — and NEVER an
+ * upsert in any of those branches.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+
+vi.mock("@/lib/server/demo-signing", () => ({
+  enforceRateLimit: vi.fn(),
+  getRequestIp: vi.fn(() => "127.0.0.1"),
+}));
+
+const supabaseMock = vi.hoisted(() => ({
+  from: vi.fn(),
+  upsert: vi.fn(),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseServer: vi.fn(() => supabaseMock),
+}));
+
+import { POST } from "../route";
+import { revalidateTag } from "next/cache";
+import { enforceRateLimit } from "@/lib/server/demo-signing";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+const mockedRevalidate = vi.mocked(revalidateTag);
+const mockedRate = vi.mocked(enforceRateLimit);
+const mockedSupabase = vi.mocked(getSupabaseServer);
+
+const TOKEN = "s3cr3t-admin-token";
+
+// A real, BFS-solvable rook exercise (a1 → h1 along rank 1, empty board).
+function validRecord(over: Record<string, unknown> = {}) {
+  return {
+    id: "rook-overlay-1",
+    kind: "exercise",
+    piece: "rook",
+    fen: "8/8/8/8/8/8/8/R7 w - - 0 1",
+    target: "h1",
+    mover: "a1",
+    tier: "easy",
+    tags: null,
+    explanation: null,
+    order: 0,
+    disabled: false,
+    ...over,
+  };
+}
+
+function req(body: unknown, headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/admin/content", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function authed(body: unknown) {
+  return req({ kind: "exercise", record: body }, { "x-admin-token": TOKEN });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabaseMock.from.mockReturnValue({ upsert: supabaseMock.upsert });
+  supabaseMock.upsert.mockResolvedValue({ error: null });
+  mockedSupabase.mockReturnValue(supabaseMock as never);
+  process.env.ADMIN_TOKEN = TOKEN;
+});
+
+afterEach(() => {
+  delete process.env.ADMIN_TOKEN;
+});
+
+describe("POST /api/admin/content", () => {
+  it("returns 503 and never writes when ADMIN_TOKEN is unset", async () => {
+    delete process.env.ADMIN_TOKEN;
+    const res = await POST(authed(validRecord()));
+    expect(res.status).toBe(503);
+    expect(supabaseMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 and never writes on a bad/absent admin token", async () => {
+    const res = await POST(req({ kind: "exercise", record: validRecord() }, { "x-admin-token": "wrong" }));
+    expect(res.status).toBe(403);
+    expect(supabaseMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and never writes on an unsolvable/malformed record", async () => {
+    const res = await POST(authed(validRecord({ target: "z9" })));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.errors.length).toBeGreaterThan(0);
+    expect(supabaseMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when Supabase is unconfigured", async () => {
+    mockedSupabase.mockReturnValue(null as never);
+    const res = await POST(authed(validRecord()));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 429 when the rate limit is exceeded", async () => {
+    mockedRate.mockRejectedValueOnce(new Error("Rate limit exceeded"));
+    const res = await POST(authed(validRecord()));
+    expect(res.status).toBe(429);
+    expect(supabaseMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it("upserts (kind,id), revalidates the content tag, and returns the saved row", async () => {
+    const res = await POST(authed(validRecord()));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.revalidated).toBe(true);
+    expect(body.saved.id).toBe("rook-overlay-1");
+    expect(body.saved.kind).toBe("exercise");
+    expect(body.saved.optimal_moves).toBe(1); // a1 → h1 is one rook move
+    expect(typeof body.saved.updated_at).toBe("string");
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("content_overlay");
+    const [row, opts] = supabaseMock.upsert.mock.calls[0];
+    expect(row).toMatchObject({ id: "rook-overlay-1", kind: "exercise", optimal_moves: 1 });
+    expect(opts).toMatchObject({ onConflict: "kind,id" });
+    expect(mockedRevalidate).toHaveBeenCalledWith("content");
+  });
+});

--- a/apps/web/src/app/api/admin/content/route.ts
+++ b/apps/web/src/app/api/admin/content/route.ts
@@ -1,0 +1,138 @@
+/**
+ * POST /api/admin/content — db-backed-content Phase 1 (write side only).
+ *
+ * Founder-only write path for the content overlay. Gated on a server-only
+ * ADMIN_TOKEN shared secret (never NEXT_PUBLIC_), rate-limited, and BFS-validated
+ * by reusing the same `buildCatalog` validator as the build/dev-route. A valid
+ * write upserts one `content_overlay` row keyed by (kind, id) and calls
+ * revalidateTag("content") so the (future, Phase 2) merged read path rebuilds.
+ *
+ * Fail-closed: 503 when ADMIN_TOKEN unset, 403 on a bad token, 400 on an
+ * unsolvable/malformed record, 503 when Supabase is unconfigured — never an
+ * upsert in any of those branches. The read path still serves the baseline.
+ *
+ * See docs/specs/db-backed-content.md (Architecture decisions 3, 5, 6).
+ */
+import { NextResponse } from "next/server";
+import { createHash, timingSafeEqual } from "node:crypto";
+import { revalidateTag } from "next/cache";
+import { buildCatalog, type LabyrinthRecord } from "@/lib/content/catalog";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { enforceRateLimit, getRequestIp } from "@/lib/server/demo-signing";
+import type {
+  ContentKind,
+  ContentOverlayRow,
+  ContentWriteRequest,
+} from "@/lib/content/overlay-types";
+
+export const runtime = "nodejs";
+
+const CONTENT_TAG = "content";
+
+/** Constant-time compare via fixed-length sha256 digests (length not leaked). */
+function tokenMatches(provided: string | null, expected: string): boolean {
+  if (!provided) return false;
+  const sha = (s: string) => createHash("sha256").update(s).digest();
+  return timingSafeEqual(sha(provided), sha(expected));
+}
+
+function err(errors: string[], status: number) {
+  return NextResponse.json({ ok: false, errors }, { status });
+}
+
+export async function POST(request: Request) {
+  // 1. Server-only secret. Absent env → route disabled (red-team P0).
+  const expected = process.env.ADMIN_TOKEN;
+  if (!expected) return err(["admin writes disabled"], 503);
+
+  // 2. Auth gate.
+  const provided = request.headers.get("x-admin-token");
+  if (!tokenMatches(provided, expected)) return err(["forbidden"], 403);
+
+  // 3. Rate limit (reuse the shared token-bucket limiter).
+  try {
+    await enforceRateLimit(getRequestIp(request));
+  } catch {
+    return err(["rate limit exceeded"], 429);
+  }
+
+  // 4. Transport.
+  let body: ContentWriteRequest;
+  try {
+    body = (await request.json()) as ContentWriteRequest;
+  } catch {
+    return err(["invalid JSON"], 400);
+  }
+  const kind: ContentKind = body?.kind === "labyrinth" ? "labyrinth" : "exercise";
+  const record = body?.record;
+  if (!record || typeof record !== "object") return err(["missing record"], 400);
+  if (!record.id) return err(["missing record id"], 400);
+
+  // 5. BFS-validate the puzzle by reusing buildCatalog. We force `disabled:false`
+  //    for validation (a disabled record is excluded from the catalog, so it
+  //    would yield no BFS result) and persist the real flag afterwards.
+  const labRecord: LabyrinthRecord = {
+    id: record.id,
+    piece: record.piece,
+    fen: record.fen,
+    target: record.target,
+    mover: record.mover ?? undefined,
+    tier: record.tier,
+    tags: record.tags ?? undefined,
+    explanation: record.explanation ?? undefined,
+    order: record.order ?? 0,
+  };
+  const cat = buildCatalog(
+    [],
+    kind === "labyrinth" ? [labRecord] : [],
+    kind === "exercise" ? [labRecord] : [],
+  );
+  if (cat.errors.length) return err(cat.errors, 400);
+  const pool = kind === "labyrinth" ? cat.labyrinths : cat.exercises;
+  const built = pool[record.piece]?.find((e) => e.id === record.id);
+  if (!built) return err(["validation produced no puzzle"], 400);
+
+  // 6. Persist the delta. optimal_moves is BFS-verified (trusted by read path).
+  const updated_at = new Date().toISOString();
+  const row: ContentOverlayRow = {
+    id: record.id,
+    kind,
+    piece: record.piece,
+    fen: record.fen,
+    target: record.target,
+    mover: record.mover ?? null,
+    tier: record.tier,
+    tags: record.tags ?? null,
+    explanation: record.explanation ?? null,
+    order: record.order ?? 0,
+    disabled: Boolean(record.disabled),
+    optimal_moves: built.optimalMoves,
+    updated_at,
+  };
+
+  const supabase = getSupabaseServer();
+  if (!supabase) return err(["content store unavailable"], 503);
+  const { error } = await supabase
+    .from("content_overlay")
+    .upsert(row, { onConflict: "kind,id" });
+  if (error) return err([error.message], 500);
+
+  // 7. On-demand revalidation so players see the change without a redeploy.
+  let revalidated = false;
+  try {
+    revalidateTag(CONTENT_TAG);
+    revalidated = true;
+  } catch {
+    revalidated = false;
+  }
+
+  // 8. Audit (never log the token itself — only a short hash of the actor).
+  console.info("[admin/content] write", {
+    id: row.id,
+    kind: row.kind,
+    actor: createHash("sha256").update(provided ?? "").digest("hex").slice(0, 12),
+    updated_at,
+  });
+
+  return NextResponse.json({ ok: true, saved: row, revalidated });
+}

--- a/apps/web/src/lib/content/overlay-types.ts
+++ b/apps/web/src/lib/content/overlay-types.ts
@@ -1,0 +1,52 @@
+/**
+ * Contracts for the DB-backed content overlay (db-backed-content Phase 1).
+ *
+ * The compiled baseline (generated module) stays the source of truth for the
+ * player read path. A `content_overlay` Supabase table holds only DELTAS:
+ * new puzzles, edits to a baseline puzzle, and soft-deletes. Phase 1 ships the
+ * write side only (this contract + the migration + the admin write route); the
+ * read path still serves the baseline. See docs/specs/db-backed-content.md.
+ */
+import type { ExerciseTier, PieceId } from "@/lib/game/types";
+
+export type ContentKind = "exercise" | "labyrinth";
+
+/**
+ * One overlay row = one puzzle delta. Mirrors the builder/import record shape
+ * (`LabyrinthRecord`) plus routing (`kind`) + audit fields. Persisted to the
+ * `content_overlay` table, keyed by `(kind, id)`.
+ */
+export interface ContentOverlayRow {
+  id: string;
+  kind: ContentKind;
+  piece: PieceId;
+  fen: string;
+  target: string;
+  mover: string | null;
+  tier: ExerciseTier;
+  tags: string[] | null;
+  explanation: string | null;
+  order: number;
+  /** Soft-delete (already a builder concept). A disabled row removes its
+   *  puzzle from the merged pool in Phase 2. */
+  disabled: boolean;
+  /** BFS-verified at write time; stored so the read path can trust it without
+   *  re-running BFS per request. */
+  optimal_moves: number;
+  /** ISO timestamp; audit + cache-key hint. Server-assigned on upsert. */
+  updated_at: string;
+}
+
+/**
+ * Admin write request (builder → server). Reuses the dev-route record shape
+ * plus `kind`. The server computes `optimal_moves` (BFS) and `updated_at`, so
+ * the client never supplies them.
+ */
+export interface ContentWriteRequest {
+  kind: ContentKind;
+  record: Omit<ContentOverlayRow, "optimal_moves" | "updated_at">;
+}
+
+export type ContentWriteResult =
+  | { ok: true; saved: ContentOverlayRow; revalidated: boolean }
+  | { ok: false; errors: string[] };

--- a/apps/web/supabase/migrations/20260617000000_content_overlay.sql
+++ b/apps/web/supabase/migrations/20260617000000_content_overlay.sql
@@ -1,0 +1,28 @@
+-- db-backed-content Phase 1 — content overlay table.
+--
+-- Holds only DELTAS over the compiled baseline catalog: new puzzles, edits to a
+-- baseline puzzle, and soft-deletes. The player read path stays the compiled
+-- generated module; this table is merged on top (Phase 2). Written only by the
+-- ADMIN_TOKEN-gated /api/admin/content route via the service-role key.
+--
+-- Service-role only: RLS is enabled with NO anon/authenticated grants, so the
+-- table is unreachable from the client. See docs/specs/db-backed-content.md.
+
+create table if not exists content_overlay (
+  id            text not null,
+  kind          text not null check (kind in ('exercise','labyrinth')),
+  piece         text not null,
+  fen           text not null,
+  target        text not null,
+  mover         text,
+  tier          text not null check (tier in ('easy','medium','hard')),
+  tags          text[],
+  explanation   text,
+  "order"       int not null default 0,
+  disabled      boolean not null default false,
+  optimal_moves int not null,
+  updated_at    timestamptz not null default now(),
+  primary key (kind, id)
+);
+
+alter table content_overlay enable row level security;


### PR DESCRIPTION
## db-backed-content — Phase 1 (write side only)

Builds the write half of the DB-backed content overlay so founder-authored
puzzles can later go live without a redeploy. **Read path is unchanged this
phase** (players still read the compiled baseline). Spec:
`docs/specs/db-backed-content.md`.

### What's in it
- **Contracts (SDD)** — `src/lib/content/overlay-types.ts`: `ContentKind`,
  `ContentOverlayRow`, `ContentWriteRequest`, `ContentWriteResult`.
- **Migration** — `content_overlay` table, PK `(kind, id)`, holds only deltas
  (new / edited / disabled puzzles + BFS-verified `optimal_moves`). RLS enabled,
  **no anon/auth grants** (service-role only). Commit-only; hosted apply is CI.
- **Write route** — `POST /api/admin/content`:
  - `503` when `ADMIN_TOKEN` unset · `403` on bad token (constant-time compare)
  - `429` rate-limited (shared limiter)
  - `400` on unsolvable/malformed records — BFS-validated by reusing
    `buildCatalog` (same validator as the build)
  - upserts `(kind,id)`, calls `revalidateTag("content")`, audit-logs
    (id/kind/token-hash); never persists on any fail-closed branch

### Tests / checks
- 6 route tests: every fail-closed branch + happy-path upsert + revalidate. `tsc` clean.
- Read path byte-identical (no consumer touched).

### Follow-ups (not this PR)
- **Phase 2** = cached `getMergedCatalog()` + per-consumer injection seam +
  hydration contract, behind `CONTENT_OVERLAY_ENABLED`.
- Apply migration to hosted via deploy/CI; local validation via `supabase start`.

Wolfcito 🐾 @akawolfcito
