### PR TITLE
feat(db-content): client catalog injection seam (Phase 2b-2)

### DIFF
--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -61,6 +61,7 @@ import {
   subscribeToShieldChanges,
 } from "@/lib/shop/shield-events";
 import { useExerciseProgress } from "@/hooks/use-exercise-progress";
+import { useExerciseCatalog } from "@/lib/content/catalog-context";
 import { useRotationSteering } from "@/hooks/use-rotation-steering";
 import { useSaveScoreState } from "@/hooks/use-save-score-state";
 import { ConnectPromptToast } from "@/components/connect-prompt/connect-prompt-toast";
@@ -124,7 +125,7 @@ import { Button } from "@/components/ui/button";
 import { track } from "@/lib/telemetry";
 import { classifyTxError, classifyTxErrorKind, isTransactionTimeout, isUserCancellation, type TxErrorKind } from "@/lib/errors";
 import { getContextAction, getRewardActions } from "@/lib/game/context-action";
-import { BADGE_THRESHOLD, EXERCISES, LABYRINTHS, labyrinthStars } from "@/lib/game/exercises";
+import { BADGE_THRESHOLD, LABYRINTHS, labyrinthStars } from "@/lib/game/exercises";
 import {
   areAllLabyrinthsSolved,
   getLabyrinthBest,
@@ -916,13 +917,19 @@ export function ExercisesScreen({
     incrementAttemptSeq,
   } = useExerciseProgress(selectedPiece, rotationOptions);
 
+  // Phase 2b-2: read the active pools from the catalog context (baseline
+  // EXERCISES when no provider is mounted → byte-identical flag-off), so
+  // this screen's pool reads agree with the hook's. Phase 2c mounts the
+  // provider with merged pools at the /exercises server boundary.
+  const catalog = useExerciseCatalog();
+
   // Progress is keyed by exerciseId (currentId). Derive the pool index for
   // the index-based affordances (drawer activeIndex, tutorial-hint gate,
   // badge-on-last-exercise math). A null/stale id falls back to the first
   // pool exercise (index 0), mirroring the hook's own derivation.
   const currentExerciseIndex = Math.max(
     0,
-    EXERCISES[selectedPiece].findIndex((ex) => ex.id === currentExercise.id),
+    catalog[selectedPiece].findIndex((ex) => ex.id === currentExercise.id),
   );
 
   // Rotation steering, extracted to a unit-tested hook in Slice 3B.
@@ -1351,7 +1358,7 @@ export function ExercisesScreen({
   const showTxToast = txToast.show && resultOverlay === null;
   const txCurrent = txToast.show ? txToast.current : "sign";
 
-  const allExercisesAttempted = EXERCISES[selectedPiece].every(
+  const allExercisesAttempted = catalog[selectedPiece].every(
     (ex) => (progress.stars[ex.id] ?? 0) > 0,
   );
 
@@ -2304,7 +2311,7 @@ export function ExercisesScreen({
    *  exit; the PieceComplete cascade owns what happens next. */
   function handleLabyrinthContinue() {
     handleExitLabyrinth();
-    const pool = EXERCISES[selectedPiece];
+    const pool = catalog[selectedPiece];
     // First pool slot with 0★ (id-map; absent id = not played) that is
     // also in today's visible set when rotation is on.
     const nextIdx = pool.findIndex(
@@ -2387,7 +2394,7 @@ export function ExercisesScreen({
 
   // Show movement lane hints on the first exercise of each piece (until the player earns stars)
   const tutorialHints = useMemo(() => {
-    const firstExerciseId = EXERCISES[selectedPiece][0]?.id;
+    const firstExerciseId = catalog[selectedPiece][0]?.id;
     if (
       currentExerciseIndex !== 0 ||
       (firstExerciseId ? (progress.stars[firstExerciseId] ?? 0) : 0) > 0
@@ -2395,7 +2402,7 @@ export function ExercisesScreen({
       return undefined;
     const targets = getValidTargets(selectedPiece, currentExercise.startPos);
     return new Set(targets.map(getPositionLabel));
-  }, [selectedPiece, currentExerciseIndex, progress.stars, currentExercise.startPos]);
+  }, [selectedPiece, currentExerciseIndex, progress.stars, currentExercise.startPos, catalog]);
 
   return (
     <div className="relative w-full overflow-x-hidden">
@@ -2669,7 +2676,7 @@ export function ExercisesScreen({
               open={exerciseDrawerOpen}
               onOpenChange={setExerciseDrawerOpen}
               piece={selectedPiece}
-              exercises={EXERCISES[selectedPiece]}
+              exercises={catalog[selectedPiece]}
               stars={progress.stars}
               activeIndex={currentExerciseIndex}
               totalStars={totalStars}

--- a/apps/web/src/hooks/__tests__/use-exercise-progress-catalog-injection.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-exercise-progress-catalog-injection.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * useExerciseProgress — catalog injection seam (db-content Phase 2b-2).
+ *
+ * The hook derives its active pool from `ExerciseCatalogContext` rather
+ * than the baseline `EXERCISES` import. With no provider the default is
+ * baseline (covered byte-identically by the other 7 test files); here we
+ * mount a provider with a single-exercise rook pool and prove the hook's
+ * pool-derived affordances (count → isLastExercise) follow the injected
+ * catalog, not the 15-exercise baseline.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/telemetry", () => ({ track: vi.fn() }));
+vi.mock("@/lib/peones/training-earn", () => ({
+  submitTrainingExerciseEarn: vi.fn().mockResolvedValue({
+    kind: "success",
+    credited: 0,
+    attestationHash: null,
+    ledgerId: null,
+    duplicate: false,
+  }),
+}));
+vi.mock("wagmi", () => ({
+  useAccount: vi.fn(() => ({ isConnected: false, address: undefined })),
+}));
+
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useExerciseProgress } from "@/hooks/use-exercise-progress";
+import { ExerciseCatalogProvider } from "@/lib/content/catalog-context";
+import { EXERCISES } from "@/lib/game/exercises";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("useExerciseProgress catalog injection", () => {
+  it("derives count/isLastExercise from the injected pool, not baseline", () => {
+    // Single-exercise rook pool: index 0 is the last exercise.
+    const injected: ExerciseCatalog = {
+      ...EXERCISES,
+      rook: [EXERCISES.rook[0]],
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ExerciseCatalogProvider value={injected}>
+        {children}
+      </ExerciseCatalogProvider>
+    );
+    const { result } = renderHook(() => useExerciseProgress("rook"), {
+      wrapper,
+    });
+    // Baseline rook has >1 exercises → isLastExercise would be false at
+    // index 0. With the injected single-exercise pool it must be true.
+    expect(result.current.currentExercise.id).toBe(EXERCISES.rook[0].id);
+    expect(result.current.isLastExercise).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/__tests__/use-rotation-steering.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-rotation-steering.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
 
 import { EXERCISES } from "@/lib/game/exercises";
+import { ExerciseCatalogProvider } from "@/lib/content/catalog-context";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
 import {
   useRotationSteering,
   type RotationSteeringOptions,
@@ -109,5 +112,28 @@ describe("useRotationSteering", () => {
     expect(goToExercise).not.toHaveBeenCalled();
     rerender(makeOptions({ suspended: false, goToExercise }));
     expect(goToExercise).toHaveBeenCalledWith(1);
+  });
+
+  // ── Phase 2b-2: catalog injection seam ──────────────────────────
+  // The steering index is resolved against the INJECTED pool, not the
+  // baseline import. Swapping the first two rook exercises moves
+  // ROOK_IDS[1] to pool index 0, so the steering target shifts from 1
+  // (baseline) to 0 — proving the hook reads the context catalog.
+  it("resolves the steering target against the injected catalog", () => {
+    const injected: ExerciseCatalog = {
+      ...EXERCISES,
+      rook: [EXERCISES.rook[1], EXERCISES.rook[0], ...EXERCISES.rook.slice(2)],
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ExerciseCatalogProvider value={injected}>
+        {children}
+      </ExerciseCatalogProvider>
+    );
+    const options = makeOptions({
+      visibleExerciseIds: new Set([ROOK_IDS[1]]),
+      currentExerciseId: ROOK_IDS[0],
+    });
+    renderHook(() => useRotationSteering(options), { wrapper });
+    expect(options.goToExercise).toHaveBeenCalledWith(0);
   });
 });

--- a/apps/web/src/hooks/use-exercise-progress.ts
+++ b/apps/web/src/hooks/use-exercise-progress.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
-import { BADGE_THRESHOLD, EXERCISES, getExerciseCount } from "@/lib/game/exercises";
+import { BADGE_THRESHOLD } from "@/lib/game/exercises";
+import { useExerciseCatalog } from "@/lib/content/catalog-context";
 import { computeStars } from "@/lib/game/scoring";
 import {
   calculateTotalStarsFromIdMap,
@@ -56,11 +57,11 @@ function clampStars(value: unknown): number {
  *  shape — readers use `?? 0`), and clamps the rest to [0,3]. Unknown ids
  *  are discarded. */
 function sanitizeStarsById(
-  piece: PieceId,
+  pool: Exercise[],
   raw: Record<string, unknown>,
 ): Record<string, number> {
   const out: Record<string, number> = {};
-  for (const ex of EXERCISES[piece]) {
+  for (const ex of pool) {
     const stars = clampStars(raw[ex.id]);
     if (stars > 0) out[ex.id] = stars;
   }
@@ -80,7 +81,7 @@ function sanitizeStarsById(
  *    is kept only if it still names a pool exercise, else null.
  *  - Anything missing/corrupt → empty progress.
  */
-function loadProgress(piece: PieceId): PieceProgress {
+function loadProgress(piece: PieceId, pool: Exercise[]): PieceProgress {
   if (typeof window === "undefined") {
     return emptyProgress(piece);
   }
@@ -96,7 +97,6 @@ function loadProgress(piece: PieceId): PieceProgress {
     if (Array.isArray(parsed.stars)) {
       const legacyStars = parsed.stars as unknown[];
       const stars: Record<string, number> = {};
-      const pool = EXERCISES[piece];
       for (let i = 0; i < pool.length; i += 1) {
         const value = clampStars(legacyStars[i]);
         if (value > 0) stars[pool[i].id] = value;
@@ -115,11 +115,11 @@ function loadProgress(piece: PieceId): PieceProgress {
       parsed.stars && typeof parsed.stars === "object"
         ? (parsed.stars as Record<string, unknown>)
         : {};
-    const stars = sanitizeStarsById(piece, starsObj);
+    const stars = sanitizeStarsById(pool, starsObj);
     const rawCurrentId =
       typeof parsed.currentId === "string" ? parsed.currentId : null;
     const currentId =
-      rawCurrentId && EXERCISES[piece].some((ex) => ex.id === rawCurrentId)
+      rawCurrentId && pool.some((ex) => ex.id === rawCurrentId)
         ? rawCurrentId
         : null;
     return { piece, currentId, stars };
@@ -144,6 +144,13 @@ export function useExerciseProgress(
    *  inside `completeExercise`. Guests skip the call entirely; their
    *  local progress + telemetry stay intact. */
   const { isConnected, address } = useAccount();
+
+  // Phase 2b-2: the active pool comes from the catalog context (baseline
+  // EXERCISES when no provider is mounted → byte-identical flag-off). The
+  // pure helpers (loadProgress, progress-adapter, visible-set) all accept
+  // it so every pool read in this hook resolves against the same catalog.
+  const catalog = useExerciseCatalog();
+  const pool = catalog[piece];
 
   // Inicializar siempre con defaults para que server y cliente rendericen igual
   // (evita hydration mismatch). localStorage se lee después del montaje.
@@ -200,26 +207,26 @@ export function useExerciseProgress(
   const lastResetExerciseIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    setProgress(loadProgress(piece));
+    setProgress(loadProgress(piece, pool));
     setHydrated(true);
-  }, [piece]);
+  }, [piece, pool]);
 
-  const count = getExerciseCount(piece);
+  const count = pool.length;
   // `currentId` (an exerciseId) drives navigation; derive the pool index
   // from it so the index-based affordances (telemetry slotIndex,
   // currentExercise, isLastExercise, nav guards) keep working. A null or
   // stale id resolves to the first pool exercise (index 0).
   const currentIdIndex = progress.currentId
-    ? EXERCISES[piece].findIndex((ex) => ex.id === progress.currentId)
+    ? pool.findIndex((ex) => ex.id === progress.currentId)
     : -1;
   const safeIndex = currentIdIndex >= 0 ? currentIdIndex : 0;
-  const currentExercise: Exercise = EXERCISES[piece][safeIndex];
+  const currentExercise: Exercise = pool[safeIndex];
   const isLastExercise = safeIndex === count - 1;
   // Badge mastery is the across-pool sum of best stars (each exercise
   // counts ≤3★ once; replays never double-count). The id-map mastery
   // helper makes the across-pool semantics explicit; sparse map → unset
   // ids contribute 0.
-  const total = calculateTotalStarsFromIdMap(piece, progress.stars);
+  const total = calculateTotalStarsFromIdMap(piece, progress.stars, catalog);
   const badgeEarned = total >= BADGE_THRESHOLD;
   const isReplay = (progress.stars[currentExercise.id] ?? 0) > 0;
 
@@ -240,13 +247,13 @@ export function useExerciseProgress(
   useEffect(() => {
     // `isGuestGraduated` + the rotation selector still consume the
     // positional stars array; bridge the id-map → array (catalog order).
-    const starsArray = starsIdMapToArray(piece, progress.stars);
+    const starsArray = starsIdMapToArray(piece, progress.stars, catalog);
     if (!rotationEnabled || address || !isGuestGraduated(starsArray)) {
       setGuestSessionSeed(null);
       return;
     }
     setGuestSessionSeed(getOrCreateGuestSessionId());
-  }, [rotationEnabled, address, piece, progress.stars]);
+  }, [rotationEnabled, address, piece, progress.stars, catalog]);
 
   // `rotation.sessionSeed` is a test override; real callers rely on the
   // derived guest seed above. A connected wallet still wins inside
@@ -254,16 +261,19 @@ export function useExerciseProgress(
   const effectiveSessionSeed = rotation?.sessionSeed ?? guestSessionSeed;
   const visibleExerciseIds = useMemo(
     () =>
-      computeVisibleExerciseIds({
-        piece,
-        enabled: rotationEnabled,
-        address: address ?? null,
-        sessionSeed: effectiveSessionSeed,
-        dateUtc: rotationDateUtc,
-        // The visible-set selector reads the native id-map directly.
-        starsById: progress.stars,
-      }),
-    [rotationEnabled, piece, address, effectiveSessionSeed, rotationDateUtc, progress.stars],
+      computeVisibleExerciseIds(
+        {
+          piece,
+          enabled: rotationEnabled,
+          address: address ?? null,
+          sessionSeed: effectiveSessionSeed,
+          dateUtc: rotationDateUtc,
+          // The visible-set selector reads the native id-map directly.
+          starsById: progress.stars,
+        },
+        catalog,
+      ),
+    [rotationEnabled, piece, address, effectiveSessionSeed, rotationDateUtc, progress.stars, catalog],
   );
   /** Mirror into a ref so `goToExercise` can read the current visible set
    *  without taking it as a dependency (keeps the callback identity
@@ -306,16 +316,16 @@ export function useExerciseProgress(
   const completeExercise = useCallback(
     (movesUsed: number) => {
       setProgress((prev) => {
-        const pieceCount = getExerciseCount(piece);
+        const pieceCount = pool.length;
         // Resolve the active exercise from currentId (fallback: first pool
         // exercise). `idx` is kept for telemetry slotIndex parity.
         const idx = prev.currentId
           ? Math.max(
               0,
-              EXERCISES[piece].findIndex((ex) => ex.id === prev.currentId),
+              pool.findIndex((ex) => ex.id === prev.currentId),
             )
           : 0;
-        const exercise = EXERCISES[piece][idx];
+        const exercise = pool[idx];
         const starsForAttempt = computeStars(movesUsed, exercise.optimalMoves);
         const bestStarsBefore = prev.stars[exercise.id] ?? 0;
         const bestStarsAfter = Math.max(
@@ -326,8 +336,8 @@ export function useExerciseProgress(
         const newStars: Record<string, number> = { ...prev.stars };
         if (bestStarsAfter > 0) newStars[exercise.id] = bestStarsAfter;
 
-        const prevTotal = calculateTotalStarsFromIdMap(piece, prev.stars);
-        const newTotal = calculateTotalStarsFromIdMap(piece, newStars);
+        const prevTotal = calculateTotalStarsFromIdMap(piece, prev.stars, catalog);
+        const newTotal = calculateTotalStarsFromIdMap(piece, newStars, catalog);
         const delta = newTotal - prevTotal;
         const wasReplay = bestStarsBefore > 0;
 
@@ -356,7 +366,7 @@ export function useExerciseProgress(
         }
 
         if (prevTotal < BADGE_THRESHOLD && newTotal >= BADGE_THRESHOLD) {
-          const exercisesCompleted = EXERCISES[piece].filter(
+          const exercisesCompleted = pool.filter(
             (ex) => (newStars[ex.id] ?? 0) > 0,
           ).length;
           track("training_piece_badge_threshold_reached", {
@@ -370,10 +380,10 @@ export function useExerciseProgress(
         // was 0 before this update. The second clause is what prevents
         // the event from re-firing on every replay after the senda
         // already closed.
-        const allDoneNow = EXERCISES[piece].every(
+        const allDoneNow = pool.every(
           (ex) => (newStars[ex.id] ?? 0) > 0,
         );
-        const hadZeroBefore = EXERCISES[piece].some(
+        const hadZeroBefore = pool.some(
           (ex) => (prev.stars[ex.id] ?? 0) === 0,
         );
         if (allDoneNow && hadZeroBefore) {
@@ -434,12 +444,11 @@ export function useExerciseProgress(
         return next;
       });
     },
-    [piece, isConnected, address]
+    [piece, isConnected, address, pool, catalog]
   );
 
   const advanceExercise = useCallback(() => {
     setProgress((prev) => {
-      const pool = EXERCISES[piece];
       const curIdx = prev.currentId
         ? pool.findIndex((ex) => ex.id === prev.currentId)
         : 0;
@@ -449,11 +458,10 @@ export function useExerciseProgress(
       saveProgress(next);
       return next;
     });
-  }, [piece]);
+  }, [pool]);
 
   const goToExercise = useCallback((index: number) => {
     setProgress((prev) => {
-      const pool = EXERCISES[piece];
       const clamped = Math.max(0, Math.min(index, pool.length - 1));
       const targetId = pool[clamped]?.id;
       if (!targetId) return prev;
@@ -477,7 +485,7 @@ export function useExerciseProgress(
       saveProgress(next);
       return next;
     });
-  }, [piece]);
+  }, [pool]);
 
   return {
     progress,

--- a/apps/web/src/hooks/use-rotation-steering.ts
+++ b/apps/web/src/hooks/use-rotation-steering.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { EXERCISES } from "@/lib/game/exercises";
+import { useExerciseCatalog } from "@/lib/content/catalog-context";
 import type { PieceId } from "@/lib/game/types";
 
 export type RotationSteeringOptions = {
@@ -47,12 +47,15 @@ export function useRotationSteering({
   goToExercise,
   suspended,
 }: RotationSteeringOptions): void {
+  // Phase 2b-2: read the active pool from the catalog context (baseline
+  // EXERCISES when no provider is mounted → byte-identical flag-off).
+  const catalog = useExerciseCatalog();
   useEffect(() => {
     if (suspended) return;
     if (!enabled || !visibleExerciseIds) return;
     if (visibleExerciseIds.size === 0) return;
     if (visibleExerciseIds.has(currentExerciseId)) return;
-    const pool = EXERCISES[piece];
+    const pool = catalog[piece];
     const firstIncomplete = pool.findIndex(
       (ex) => visibleExerciseIds.has(ex.id) && (stars[ex.id] ?? 0) === 0,
     );
@@ -69,5 +72,6 @@ export function useRotationSteering({
     piece,
     stars,
     goToExercise,
+    catalog,
   ]);
 }

--- a/apps/web/src/lib/content/__tests__/catalog-context.test.tsx
+++ b/apps/web/src/lib/content/__tests__/catalog-context.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * ExerciseCatalogContext — db-backed-content Phase 2b-2 (client seam).
+ *
+ * The context carries the by-piece exercise pools (`ExerciseCatalog`).
+ * Its default value is the compiled baseline `EXERCISES`, so any consumer
+ * rendered WITHOUT a provider behaves byte-identically to a direct
+ * `EXERCISES` import. Phase 2c mounts the provider with the merged
+ * (baseline ⊕ overlay) pools at the /exercises server boundary.
+ *
+ * Coverage:
+ *  - No provider → `useExerciseCatalog()` returns the baseline EXERCISES.
+ *  - With a provider → returns the injected catalog (proves the seam, not
+ *    just the default).
+ */
+
+import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  ExerciseCatalogProvider,
+  useExerciseCatalog,
+} from "@/lib/content/catalog-context";
+import { EXERCISES } from "@/lib/game/exercises";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
+
+describe("ExerciseCatalogContext", () => {
+  it("returns the baseline EXERCISES when no provider is mounted", () => {
+    const { result } = renderHook(() => useExerciseCatalog());
+    expect(result.current).toBe(EXERCISES);
+  });
+
+  it("returns the injected catalog when wrapped in a provider", () => {
+    const injected: ExerciseCatalog = {
+      ...EXERCISES,
+      rook: EXERCISES.rook.slice(0, 1),
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ExerciseCatalogProvider value={injected}>
+        {children}
+      </ExerciseCatalogProvider>
+    );
+    const { result } = renderHook(() => useExerciseCatalog(), { wrapper });
+    expect(result.current).toBe(injected);
+    expect(result.current.rook).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/content/catalog-context.tsx
+++ b/apps/web/src/lib/content/catalog-context.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * ExerciseCatalogContext — db-backed-content Phase 2b-2 (client seam).
+ *
+ * Carries the by-piece exercise pools (`ExerciseCatalog`) that the client
+ * surfaces read. The default value is the compiled baseline `EXERCISES`,
+ * so a consumer rendered WITHOUT a provider behaves byte-identically to a
+ * direct `EXERCISES` import — this is what keeps the flag-off read path
+ * unchanged in Phase 2b.
+ *
+ * Phase 2c mounts `<ExerciseCatalogProvider>` at the /exercises server
+ * boundary with the merged (baseline ⊕ overlay) pools, behind
+ * `CONTENT_OVERLAY_ENABLED`. Until then no provider is mounted and every
+ * consumer falls through to the baseline default.
+ *
+ * Note: unlike most context hooks here, `useExerciseCatalog` does NOT
+ * throw when consumed outside a provider — the baseline default is the
+ * intended fallback, not a misuse.
+ */
+
+import { createContext, useContext, type ReactNode } from "react";
+import { EXERCISES } from "@/lib/game/exercises";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
+
+const ExerciseCatalogContext = createContext<ExerciseCatalog>(EXERCISES);
+
+export function ExerciseCatalogProvider({
+  value,
+  children,
+}: {
+  value: ExerciseCatalog;
+  children: ReactNode;
+}) {
+  return (
+    <ExerciseCatalogContext.Provider value={value}>
+      {children}
+    </ExerciseCatalogContext.Provider>
+  );
+}
+
+/** Returns the active by-piece exercise pools. Baseline `EXERCISES` when
+ *  no provider is mounted (Phase 2b flag-off path). */
+export function useExerciseCatalog(): ExerciseCatalog {
+  return useContext(ExerciseCatalogContext);
+}

--- a/apps/web/src/lib/exercises/__tests__/visible-set.test.ts
+++ b/apps/web/src/lib/exercises/__tests__/visible-set.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { EXERCISES } from "@/lib/game/exercises";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
 import { computeVisibleExerciseIds } from "@/lib/exercises/visible-set";
 
 const DATE = "2026-06-08";
@@ -65,5 +66,27 @@ describe("computeVisibleExerciseIds", () => {
     expect(result).not.toBeNull();
     expect(result!.size).toBeLessThanOrEqual(5);
     expect(result!.size).toBeGreaterThan(0);
+  });
+
+  // ── Phase 2b-2: catalog injection seam ──────────────────────────
+  it("computes the visible set against the injected catalog", () => {
+    // Single-exercise rook pool → the guest canonical set holds exactly
+    // that one id, not the baseline first-five.
+    const injected: ExerciseCatalog = {
+      ...EXERCISES,
+      rook: [EXERCISES.rook[0]],
+    };
+    const result = computeVisibleExerciseIds(
+      {
+        piece: "rook",
+        enabled: true,
+        address: null,
+        sessionSeed: null,
+        dateUtc: DATE,
+        starsById: {},
+      },
+      injected,
+    );
+    expect([...result!]).toEqual([EXERCISES.rook[0].id]);
   });
 });

--- a/apps/web/src/lib/exercises/visible-set.ts
+++ b/apps/web/src/lib/exercises/visible-set.ts
@@ -13,40 +13,49 @@
 import {
   getCanonicalFive,
   getVisibleExercisesForToday,
+  type ExerciseCatalog,
   type ExerciseStarsById,
 } from "@/lib/game/rotation";
 import { normalizeStarsById } from "@/lib/game/progress-adapter";
+import { EXERCISES } from "@/lib/game/exercises";
 import type { PieceId } from "@/lib/game/types";
 
-export function computeVisibleExerciseIds(args: {
-  piece: PieceId;
-  /** Rotation flag. When false, returns null (legacy: no filtering). */
-  enabled: boolean;
-  /** Connected wallet address, or null for a guest. */
-  address: string | null;
-  /** Guest session seed (e.g. a session_uuid), or null. */
-  sessionSeed: string | null;
-  /** UTC date string "YYYY-MM-DD". */
-  dateUtc: string;
-  /** id-keyed stars map for the piece (sparse; absent id = not played). */
-  starsById: ExerciseStarsById;
-}): Set<string> | null {
+export function computeVisibleExerciseIds(
+  args: {
+    piece: PieceId;
+    /** Rotation flag. When false, returns null (legacy: no filtering). */
+    enabled: boolean;
+    /** Connected wallet address, or null for a guest. */
+    address: string | null;
+    /** Guest session seed (e.g. a session_uuid), or null. */
+    sessionSeed: string | null;
+    /** UTC date string "YYYY-MM-DD". */
+    dateUtc: string;
+    /** id-keyed stars map for the piece (sparse; absent id = not played). */
+    starsById: ExerciseStarsById;
+  },
+  /** Phase 2b-2: by-piece pools to read. Defaults to the baseline
+   *  `EXERCISES` so flag-off callers are byte-identical; the client
+   *  catalog context passes the merged pools when a provider is mounted. */
+  catalog: ExerciseCatalog = EXERCISES,
+): Set<string> | null {
   if (!args.enabled) return null;
 
   const seed = args.address ?? args.sessionSeed;
   // Guest with no wallet and no session seed yet → canonical first touch.
   if (!seed) {
-    return new Set(getCanonicalFive(args.piece).map((ex) => ex.id));
+    return new Set(getCanonicalFive(args.piece, catalog).map((ex) => ex.id));
   }
 
   // Normalize the sparse id-map to one clamped entry per pool exercise so
   // the rotation selector reads a complete, in-range progress map.
-  const progress = normalizeStarsById(args.piece, args.starsById);
+  const progress = normalizeStarsById(args.piece, args.starsById, catalog);
   const visible = getVisibleExercisesForToday({
     piece: args.piece,
     walletOrSessionSeed: seed,
     dateUtc: args.dateUtc,
     progress,
+    catalog,
   });
   return new Set(visible.map((ex) => ex.id));
 }


### PR DESCRIPTION
## db-backed-content — Phase 2b-2 (client injection seam)

The client half of the Phase 2b injection seam. Introduces a React context
carrying the by-piece exercise pools, defaulting to the compiled baseline
`EXERCISES`. **No provider is mounted yet** → every consumer falls through
to the baseline default, so the read path is byte-identical to today
(flag-off acceptance). Phase 2c mounts `<ExerciseCatalogProvider>` at the
`/exercises` server boundary with the merged (baseline ⊕ overlay) pools,
behind `CONTENT_OVERLAY_ENABLED`.

### Changes
- **`lib/content/catalog-context.tsx`** (new) — `ExerciseCatalogContext`
  (default `EXERCISES`), `<ExerciseCatalogProvider>`, `useExerciseCatalog()`.
  Does NOT throw when consumed outside a provider — the baseline default is
  the intended fallback.
- **`hooks/use-rotation-steering.ts`** — resolves the steering target index
  against the injected catalog.
- **`lib/exercises/visible-set.ts`** — `computeVisibleExerciseIds` gains an
  optional `catalog` arg (default baseline) threaded to `getCanonicalFive`,
  `normalizeStarsById`, `getVisibleExercisesForToday`. Closes the 2b-1 seam
  gap before the hook consumes it.
- **`hooks/use-exercise-progress.ts`** — derives its active pool + count
  from the context and threads the catalog into the pure helpers
  (`loadProgress`, `sanitizeStarsById`, progress-adapter totals,
  visible-set). `useCallback` deps gain the stable pool/catalog refs.
- **`components/exercises/exercises-screen.tsx`** — the 5 `EXERCISES[piece]`
  reads now read from the context; `LABYRINTHS` stays on the direct import
  (overlay labyrinths are out of 2b-2 scope).

### Verification
- New injection tests: catalog-context (2), use-rotation-steering (+1),
  visible-set (+1), use-exercise-progress (+1). The 8 existing
  use-exercise-progress test files stay green unchanged (byte-identical).
- Full suite **3890/3890**, `tsc --noEmit` clean, eslint clean.

### Not in scope (Phase 2c)
Mounting the provider at the server boundary, `CONTENT_OVERLAY_ENABLED`
flag, hydration contract, cache-bust test. Open Q before 2c enable: senda
re-open UX.

Wolfcito 🐾 @akawolfcito
