### PR TITLE
feat(db-content): Phase 2b-1 — catalog injection seam (pure helpers)

### DIFF
--- a/apps/web/src/lib/game/__tests__/catalog-injection.test.ts
+++ b/apps/web/src/lib/game/__tests__/catalog-injection.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Catalog injection seam — db-backed-content Phase 2b-1.
+ *
+ * Proves the pure read-path helpers accept an injected catalog (default =
+ * baseline). With NO catalog arg every function behaves exactly as before
+ * (covered by the existing per-file suites + tsc); these tests assert the
+ * injected catalog is honored, so Phase 2c can thread the merged catalog.
+ */
+import { describe, expect, it } from "vitest";
+import type { Exercise, PieceId } from "@/lib/game/types";
+import {
+  getExercisePool,
+  getPieceMasteryStars,
+  getVisibleExercisesForToday,
+} from "@/lib/game/rotation";
+import { buildTrainingPath } from "@/lib/training/path";
+import { migrateStarsArrayToIdMap } from "@/lib/game/progress-adapter";
+import { deriveRewardTiles } from "@/lib/hub/derive-reward-tiles";
+
+function ex(id: string): Exercise {
+  return { id, startPos: { file: 0, rank: 0 }, targetPos: { file: 7, rank: 0 }, optimalMoves: 1, tier: "easy" };
+}
+
+function emptyCatalog(): Record<PieceId, Exercise[]> {
+  return { rook: [], bishop: [], knight: [], pawn: [], queen: [], king: [] };
+}
+
+const INJECTED: Record<PieceId, Exercise[]> = {
+  ...emptyCatalog(),
+  rook: [ex("inj-1"), ex("inj-2"), ex("inj-3")],
+};
+
+describe("rotation — injected catalog", () => {
+  it("getExercisePool reads the injected pool", () => {
+    expect(getExercisePool("rook", INJECTED).map((e) => e.id)).toEqual(["inj-1", "inj-2", "inj-3"]);
+  });
+
+  it("getPieceMasteryStars sums over the injected pool", () => {
+    expect(getPieceMasteryStars("rook", { "inj-1": 3, "inj-2": 2 }, INJECTED)).toBe(5);
+  });
+
+  it("getVisibleExercisesForToday selects from the injected pool", () => {
+    const ids = getVisibleExercisesForToday({
+      piece: "rook",
+      walletOrSessionSeed: "seed",
+      dateUtc: "2026-06-17",
+      catalog: INJECTED,
+    }).map((e) => e.id);
+    expect(ids.sort()).toEqual(["inj-1", "inj-2", "inj-3"]);
+  });
+});
+
+describe("training path — injected catalog", () => {
+  it("buildTrainingPath builds nodes from the injected exercises", () => {
+    const path = buildTrainingPath({
+      piece: "rook",
+      progress: { piece: "rook", currentId: null, stars: {} },
+      labyrinthBests: {},
+      badgeClaimed: false,
+      catalog: { exercises: INJECTED, labyrinths: emptyCatalog() },
+    });
+    const exerciseIds = path.filter((n) => n.kind === "exercise").map((n) => n.id);
+    expect(exerciseIds).toEqual(["inj-1", "inj-2", "inj-3"]);
+  });
+});
+
+describe("progress-adapter — injected catalog", () => {
+  it("migrateStarsArrayToIdMap maps by the injected pool order", () => {
+    expect(migrateStarsArrayToIdMap("rook", [3, 2, 1], INJECTED)).toEqual({
+      "inj-1": 3,
+      "inj-2": 2,
+      "inj-3": 1,
+    });
+  });
+});
+
+describe("derive-reward-tiles — injected catalog", () => {
+  it("gates on the injected pool (empty pool → locked)", () => {
+    const tiles = deriveRewardTiles({
+      badgesClaimed: {},
+      starsPerPiece: { rook: 99 },
+      catalog: { ...INJECTED, rook: [] }, // rook now empty → cannot be claimable
+    });
+    expect(tiles.find((t) => t.id === "rook")?.state).toBe("locked");
+  });
+});

--- a/apps/web/src/lib/game/progress-adapter.ts
+++ b/apps/web/src/lib/game/progress-adapter.ts
@@ -18,7 +18,11 @@
  */
 
 import { EXERCISES } from "@/lib/game/exercises";
-import { getPieceMasteryStars, type ExerciseStarsById } from "@/lib/game/rotation";
+import {
+  getPieceMasteryStars,
+  type ExerciseCatalog,
+  type ExerciseStarsById,
+} from "@/lib/game/rotation";
 import type { PieceId } from "@/lib/game/types";
 
 export type { ExerciseStarsById } from "@/lib/game/rotation";
@@ -43,8 +47,9 @@ function clampStars(value: unknown): number {
 export function migrateStarsArrayToIdMap(
   piece: PieceId,
   starsArray: readonly number[],
+  catalog: ExerciseCatalog = EXERCISES,
 ): ExerciseStarsById {
-  const pool = EXERCISES[piece];
+  const pool = catalog[piece];
   const out: ExerciseStarsById = {};
   for (let i = 0; i < pool.length; i += 1) {
     out[pool[i].id] = clampStars(starsArray[i]);
@@ -60,8 +65,9 @@ export function migrateStarsArrayToIdMap(
 export function starsIdMapToArray(
   piece: PieceId,
   starsById: ExerciseStarsById,
+  catalog: ExerciseCatalog = EXERCISES,
 ): number[] {
-  return EXERCISES[piece].map((ex) => clampStars(starsById[ex.id]));
+  return catalog[piece].map((ex) => clampStars(starsById[ex.id]));
 }
 
 /**
@@ -72,9 +78,10 @@ export function starsIdMapToArray(
 export function normalizeStarsById(
   piece: PieceId,
   starsById: ExerciseStarsById,
+  catalog: ExerciseCatalog = EXERCISES,
 ): ExerciseStarsById {
   const out: ExerciseStarsById = {};
-  for (const ex of EXERCISES[piece]) {
+  for (const ex of catalog[piece]) {
     out[ex.id] = clampStars(starsById[ex.id]);
   }
   return out;
@@ -104,8 +111,13 @@ export function setStarsForExercise(
 export function calculateTotalStarsFromIdMap(
   piece: PieceId,
   starsById: ExerciseStarsById,
+  catalog: ExerciseCatalog = EXERCISES,
 ): number {
-  return getPieceMasteryStars(piece, normalizeStarsById(piece, starsById));
+  return getPieceMasteryStars(
+    piece,
+    normalizeStarsById(piece, starsById, catalog),
+    catalog,
+  );
 }
 
 /** Across-pool mastery from a legacy positional stars array — the
@@ -117,6 +129,11 @@ export function calculateTotalStarsFromIdMap(
 export function calculatePoolMasteryFromArray(
   piece: PieceId,
   starsArray: readonly number[],
+  catalog: ExerciseCatalog = EXERCISES,
 ): number {
-  return getPieceMasteryStars(piece, migrateStarsArrayToIdMap(piece, starsArray));
+  return getPieceMasteryStars(
+    piece,
+    migrateStarsArrayToIdMap(piece, starsArray, catalog),
+    catalog,
+  );
 }

--- a/apps/web/src/lib/game/rotation.ts
+++ b/apps/web/src/lib/game/rotation.ts
@@ -32,16 +32,26 @@ export const CANONICAL_FIVE_COUNT = 5;
 /** Max exercises surfaced per piece per day. */
 export const DAILY_VISIBLE_LIMIT = 5;
 
+/** A by-piece catalog the read path can inject. Defaults to the baseline
+ *  `EXERCISES`; Phase 2c passes the merged (baseline ⊕ overlay) catalog. */
+export type ExerciseCatalog = Record<PieceId, Exercise[]>;
+
 /** Full pool for a piece. Returns a shallow copy so callers can never
  *  mutate the catalog array. */
-export function getExercisePool(piece: PieceId): Exercise[] {
-  return [...EXERCISES[piece]];
+export function getExercisePool(
+  piece: PieceId,
+  catalog: ExerciseCatalog = EXERCISES,
+): Exercise[] {
+  return [...catalog[piece]];
 }
 
 /** The canonical first-touch set: the first 5 exercises of the pool.
  *  (Caveat accepted: Knight/Pawn include one Medium among their first 5.) */
-export function getCanonicalFive(piece: PieceId): Exercise[] {
-  return EXERCISES[piece].slice(0, CANONICAL_FIVE_COUNT);
+export function getCanonicalFive(
+  piece: PieceId,
+  catalog: ExerciseCatalog = EXERCISES,
+): Exercise[] {
+  return catalog[piece].slice(0, CANONICAL_FIVE_COUNT);
 }
 
 /** Mastery = sum of best stars across the whole pool (each ≤3). Mirrors
@@ -50,9 +60,10 @@ export function getCanonicalFive(piece: PieceId): Exercise[] {
 export function getPieceMasteryStars(
   piece: PieceId,
   progress?: ExerciseStarsById,
+  catalog: ExerciseCatalog = EXERCISES,
 ): number {
   if (!progress) return 0;
-  return EXERCISES[piece].reduce((sum, ex) => {
+  return catalog[piece].reduce((sum, ex) => {
     const raw = progress[ex.id] ?? 0;
     const clamped = raw < 0 ? 0 : raw > 3 ? 3 : raw;
     return sum + clamped;
@@ -111,15 +122,17 @@ export function getVisibleExercisesForToday(opts: {
   dateUtc: string;
   progress?: ExerciseStarsById;
   limit?: number;
+  catalog?: ExerciseCatalog;
 }): Exercise[] {
   const { piece, walletOrSessionSeed, dateUtc, progress } = opts;
   const limit = opts.limit ?? DAILY_VISIBLE_LIMIT;
+  const catalog = opts.catalog ?? EXERCISES;
 
-  const mastery = getPieceMasteryStars(piece, progress);
+  const mastery = getPieceMasteryStars(piece, progress, catalog);
   const unlocked = new Set(getUnlockedTiers(mastery));
   const seed = buildRotationSeed({ piece, walletOrSessionSeed, dateUtc });
 
-  return EXERCISES[piece]
+  return catalog[piece]
     .filter((ex) => unlocked.has(ex.tier ?? "easy"))
     .map((ex) => ({
       ex,

--- a/apps/web/src/lib/hub/derive-reward-tiles.ts
+++ b/apps/web/src/lib/hub/derive-reward-tiles.ts
@@ -1,5 +1,6 @@
 import type { RewardTile } from "@/components/kingdom/reward-column";
 import { EXERCISES } from "@/lib/game/exercises";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
 import type { PieceId } from "@/lib/game/types";
 
 /** Narrative unlock order surfaced in the Hub reward column. Mirrors the
@@ -28,6 +29,9 @@ export type RewardDerivationInput = {
   /** Tap handler forwarded onto each tile. The container decides routing
    *  per `(piece, state)`. */
   onTileTap?: (piece: PieceId) => void;
+  /** Injected catalog (default = baseline EXERCISES) — gates the `hasExercises`
+   *  check so a live overlay addition can flip a "soon" piece on. */
+  catalog?: ExerciseCatalog;
 };
 
 const DEFAULT_THRESHOLD = 10;
@@ -51,6 +55,7 @@ export function deriveRewardTiles(input: RewardDerivationInput): RewardTile[] {
     starsPerPiece,
     threshold = DEFAULT_THRESHOLD,
     onTileTap,
+    catalog = EXERCISES,
   } = input;
 
   const tiles: RewardTile[] = [];
@@ -72,7 +77,7 @@ export function deriveRewardTiles(input: RewardDerivationInput): RewardTile[] {
       continue;
     }
 
-    const hasExercises = EXERCISES[piece].length > 0;
+    const hasExercises = catalog[piece].length > 0;
 
     let state: RewardTile["state"];
     if (!hasExercises) {

--- a/apps/web/src/lib/training/path.ts
+++ b/apps/web/src/lib/training/path.ts
@@ -7,13 +7,20 @@
  * the path comes out. TrainingNode is a view-model, never stored.
  * ----------------------------------------------------------------- */
 
-import type { PieceId, PieceProgress } from "@/lib/game/types";
+import type { Exercise, PieceId, PieceProgress } from "@/lib/game/types";
 import {
   BADGE_THRESHOLD,
   EXERCISES,
   LABYRINTHS,
   labyrinthStars,
 } from "@/lib/game/exercises";
+
+/** Injected catalog for the training path (default = baseline). Phase 2c
+ *  passes the merged (baseline ⊕ overlay) catalog. */
+export type TrainingCatalog = {
+  exercises: Record<PieceId, Exercise[]>;
+  labyrinths: Record<PieceId, Exercise[]>;
+};
 
 export type TrainingNodeKind = "exercise" | "labyrinth" | "badge" | "mastery";
 
@@ -48,6 +55,8 @@ export type TrainingPathInput = {
   /** On-chain claim state. Always false for guests — mastery stays
    *  gated behind the wallet claim by design (founder decision 2026-06-11). */
   badgeClaimed: boolean;
+  /** Injected catalog (default = baseline EXERCISES/LABYRINTHS). */
+  catalog?: TrainingCatalog;
 };
 
 export type PieceMastery = "none" | "badge" | "mastered";
@@ -58,6 +67,8 @@ export const LABYRINTH_UNLOCK_THRESHOLD = 6;
 
 export function buildTrainingPath(input: TrainingPathInput): TrainingNode[] {
   const { piece, progress, labyrinthBests, badgeClaimed } = input;
+  const exercisesCatalog = input.catalog?.exercises ?? EXERCISES;
+  const labyrinthsCatalog = input.catalog?.labyrinths ?? LABYRINTHS;
   // Across-pool exercise mastery: sum the best stars in the id-map. Sparse
   // map → unset ids contribute 0. Labyrinth stars never count here.
   const totalStars = Object.values(progress.stars).reduce(
@@ -68,7 +79,7 @@ export function buildTrainingPath(input: TrainingPathInput): TrainingNode[] {
   // Exercise nodes follow the authored catalog `order` (EXERCISES[piece] is
   // order-sorted at import time). Stars are read by exerciseId — immune to
   // catalog reordering.
-  const exerciseNodes: TrainingNode[] = EXERCISES[piece].map((exercise) => {
+  const exerciseNodes: TrainingNode[] = exercisesCatalog[piece].map((exercise) => {
     const stars = progress.stars[exercise.id] ?? 0;
     return {
       id: exercise.id,
@@ -83,7 +94,7 @@ export function buildTrainingPath(input: TrainingPathInput): TrainingNode[] {
   // The in-game sequence follows the authored catalog `order` (NOT
   // difficulty). LABYRINTHS[piece] is already sorted by (order, id) at
   // import time, so we consume it as-is — the author controls the order.
-  const orderedLabyrinths = LABYRINTHS[piece];
+  const orderedLabyrinths = labyrinthsCatalog[piece];
 
   const labyrinthNodes: TrainingNode[] = [];
   for (const [index, labyrinth] of orderedLabyrinths.entries()) {


### PR DESCRIPTION
First half of Phase 2b: optional injected catalog (default = baseline) in the pure read-path helpers (rotation, training/path, progress-adapter, derive-reward-tiles), so Phase 2c can thread the merged catalog. Flag-off byte-identical (defaults preserve behavior). 6 injection tests; game+training+hub 631/631; tsc + eslint clean. No consumer passes a custom catalog yet — that's 2b-2 (CatalogContext for hooks/components).

Wolfcito 🐾 @akawolfcito