### PR TITLE
feat(dev): labyrinth-builder previews on the real procedural board

### DIFF
--- a/apps/web/src/app/dev/_components/procedural-board.tsx
+++ b/apps/web/src/app/dev/_components/procedural-board.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/**
+ * ProceduralBoard — dev-only programmatic chess board (no bg image).
+ *
+ * The 8×8 textured tiles ARE the board, so cell alignment is guaranteed by
+ * construction. The candy frame PNG (transparent center) overlays on top with
+ * the grid inset to its measured opening. Coordinates ride the frame band.
+ *
+ * Reused by /dev/board-procedural (PoC) and /dev/labyrinth-builder (preview).
+ * Consumers overlay per-cell content (piece sprite, goal star, walls…) via the
+ * `renderCell` render-prop and handle clicks via `onCellClick`.
+ */
+import type { CSSProperties, ReactNode } from "react";
+
+export const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
+export const RANKS = [8, 7, 6, 5, 4, 3, 2, 1]; // top → bottom
+
+// Measured inner opening of borde-tablero-chesscito1.png (1040×1028).
+export const BOARD_INSET = { top: 3.4, right: 3.56, bottom: 3.99, left: 3.65 };
+export const BOARD_INNER_W = 100 - BOARD_INSET.left - BOARD_INSET.right; // 92.79
+export const BOARD_INNER_H = 100 - BOARD_INSET.top - BOARD_INSET.bottom; // 92.61
+
+const TILE_LIGHT = "/dev/tablero/casilla-clara.png";
+const TILE_DARK = "/dev/tablero/casilla-oscura.png";
+const BORDER = "/dev/tablero/borde-tablero-chesscito1.png";
+
+const LABEL_STYLE: CSSProperties = {
+  position: "absolute",
+  fontSize: "1rem",
+  fontWeight: 900,
+  lineHeight: 1,
+  color: "#d9f17e",
+  WebkitTextStrokeWidth: "2px",
+  WebkitTextStrokeColor: "#1c300a",
+  paintOrder: "stroke",
+  pointerEvents: "none",
+  userSelect: "none",
+};
+
+export function isDarkSquare(file: number, rank: number): boolean {
+  return (file + (8 - rank)) % 2 === 0;
+}
+
+export interface ProceduralBoardProps {
+  /** Overlay content for a cell (markers, sprites). file 0–7, rank 1–8. */
+  renderCell?: (file: number, rank: number, square: string) => ReactNode;
+  /** Click handler — when set, cells become buttons. */
+  onCellClick?: (file: number, rank: number, square: string) => void;
+  showCoordinates?: boolean;
+  darkColor?: string;
+  lightColor?: string;
+  /** Max board width (CSS). Default 23.5rem (390px mobile cap). */
+  maxWidth?: string;
+}
+
+export function ProceduralBoard({
+  renderCell,
+  onCellClick,
+  showCoordinates = true,
+  darkColor = "#7fb24a",
+  lightColor = "#efe6c4",
+  maxWidth = "23.5rem",
+}: ProceduralBoardProps) {
+  const clickable = !!onCellClick;
+  return (
+    <div
+      style={{
+        width: `min(100%, ${maxWidth})`,
+        aspectRatio: "1 / 1",
+        position: "relative",
+      }}
+    >
+      {/* 8×8 textured grid, inset to the frame opening (below the border) */}
+      <div
+        style={{
+          position: "absolute",
+          top: `${BOARD_INSET.top}%`,
+          right: `${BOARD_INSET.right}%`,
+          bottom: `${BOARD_INSET.bottom}%`,
+          left: `${BOARD_INSET.left}%`,
+          display: "grid",
+          gridTemplateColumns: "repeat(8, 1fr)",
+          gridTemplateRows: "repeat(8, 1fr)",
+          zIndex: 1,
+        }}
+      >
+        {RANKS.map((rank) =>
+          FILES.map((file, col) => {
+            const sq = `${file}${rank}`;
+            const dark = isDarkSquare(col, rank);
+            const cellStyle: CSSProperties = {
+              position: "relative",
+              padding: 0,
+              border: "none",
+              backgroundColor: dark ? darkColor : lightColor,
+              backgroundImage: `url(${dark ? TILE_DARK : TILE_LIGHT})`,
+              backgroundSize: "100% 100%",
+              cursor: clickable ? "pointer" : "default",
+            };
+            const content = renderCell?.(col, rank, sq);
+            return clickable ? (
+              <button
+                key={sq}
+                type="button"
+                onClick={() => onCellClick!(col, rank, sq)}
+                title={sq}
+                style={cellStyle}
+              >
+                {content}
+              </button>
+            ) : (
+              <div key={sq} title={sq} style={cellStyle}>
+                {content}
+              </div>
+            );
+          }),
+        )}
+      </div>
+
+      {/* Candy frame — supplied PNG, transparent center, on top */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={BORDER}
+        alt=""
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          zIndex: 2,
+          pointerEvents: "none",
+        }}
+      />
+
+      {/* Coordinate labels ON the frame band */}
+      {showCoordinates &&
+        RANKS.map((rank, row) => (
+          <span
+            key={`rank-${rank}`}
+            style={{
+              ...LABEL_STYLE,
+              left: `${BOARD_INSET.left / 2}%`,
+              top: `${BOARD_INSET.top + (BOARD_INNER_H * (row + 0.5)) / 8}%`,
+              transform: "translate(-50%, -50%)",
+              zIndex: 3,
+            }}
+          >
+            {rank}
+          </span>
+        ))}
+      {showCoordinates &&
+        FILES.map((file, col) => (
+          <span
+            key={`file-${file}`}
+            style={{
+              ...LABEL_STYLE,
+              left: `${BOARD_INSET.left + (BOARD_INNER_W * (col + 0.5)) / 8}%`,
+              top: `${100 - BOARD_INSET.bottom / 2}%`,
+              transform: "translate(-50%, -50%)",
+              zIndex: 3,
+            }}
+          >
+            {file}
+          </span>
+        ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/dev/board-procedural/page.tsx
+++ b/apps/web/src/app/dev/board-procedural/page.tsx
@@ -2,46 +2,23 @@
 
 /**
  * /dev/board-procedural — dev-only proof-of-concept of a fully programmatic
- * board. The 8×8 squares ARE the board (textured tiles drawn by code), so cell
- * alignment is guaranteed by construction. The candy frame is the supplied
- * border PNG (transparent center) overlaid on top; the grid is inset to the
- * frame's measured inner opening so the squares sit exactly inside the tube.
- *
- * Assets (dev): casilla-clara/oscura tiles + borde-tablero-chesscito frame.
+ * board. Renders the shared <ProceduralBoard> (textured tiles + supplied frame
+ * PNG, grid inset to the frame's measured opening) plus palette controls and a
+ * Figma SVG export of the grid geometry.
  */
-import { useState, type CSSProperties } from 'react'
+import { useState } from 'react'
 import { notFound } from 'next/navigation'
+import {
+  ProceduralBoard,
+  FILES,
+  RANKS,
+  BOARD_INSET,
+  BOARD_INNER_W,
+  BOARD_INNER_H,
+  isDarkSquare,
+} from '../_components/procedural-board'
 
 export const dynamic = 'force-dynamic'
-
-const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
-const RANKS = [8, 7, 6, 5, 4, 3, 2, 1] // top → bottom
-
-// Measured inner opening of borde-tablero-chesscito1.png (1040×1028): the green
-// tube's transparent center. Insets are % of the board square.
-const INSET = { top: 3.4, right: 3.56, bottom: 3.99, left: 3.65 }
-const INNER_W = 100 - INSET.left - INSET.right // 92.79
-const INNER_H = 100 - INSET.top - INSET.bottom // 92.61
-
-const TILE_LIGHT = '/dev/tablero/casilla-clara.png'
-const TILE_DARK = '/dev/tablero/casilla-oscura.png'
-const BORDER = '/dev/tablero/borde-tablero-chesscito1.png'
-
-// Corner coordinate label: cream fill + black stroke so it reads on BOTH the
-// cream and green tiles (paintOrder keeps the stroke behind the glyph so thin
-// text stays legible). Sally's recipe — one consistent in-cell system.
-const LABEL_STYLE: CSSProperties = {
-  position: 'absolute',
-  fontSize: '1rem',
-  fontWeight: 900,
-  lineHeight: 1,
-  color: '#d9f17e',
-  WebkitTextStrokeWidth: '2px',
-  WebkitTextStrokeColor: '#1c300a',
-  paintOrder: 'stroke',
-  pointerEvents: 'none',
-  userSelect: 'none',
-}
 
 export default function BoardProceduralPage() {
   if (process.env.NODE_ENV === 'production') notFound()
@@ -52,20 +29,20 @@ export default function BoardProceduralPage() {
 
   function exportSvg() {
     const S = 1000
-    const x0 = (INSET.left / 100) * S
-    const y0 = (INSET.top / 100) * S
-    const cw = ((INNER_W / 100) * S) / 8
-    const ch = ((INNER_H / 100) * S) / 8
+    const x0 = (BOARD_INSET.left / 100) * S
+    const y0 = (BOARD_INSET.top / 100) * S
+    const cw = ((BOARD_INNER_W / 100) * S) / 8
+    const ch = ((BOARD_INNER_H / 100) * S) / 8
     const r2 = (n: number) => Math.round(n * 100) / 100
     const cells: string[] = []
     RANKS.forEach((rank, row) =>
       FILES.forEach((file, col) => {
-        const isDark = (col + (8 - rank)) % 2 === 0
+        const dark = isDarkSquare(col, rank)
         cells.push(
           `<rect id="${file}${rank}" x="${r2(x0 + col * cw)}" y="${r2(
             y0 + row * ch,
           )}" width="${r2(cw)}" height="${r2(ch)}" fill="${
-            isDark ? darkColor : lightColor
+            dark ? darkColor : lightColor
           }"/>`,
         )
       }),
@@ -91,96 +68,11 @@ export default function BoardProceduralPage() {
             Textured tiles + supplied frame PNG. Grid inset to the frame&apos;s
             measured opening — cells sit exactly inside the tube.
           </p>
-
-          <div
-            style={{
-              width: 'min(100%, 23.5rem)',
-              aspectRatio: '1 / 1',
-              position: 'relative',
-            }}
-          >
-            {/* 8×8 textured grid, inset to the frame opening (below the border) */}
-            <div
-              style={{
-                position: 'absolute',
-                top: `${INSET.top}%`,
-                right: `${INSET.right}%`,
-                bottom: `${INSET.bottom}%`,
-                left: `${INSET.left}%`,
-                display: 'grid',
-                gridTemplateColumns: 'repeat(8, 1fr)',
-                gridTemplateRows: 'repeat(8, 1fr)',
-                zIndex: 1,
-              }}
-            >
-              {RANKS.map((rank) =>
-                FILES.map((file, col) => {
-                  const isDark = (col + (8 - rank)) % 2 === 0
-                  return (
-                    <div
-                      key={`${file}${rank}`}
-                      style={{
-                        backgroundColor: isDark ? darkColor : lightColor,
-                        backgroundImage: `url(${
-                          isDark ? TILE_DARK : TILE_LIGHT
-                        })`,
-                        backgroundSize: '100% 100%',
-                      }}
-                      title={`${file}${rank}`}
-                    />
-                  )
-                }),
-              )}
-            </div>
-
-            {/* Candy frame — supplied PNG, transparent center, on top */}
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={BORDER}
-              alt=""
-              style={{
-                position: 'absolute',
-                inset: 0,
-                width: '100%',
-                height: '100%',
-                zIndex: 2,
-                pointerEvents: 'none',
-              }}
-            />
-
-            {/* Coordinate labels ON the frame band (over the green tube), cream
-                fill + black stroke so they read on the green. */}
-            {showLabels &&
-              RANKS.map((rank, row) => (
-                <span
-                  key={`rank-${rank}`}
-                  style={{
-                    ...LABEL_STYLE,
-                    left: `${INSET.left / 2}%`,
-                    top: `${INSET.top + (INNER_H * (row + 0.5)) / 8}%`,
-                    transform: 'translate(-50%, -50%)',
-                    zIndex: 3,
-                  }}
-                >
-                  {rank}
-                </span>
-              ))}
-            {showLabels &&
-              FILES.map((file, col) => (
-                <span
-                  key={`file-${file}`}
-                  style={{
-                    ...LABEL_STYLE,
-                    left: `${INSET.left + (INNER_W * (col + 0.5)) / 8}%`,
-                    top: `${100 - INSET.bottom / 2}%`,
-                    transform: 'translate(-50%, -50%)',
-                    zIndex: 3,
-                  }}
-                >
-                  {file}
-                </span>
-              ))}
-          </div>
+          <ProceduralBoard
+            showCoordinates={showLabels}
+            darkColor={darkColor}
+            lightColor={lightColor}
+          />
         </section>
 
         <section className="flex flex-1 flex-col gap-4">
@@ -214,9 +106,10 @@ export default function BoardProceduralPage() {
           <div className="rounded border border-slate-800 bg-slate-900 p-3 text-sm">
             <p className="mb-1 font-semibold text-slate-300">Geometry</p>
             <p className="text-slate-400">
-              Frame opening inset — top {INSET.top}% · right {INSET.right}% ·
-              bottom {INSET.bottom}% · left {INSET.left}% · inner{' '}
-              {INNER_W.toFixed(2)}% × {INNER_H.toFixed(2)}% (square)
+              Frame opening inset — top {BOARD_INSET.top}% · right{' '}
+              {BOARD_INSET.right}% · bottom {BOARD_INSET.bottom}% · left{' '}
+              {BOARD_INSET.left}% · inner {BOARD_INNER_W.toFixed(2)}% ×{' '}
+              {BOARD_INNER_H.toFixed(2)}%
             </p>
           </div>
 

--- a/apps/web/src/app/dev/labyrinth-builder/page.tsx
+++ b/apps/web/src/app/dev/labyrinth-builder/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
 import { notFound } from "next/navigation";
 import {
   buildFenBlock,
@@ -19,13 +19,87 @@ import {
   GENERATED_LABYRINTHS,
 } from "@/lib/game/generated/puzzles.generated";
 import type { BoardPosition, ExerciseTier, PieceId } from "@/lib/game/types";
+import { THEME_CONFIG } from "@/lib/theme";
+import { ProceduralBoard } from "../_components/procedural-board";
 
 export const dynamic = "force-dynamic";
 
 const PIECES: PieceId[] = ["rook", "bishop", "knight", "pawn", "queen", "king"];
-const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
-// Ranks 8 (top) → 1 (bottom) so a1 renders bottom-left.
-const RANKS = [8, 7, 6, 5, 4, 3, 2, 1];
+
+// Real in-game sprites so the builder previews puzzles on a board that matches
+// /exercises. White pieces; star marks the goal (same as board.tsx).
+const PIECE_SRC: Record<PieceId, string> = {
+  rook: `${THEME_CONFIG.piecesBase}/w-rook.png`,
+  bishop: `${THEME_CONFIG.piecesBase}/w-bishop.png`,
+  knight: `${THEME_CONFIG.piecesBase}/w-knight.png`,
+  pawn: `${THEME_CONFIG.piecesBase}/w-pawn.png`,
+  queen: `${THEME_CONFIG.piecesBase}/w-queen.png`,
+  king: `${THEME_CONFIG.piecesBase}/w-king.png`,
+};
+const STAR_SRC = "/art/redesign/icons/star.png";
+
+// Per-cell marker overlays drawn on the textured ProceduralBoard cells. All are
+// pointer-events:none so taps pass through to the cell button (brush logic).
+const CELL_OVERLAY: Record<string, CSSProperties> = {
+  wall: {
+    position: "absolute",
+    inset: 0,
+    background: "rgba(15, 23, 42, 0.62)",
+    boxShadow: "inset 0 0 0 2px rgba(15,23,42,0.5)",
+    pointerEvents: "none",
+  },
+  capture: {
+    position: "absolute",
+    left: "16%",
+    top: "16%",
+    width: "68%",
+    height: "68%",
+    borderRadius: "50%",
+    border: "3px solid rgba(248, 113, 113, 0.95)",
+    boxShadow: "0 0 8px rgba(248,113,113,0.7)",
+    pointerEvents: "none",
+  },
+  sprite: {
+    position: "absolute",
+    left: "9%",
+    top: "9%",
+    width: "82%",
+    height: "82%",
+    objectFit: "contain",
+    pointerEvents: "none",
+  },
+  star: {
+    position: "absolute",
+    left: "18%",
+    top: "18%",
+    width: "64%",
+    height: "64%",
+    objectFit: "contain",
+    pointerEvents: "none",
+  },
+  dot: {
+    position: "absolute",
+    left: "39%",
+    top: "39%",
+    width: "22%",
+    height: "22%",
+    borderRadius: "50%",
+    background: "rgba(125, 211, 252, 0.95)",
+    boxShadow: "0 0 4px rgba(56,189,248,0.8)",
+    pointerEvents: "none",
+  },
+  trace: {
+    position: "absolute",
+    top: "2px",
+    right: "3px",
+    fontSize: "0.55rem",
+    fontWeight: 800,
+    lineHeight: 1,
+    color: "#fff",
+    textShadow: "0 1px 2px rgba(0,0,0,0.8)",
+    pointerEvents: "none",
+  },
+};
 
 type Brush = "start" | "goal" | "wall" | "capture" | "trace";
 type Kind = "exercise" | "labyrinth";
@@ -392,28 +466,40 @@ export default function LabyrinthBuilderPage() {
             ))}
           </div>
 
-          <div className="inline-grid grid-cols-[1.25rem_repeat(8,2.5rem)] gap-0">
-            {/* file labels (top) */}
-            <div />
-            {FILES.map((f) => (
-              <div
-                key={`top-${f}`}
-                className="flex h-5 items-center justify-center text-xs text-slate-400"
-              >
-                {f}
-              </div>
-            ))}
-            {RANKS.map((rank) => (
-              <RankRow
-                key={`r-${rank}`}
-                rank={rank}
-                state={state}
-                pathSquares={pathSquares}
-                traceIndex={traceIndex}
-                onCell={handleCell}
-              />
-            ))}
-          </div>
+          <ProceduralBoard
+            onCellClick={(_file, _rank, sq) => handleCell(sq)}
+            renderCell={(_file, _rank, sq) => {
+              const isStart = state.start === sq;
+              const isGoal = state.goal === sq;
+              const isWall = state.walls.includes(sq);
+              const isCapture = state.captures.includes(sq);
+              const inPath = pathSquares.has(sq);
+              const traceOrder = traceIndex.get(sq);
+              return (
+                <>
+                  {isWall && !isStart && !isGoal && (
+                    <span style={CELL_OVERLAY.wall} />
+                  )}
+                  {isCapture && !isStart && (
+                    <span style={CELL_OVERLAY.capture} />
+                  )}
+                  {isStart ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={PIECE_SRC[state.piece]} alt="" style={CELL_OVERLAY.sprite} />
+                  ) : isGoal ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={STAR_SRC} alt="" style={CELL_OVERLAY.star} />
+                  ) : null}
+                  {inPath && !isStart && !isGoal && !isWall && (
+                    <span style={CELL_OVERLAY.dot} />
+                  )}
+                  {traceOrder !== undefined && (
+                    <span style={CELL_OVERLAY.trace}>{traceOrder}</span>
+                  )}
+                </>
+              );
+            }}
+          />
 
           {/* Brushes */}
           <div className="flex flex-wrap gap-2">
@@ -444,8 +530,8 @@ export default function LabyrinthBuilderPage() {
             </button>
           </div>
           <p className="text-xs text-slate-500">
-            green=start · amber★=goal · slate=wall · red=capture · dot=BFS path ·
-            number=traced order
+            piece=start · ★=goal · dark tile=wall · red ring=capture · blue
+            dot=BFS path · number=traced order
           </p>
         </section>
 
@@ -741,66 +827,5 @@ mover=${fenBlock.mover}`}
         </section>
       </div>
     </main>
-  );
-}
-
-function RankRow({
-  rank,
-  state,
-  pathSquares,
-  traceIndex,
-  onCell,
-}: {
-  rank: number;
-  state: BuilderState;
-  pathSquares: Set<string>;
-  traceIndex: Map<string, number>;
-  onCell: (sq: string) => void;
-}) {
-  return (
-    <>
-      <div className="flex w-5 items-center justify-center text-xs text-slate-400">
-        {rank}
-      </div>
-      {FILES.map((f) => {
-        const sq = `${f}${rank}`;
-        const isStart = state.start === sq;
-        const isGoal = state.goal === sq;
-        const isWall = state.walls.includes(sq);
-        const isCapture = state.captures.includes(sq);
-        const inPath = pathSquares.has(sq);
-        const traceOrder = traceIndex.get(sq);
-        // Checker background for empty squares.
-        const fileIdx = f.charCodeAt(0) - 97;
-        const isDark = (fileIdx + rank) % 2 === 0;
-
-        let bg = isDark ? "bg-slate-800/60" : "bg-slate-700/40";
-        if (isWall) bg = "bg-slate-500";
-        if (isCapture) bg = "bg-red-600";
-        if (isGoal) bg = "bg-amber-500";
-        if (isStart) bg = "bg-emerald-500";
-
-        return (
-          <button
-            key={sq}
-            type="button"
-            onClick={() => onCell(sq)}
-            className={`relative flex h-10 w-10 items-center justify-center border border-slate-900 text-sm font-bold ${bg}`}
-            title={sq}
-          >
-            {isStart && "●"}
-            {isGoal && !isStart && "★"}
-            {inPath && !isStart && !isGoal && (
-              <span className="absolute h-2 w-2 rounded-full bg-sky-300" />
-            )}
-            {traceOrder !== undefined && (
-              <span className="absolute right-0.5 top-0.5 text-[9px] leading-none text-white/90">
-                {traceOrder}
-              </span>
-            )}
-          </button>
-        );
-      })}
-    </>
   );
 }


### PR DESCRIPTION
## Builder previews on the real procedural board

Wires the programmatic board into `/dev/labyrinth-builder` so authored puzzles
preview on a board that matches `/exercises` — the original goal behind this
session's board work.

### What's in it
- **Extract `ProceduralBoard`** → `app/dev/_components/procedural-board.tsx`:
  reusable component (textured tiles + frame PNG + frame-band lime coords) with
  `renderCell` + `onCellClick` props. `/dev/board-procedural` now consumes it
  (no visual change).
- **Builder swaps its flat CSS grid** for `<ProceduralBoard>`. Per-cell markers
  on the textured board:
  - **start** → real white piece sprite (follows the piece selector)
  - **goal** → star (`/art/redesign/icons/star.png`)
  - **wall** → dark tile · **capture** (pawn) → red ring
  - **BFS path** → blue dot · **trace** → corner number
  - precedence start > goal > wall; all markers `pointer-events:none` so taps
    pass to the cell (brush logic unchanged).

### Checks
- `tsc` + eslint clean. Builder lib + dev-API tests **33/33**.
- Verified at 390px: start d4, goal g7, walls d6/f4 → BFS path dots, optimal
  moves 3, FEN export + Save all working.
- Dev-only (`NODE_ENV` guard → 404 on Vercel).

Wolfcito 🐾 @akawolfcito
