### PR TITLE
feat(db-content): Phase 2a — merged catalog loader (cached, fallback)

### DIFF
--- a/apps/web/src/lib/content/__tests__/merged-catalog.test.ts
+++ b/apps/web/src/lib/content/__tests__/merged-catalog.test.ts
@@ -1,0 +1,138 @@
+/**
+ * mergeOverlay — db-backed-content Phase 2a (pure merge logic).
+ *
+ * Baseline ⊕ overlay deltas: append-new, replace-edit (overlay fields + order
+ * win), remove-disabled, descriptions merged, sorted (order,id). Each overlay
+ * row is re-BFS-verified by reusing buildCatalog — a row that is unsolvable or
+ * whose stored optimal_moves disagrees with the recomputed value is DROPPED
+ * (the DB value is never blindly trusted). No consumer touched this slice.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const supabaseMock = vi.hoisted(() => ({ from: vi.fn(), select: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseServer: vi.fn(() => supabaseMock),
+}));
+
+import { mergeOverlay, loadMergedCatalog } from "../merged-catalog";
+import { buildCatalog, type ExerciseRecord } from "../catalog";
+import { posToSquare } from "@/lib/game/fen-puzzle";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import type { BaselineCatalog, ContentOverlayRow } from "../overlay-types";
+
+const mockedSupabase = vi.mocked(getSupabaseServer);
+
+const EMPTY_BOARD = "8/8/8/8/8/8/8/R7 w - - 0 1";
+
+function baselineWith(records: ExerciseRecord[]): BaselineCatalog {
+  const c = buildCatalog([], [], records);
+  expect(c.errors).toEqual([]);
+  return { exercises: c.exercises, labyrinths: c.labyrinths, descriptions: c.descriptions };
+}
+
+function row(over: Partial<ContentOverlayRow> = {}): ContentOverlayRow {
+  return {
+    id: "rook-ovl",
+    kind: "exercise",
+    piece: "rook",
+    fen: EMPTY_BOARD,
+    target: "a8",
+    mover: "a1",
+    tier: "easy",
+    tags: null,
+    explanation: null,
+    order: 5,
+    disabled: false,
+    optimal_moves: 1, // a1 → a8 (or h1) is one rook move
+    updated_at: "2026-06-17T00:00:00Z",
+    ...over,
+  };
+}
+
+// One baseline rook exercise: a1 → h1, order 0, with a description.
+const BASE = baselineWith([
+  { id: "rook-base-1", piece: "rook", fen: EMPTY_BOARD, target: "h1", mover: "a1", order: 0, explanation: "Base one" },
+]);
+
+describe("mergeOverlay", () => {
+  it("returns the baseline unchanged for an empty overlay", () => {
+    const m = mergeOverlay(BASE, []);
+    expect(m.exercises.rook.map((e) => e.id)).toEqual(["rook-base-1"]);
+    expect(m.overlayCount).toBe(0);
+    expect(m.source).toBe("baseline+overlay");
+  });
+
+  it("appends a new overlay puzzle (sorted by order,id)", () => {
+    const m = mergeOverlay(BASE, [row({ id: "rook-new", target: "a8", order: 5 })]);
+    expect(m.exercises.rook.map((e) => e.id)).toEqual(["rook-base-1", "rook-new"]);
+    expect(m.overlayCount).toBe(1);
+  });
+
+  it("replaces a baseline puzzle of the same id (overlay fields win)", () => {
+    const m = mergeOverlay(BASE, [row({ id: "rook-base-1", target: "a8", order: 0 })]);
+    const hit = m.exercises.rook.filter((e) => e.id === "rook-base-1");
+    expect(hit).toHaveLength(1);
+    expect(posToSquare(hit[0].targetPos)).toBe("a8"); // overlay target, not baseline h1
+    expect(m.exercises.rook).toHaveLength(1);
+  });
+
+  it("removes a disabled overlay row from the pool and its description", () => {
+    const m = mergeOverlay(BASE, [row({ id: "rook-base-1", disabled: true })]);
+    expect(m.exercises.rook.find((e) => e.id === "rook-base-1")).toBeUndefined();
+    expect(m.descriptions["rook-base-1"]).toBeUndefined();
+  });
+
+  it("merges an overlay explanation into descriptions", () => {
+    const m = mergeOverlay(BASE, [row({ id: "rook-new", target: "a8", explanation: "Climb the a-file" })]);
+    expect(m.descriptions["rook-new"]).toBe("Climb the a-file");
+  });
+
+  it("drops an unsolvable/malformed overlay row", () => {
+    const m = mergeOverlay(BASE, [row({ id: "rook-bad", target: "z9" })]);
+    expect(m.exercises.rook.map((e) => e.id)).toEqual(["rook-base-1"]);
+    expect(m.overlayCount).toBe(0);
+  });
+
+  it("drops a row whose stored optimal_moves disagrees with BFS", () => {
+    const m = mergeOverlay(BASE, [row({ id: "rook-liar", target: "a8", optimal_moves: 9 })]);
+    expect(m.exercises.rook.find((e) => e.id === "rook-liar")).toBeUndefined();
+    expect(m.overlayCount).toBe(0);
+  });
+});
+
+describe("loadMergedCatalog (fetch + fallback)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabaseMock.from.mockReturnValue({ select: supabaseMock.select });
+    mockedSupabase.mockReturnValue(supabaseMock as never);
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("falls back to baseline-only when Supabase is unconfigured", async () => {
+    mockedSupabase.mockReturnValue(null as never);
+    const m = await loadMergedCatalog();
+    expect(m.source).toBe("baseline-only");
+    expect(m.overlayCount).toBe(0);
+    expect(m.exercises.rook.length).toBeGreaterThan(0); // real baseline served
+  });
+
+  it("falls back to baseline-only when the query errors", async () => {
+    supabaseMock.select.mockResolvedValue({ data: null, error: { message: "paused" } });
+    const m = await loadMergedCatalog();
+    expect(m.source).toBe("baseline-only");
+  });
+
+  it("falls back to baseline-only when the query throws", async () => {
+    supabaseMock.select.mockRejectedValue(new Error("network"));
+    const m = await loadMergedCatalog();
+    expect(m.source).toBe("baseline-only");
+  });
+
+  it("merges overlay rows when the query succeeds", async () => {
+    supabaseMock.select.mockResolvedValue({ data: [row({ id: "rook-ovl-live", target: "a8" })], error: null });
+    const m = await loadMergedCatalog();
+    expect(m.source).toBe("baseline+overlay");
+    expect(m.overlayCount).toBe(1);
+    expect(m.exercises.rook.some((e) => e.id === "rook-ovl-live")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/content/merged-catalog.ts
+++ b/apps/web/src/lib/content/merged-catalog.ts
@@ -1,0 +1,217 @@
+/**
+ * Merged content catalog — db-backed-content Phase 2a.
+ *
+ * `mergeOverlay` (pure): baseline ⊕ overlay deltas. Append-new, replace-edit
+ * (overlay fields + order win), remove-disabled, descriptions merged, each pool
+ * sorted (order,id). Every non-disabled overlay row is re-BFS-verified by
+ * reusing `buildCatalog`; a row that is unsolvable/malformed or whose stored
+ * `optimal_moves` disagrees with the recomputed value is DROPPED — the DB value
+ * is never blindly trusted.
+ *
+ * `getMergedCatalog`: the cached, ready-to-serve entry point. Fetches the
+ * overlay once per cache rebuild (tagged "content"; the write route revalidates
+ * it), merges over the compiled baseline, and falls back to baseline-only
+ * whenever the overlay is unavailable (no client / fetch error / timeout).
+ *
+ * NO player consumer reads this yet (Phase 2b/2c). This slice is the loader +
+ * merge logic only.
+ */
+import { unstable_cache } from "next/cache";
+import type { Exercise, PieceId } from "@/lib/game/types";
+import {
+  GENERATED_EXERCISES,
+  GENERATED_LABYRINTHS,
+  GENERATED_EXERCISE_DESCRIPTIONS,
+} from "@/lib/game/generated/puzzles.generated";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { buildCatalog, type LabyrinthRecord } from "./catalog";
+import type {
+  BaselineCatalog,
+  ContentOverlayRow,
+  MergedCatalog,
+} from "./overlay-types";
+
+/** Cache tag the admin write route revalidates after a save. */
+export const CONTENT_TAG = "content";
+/** Degrade to baseline fast if the (possibly paused free-tier) DB is slow. */
+const OVERLAY_TIMEOUT_MS = 2000;
+
+const PIECES: PieceId[] = ["rook", "bishop", "knight", "pawn", "queen", "king"];
+
+function emptyByPiece<T>(): Record<PieceId, T[]> {
+  return { rook: [], bishop: [], knight: [], pawn: [], queen: [], king: [] };
+}
+
+type Entry = { exercise: Exercise; order: number };
+
+/**
+ * Re-validate a single overlay row through the shared BFS catalog builder.
+ * Returns the built Exercise (+ description) or null when the row is
+ * unsolvable/malformed or its stored optimal_moves disagrees with BFS.
+ */
+function buildOverlayRow(
+  row: ContentOverlayRow,
+): { exercise: Exercise; description?: string } | null {
+  const rec: LabyrinthRecord = {
+    id: row.id,
+    piece: row.piece,
+    fen: row.fen,
+    target: row.target,
+    mover: row.mover ?? undefined,
+    tier: row.tier,
+    tags: row.tags ?? undefined,
+    explanation: row.explanation ?? undefined,
+    order: row.order,
+  };
+  const cat = buildCatalog(
+    [],
+    row.kind === "labyrinth" ? [rec] : [],
+    row.kind === "exercise" ? [rec] : [],
+  );
+  if (cat.errors.length) return null;
+  const pool = row.kind === "labyrinth" ? cat.labyrinths : cat.exercises;
+  const built = pool[row.piece]?.find((e) => e.id === row.id);
+  if (!built) return null;
+  if (built.optimalMoves !== row.optimal_moves) return null; // trust-but-verify
+  return { exercise: built, description: cat.descriptions[row.id] };
+}
+
+function tag(baseline: Record<PieceId, Exercise[]>): Record<PieceId, Entry[]> {
+  const out = emptyByPiece<Entry>();
+  for (const p of PIECES) {
+    out[p] = (baseline[p] ?? []).map((exercise, order) => ({ exercise, order }));
+  }
+  return out;
+}
+
+function finalize(rec: Record<PieceId, Entry[]>): Record<PieceId, Exercise[]> {
+  const out = emptyByPiece<Exercise>();
+  for (const p of PIECES) {
+    out[p] = [...rec[p]]
+      .sort(
+        (a, b) =>
+          a.order - b.order || a.exercise.id.localeCompare(b.exercise.id),
+      )
+      .map((e) => e.exercise);
+  }
+  return out;
+}
+
+export function mergeOverlay(
+  baseline: BaselineCatalog,
+  overlay: ContentOverlayRow[],
+): MergedCatalog {
+  const exercises = tag(baseline.exercises);
+  const labyrinths = tag(baseline.labyrinths);
+  const descriptions = { ...baseline.descriptions };
+  let applied = 0;
+
+  for (const row of overlay) {
+    try {
+      const list = (row.kind === "labyrinth" ? labyrinths : exercises)[
+        row.piece
+      ];
+      if (!list) continue; // unknown piece — defensive skip
+
+      if (row.disabled) {
+        const idx = list.findIndex((e) => e.exercise.id === row.id);
+        if (idx >= 0) list.splice(idx, 1);
+        delete descriptions[row.id];
+        applied++;
+        continue;
+      }
+
+      const built = buildOverlayRow(row);
+      if (!built) continue; // dropped (unsolvable / optimal_moves mismatch)
+
+      const entry: Entry = { exercise: built.exercise, order: row.order };
+      const idx = list.findIndex((e) => e.exercise.id === row.id);
+      if (idx >= 0) list[idx] = entry;
+      else list.push(entry);
+
+      // Overlay row is authoritative for its description: set it, or clear any
+      // stale baseline description when the edit carries no objective.
+      if (built.description) descriptions[row.id] = built.description;
+      else delete descriptions[row.id];
+      applied++;
+    } catch {
+      // A malformed (hand-edited) row is skipped; the rest of the overlay still
+      // applies and the merge never throws to the player.
+      continue;
+    }
+  }
+
+  return {
+    exercises: finalize(exercises),
+    labyrinths: finalize(labyrinths),
+    descriptions,
+    source: "baseline+overlay",
+    overlayCount: applied,
+  };
+}
+
+/** The compiled baseline catalog (the generated module). */
+export function getBaseline(): BaselineCatalog {
+  return {
+    exercises: GENERATED_EXERCISES,
+    labyrinths: GENERATED_LABYRINTHS,
+    descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
+  };
+}
+
+/** Resolve a promise to its value, or `null` on rejection or timeout. */
+function withTimeout<T>(p: PromiseLike<T>, ms: number): Promise<T | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(null);
+      },
+    );
+  });
+}
+
+/**
+ * Fetch overlay rows. Returns `null` (→ baseline-only fallback) when the client
+ * is unconfigured, the query errors, times out, or returns a non-array.
+ */
+async function fetchOverlayRows(): Promise<ContentOverlayRow[] | null> {
+  const client = getSupabaseServer();
+  if (!client) return null;
+  const res = await withTimeout(
+    client.from("content_overlay").select("*"),
+    OVERLAY_TIMEOUT_MS,
+  );
+  const row = res as { data?: unknown; error?: unknown } | null;
+  if (!row || row.error || !Array.isArray(row.data)) return null;
+  return row.data as ContentOverlayRow[];
+}
+
+/**
+ * Uncached loader: baseline ⊕ overlay, or baseline-only when the overlay is
+ * unavailable. Exported for tests; players read the cached `getMergedCatalog`.
+ */
+export async function loadMergedCatalog(): Promise<MergedCatalog> {
+  const baseline = getBaseline();
+  const rows = await fetchOverlayRows();
+  if (rows === null) {
+    return { ...baseline, source: "baseline-only", overlayCount: 0 };
+  }
+  return mergeOverlay(baseline, rows);
+}
+
+/**
+ * Cached, ready-to-serve catalog. The overlay is read ~once per cache rebuild
+ * (tagged "content"); the admin write route calls `revalidateTag("content")`
+ * on save, so players are served from cache with zero per-request DB hits.
+ */
+export const getMergedCatalog = unstable_cache(
+  loadMergedCatalog,
+  ["content-merged-catalog"],
+  { tags: [CONTENT_TAG] },
+);

--- a/apps/web/src/lib/content/overlay-types.ts
+++ b/apps/web/src/lib/content/overlay-types.ts
@@ -7,9 +7,26 @@
  * write side only (this contract + the migration + the admin write route); the
  * read path still serves the baseline. See docs/specs/db-backed-content.md.
  */
-import type { ExerciseTier, PieceId } from "@/lib/game/types";
+import type { Exercise, ExerciseTier, PieceId } from "@/lib/game/types";
 
 export type ContentKind = "exercise" | "labyrinth";
+
+/** The compiled baseline catalog shape (mirrors the generated module). Input to
+ *  the overlay merge; also the fallback when the overlay is unavailable. */
+export interface BaselineCatalog {
+  exercises: Record<PieceId, Exercise[]>;
+  labyrinths: Record<PieceId, Exercise[]>;
+  descriptions: Record<string, string>;
+}
+
+/** The merged, ready-to-serve catalog (same shape the generated module exports,
+ *  plus observability fields). Returned by getMergedCatalog(). */
+export interface MergedCatalog extends BaselineCatalog {
+  /** "baseline-only" when the overlay was unavailable/empty (fallback path). */
+  source: "baseline+overlay" | "baseline-only";
+  /** How many overlay rows were actually applied (post-validation). */
+  overlayCount: number;
+}
 
 /**
  * One overlay row = one puzzle delta. Mirrors the builder/import record shape


### PR DESCRIPTION
## db-backed-content — Phase 2a (merged catalog loader)

The first slice of Phase 2: the cached merge loader. **Pure + additive — NO
player consumer reads it yet** (the injection seam is 2b, hydration + flag is
2c), so there is zero behaviour change to the live read path.

### What's in it
- **Types** — `BaselineCatalog`, `MergedCatalog` (baseline shape + `source` +
  `overlayCount`).
- **`mergeOverlay(baseline, rows)`** (pure): append-new · replace-edit (overlay
  fields + order win) · remove-disabled · descriptions merged · sorted
  `(order,id)`. Each non-disabled row is **re-BFS-verified** via `buildCatalog`;
  rows that are unsolvable/malformed or whose stored `optimal_moves` disagrees
  are **dropped** (DB value never blindly trusted). A malformed row is skipped,
  never throws.
- **`getMergedCatalog`** — `unstable_cache` (tag `"content"`, revalidated by the
  write route) over `loadMergedCatalog`, which fetches the overlay with a 2s
  timeout and **falls back to baseline-only** on null client / error / timeout.

### Checks
- 11 tests (merge cases + fetch/fallback). `tsc` + eslint clean.
- content + game suites **742/742** (no regression — nothing consumes it yet).

### Next (separate PRs)
- **2b** — per-consumer injection seam (~8 files, default arg = baseline →
  flag-off byte-identical).
- **2c** — hydration contract (server boundary → `CatalogProvider`) + enable
  `CONTENT_OVERLAY_ENABLED`. Cache-bust integration test lands here.

Wolfcito 🐾 @akawolfcito
