### PR TITLE
feat(db-content): mount catalog provider at /exercises boundary (Phase 2c)

### DIFF
--- a/apps/web/src/app/[locale]/exercises/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/exercises/__tests__/page.test.tsx
@@ -1,10 +1,29 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+
+// db-backed-content Phase 2c: the page mounts an ExerciseCatalogProvider with
+// the merged (baseline ⊕ overlay) pools ONLY when CONTENT_OVERLAY_ENABLED is
+// on. With the flag off it renders <ExercisesScreen /> directly — byte-identical
+// to the pre-2c behavior, and never calls getMergedCatalog (no DB hit).
+
+let overlayEnabled = false;
+const getMergedCatalog = vi.fn();
 
 vi.mock("@/components/exercises/exercises-screen", () => ({
-  ExercisesScreen: (props: unknown) => ({
-    type: "ExercisesScreen",
+  ExercisesScreen: (props: unknown) => ({ type: "ExercisesScreen", props }),
+}));
+vi.mock("@/lib/content/catalog-context", () => ({
+  ExerciseCatalogProvider: (props: unknown) => ({
+    type: "ExerciseCatalogProvider",
     props,
   }),
+}));
+vi.mock("@/lib/content/merged-catalog", () => ({
+  getMergedCatalog: () => getMergedCatalog(),
+}));
+vi.mock("@/lib/content/overlay-flag", () => ({
+  get CONTENT_OVERLAY_ENABLED() {
+    return overlayEnabled;
+  },
 }));
 
 import ExercisesPage from "../page";
@@ -14,32 +33,43 @@ type SearchParamsLike = {
 };
 
 type RenderedElement = {
-  type: { name?: string };
+  type: { name?: string } | string;
   props: Record<string, unknown>;
 };
 
-function renderPage(searchParams: SearchParamsLike): RenderedElement {
-  return ExercisesPage({ searchParams }) as unknown as RenderedElement;
+async function renderPage(
+  searchParams: SearchParamsLike,
+): Promise<RenderedElement> {
+  return (await ExercisesPage({ searchParams })) as unknown as RenderedElement;
 }
 
-describe("/exercises page (server)", () => {
-  it("renders <ExercisesScreen /> with no initialPiece when `piece` is missing", () => {
-    const el = renderPage({});
-    expect((el.type as unknown as { name: string }).name).toBe("ExercisesScreen");
+beforeEach(() => {
+  overlayEnabled = false;
+  getMergedCatalog.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("/exercises page (server) — flag OFF (baseline)", () => {
+  it("renders <ExercisesScreen /> with no initialPiece when `piece` is missing", async () => {
+    const el = await renderPage({});
+    expect((el.type as { name: string }).name).toBe("ExercisesScreen");
     expect(el.props.initialPiece).toBeUndefined();
   });
 
-  it("forwards a valid `?piece=` to initialPiece", () => {
-    const el = renderPage({ piece: "bishop" });
+  it("forwards a valid `?piece=` to initialPiece", async () => {
+    const el = await renderPage({ piece: "bishop" });
     expect(el.props).toMatchObject({ initialPiece: "bishop" });
   });
 
-  it("ignores an unknown `?piece=` (initialPiece undefined)", () => {
-    const el = renderPage({ piece: "dragon" });
+  it("ignores an unknown `?piece=` (initialPiece undefined)", async () => {
+    const el = await renderPage({ piece: "dragon" });
     expect(el.props.initialPiece).toBeUndefined();
   });
 
-  it("accepts pieces with defined exercises (rook, bishop, knight, pawn, queen, king)", () => {
+  it("accepts pieces with defined exercises (rook, bishop, knight, pawn, queen, king)", async () => {
     for (const piece of [
       "rook",
       "bishop",
@@ -48,13 +78,63 @@ describe("/exercises page (server)", () => {
       "queen",
       "king",
     ] as const) {
-      const el = renderPage({ piece });
+      const el = await renderPage({ piece });
       expect(el.props).toMatchObject({ initialPiece: piece });
     }
   });
 
-  it("array-shaped `?piece=` is flattened to first entry", () => {
-    const el = renderPage({ piece: ["knight", "pawn"] });
+  it("array-shaped `?piece=` is flattened to first entry", async () => {
+    const el = await renderPage({ piece: ["knight", "pawn"] });
     expect(el.props).toMatchObject({ initialPiece: "knight" });
+  });
+
+  it("does NOT mount a provider and never reads the merged catalog", async () => {
+    const el = await renderPage({ piece: "rook" });
+    expect((el.type as { name: string }).name).toBe("ExercisesScreen");
+    expect(getMergedCatalog).not.toHaveBeenCalled();
+  });
+});
+
+describe("/exercises page (server) — flag ON (overlay)", () => {
+  const mergedPools = {
+    exercises: {
+      rook: [{ id: "rook-overlay-1" }],
+      bishop: [{ id: "bishop-baseline" }],
+      knight: [],
+      pawn: [],
+      queen: [],
+      king: [],
+    },
+    labyrinths: {},
+    descriptions: {},
+    source: "baseline+overlay" as const,
+    overlayCount: 1,
+  };
+
+  beforeEach(() => {
+    overlayEnabled = true;
+    getMergedCatalog.mockResolvedValue(mergedPools);
+  });
+
+  it("mounts ExerciseCatalogProvider with the merged exercise pools", async () => {
+    const el = await renderPage({});
+    expect((el.type as { name: string }).name).toBe("ExerciseCatalogProvider");
+    expect(el.props.value).toBe(mergedPools.exercises);
+    expect(getMergedCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps <ExercisesScreen /> as the provider child", async () => {
+    const el = await renderPage({ piece: "rook" });
+    const child = el.props.children as RenderedElement;
+    expect((child.type as { name: string }).name).toBe("ExercisesScreen");
+    expect(child.props).toMatchObject({ initialPiece: "rook" });
+  });
+
+  it("validates `?piece=` against the MERGED pools, not the baseline", async () => {
+    // knight is empty in the merged pools → rejected even though the baseline
+    // has knight exercises.
+    const el = await renderPage({ piece: "knight" });
+    const child = el.props.children as RenderedElement;
+    expect(child.props.initialPiece).toBeUndefined();
   });
 });

--- a/apps/web/src/app/[locale]/exercises/page.tsx
+++ b/apps/web/src/app/[locale]/exercises/page.tsx
@@ -2,7 +2,11 @@ import {
   ExercisesScreen,
   type ExercisesInitialSheet,
 } from "@/components/exercises/exercises-screen";
+import { ExerciseCatalogProvider } from "@/lib/content/catalog-context";
+import { getMergedCatalog } from "@/lib/content/merged-catalog";
+import { CONTENT_OVERLAY_ENABLED } from "@/lib/content/overlay-flag";
 import { EXERCISES } from "@/lib/game/exercises";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
 import type { PieceId } from "@/lib/game/types";
 
 type SearchParams = {
@@ -24,8 +28,11 @@ const SUPPORTED_SHEETS = new Set<ExercisesInitialSheet>([
   "pro",
 ]);
 
-function pieceHasExercises(piece: string): piece is PieceId {
-  const exercises = (EXERCISES as Record<string, unknown[] | undefined>)[piece];
+function pieceHasExercises(
+  piece: string,
+  catalog: ExerciseCatalog,
+): piece is PieceId {
+  const exercises = (catalog as Record<string, unknown[] | undefined>)[piece];
   return Array.isArray(exercises) && exercises.length > 0;
 }
 
@@ -51,15 +58,42 @@ function parseInitialSheet(raw: string | undefined): ExercisesInitialSheet | und
  *
  * Server component on purpose: reading `searchParams` from props avoids
  * `useSearchParams()` + Suspense overhead.
+ *
+ * db-backed-content Phase 2c (the server boundary / hydration contract):
+ * when `CONTENT_OVERLAY_ENABLED` is on, this boundary is the single source
+ * of the catalog — it calls the cached `getMergedCatalog()` (baseline ⊕
+ * overlay, tagged `"content"`) and mounts `<ExerciseCatalogProvider>` with
+ * the merged exercise pools serialized into the client boundary, so SSR and
+ * the first client render read the SAME pools (no hydration mismatch, no
+ * client re-fetch). With the flag off no provider is mounted and every
+ * consumer falls through to the baseline `EXERCISES` default — byte-identical
+ * to the pre-2c read path, with zero DB hits.
  */
-export default function ExercisesPage({
+export default async function ExercisesPage({
   searchParams,
 }: {
   searchParams: SearchParams;
 }) {
+  const merged = CONTENT_OVERLAY_ENABLED ? await getMergedCatalog() : null;
+  // The piece-validity check must read the SAME pools the screen will render
+  // from, so an overlay-added piece is accepted (and an overlay-emptied piece
+  // rejected) under the flag — and baseline when the flag is off.
+  const catalog: ExerciseCatalog = merged ? merged.exercises : EXERCISES;
+
   const piece = firstParam(searchParams.piece);
-  const initialPiece = piece && pieceHasExercises(piece) ? piece : undefined;
+  const initialPiece =
+    piece && pieceHasExercises(piece, catalog) ? piece : undefined;
   const initialSheet = parseInitialSheet(firstParam(searchParams.sheet));
 
-  return <ExercisesScreen initialPiece={initialPiece} initialSheet={initialSheet} />;
+  const screen = (
+    <ExercisesScreen initialPiece={initialPiece} initialSheet={initialSheet} />
+  );
+
+  if (!merged) return screen;
+
+  return (
+    <ExerciseCatalogProvider value={merged.exercises}>
+      {screen}
+    </ExerciseCatalogProvider>
+  );
 }

--- a/apps/web/src/lib/content/overlay-flag.ts
+++ b/apps/web/src/lib/content/overlay-flag.ts
@@ -1,0 +1,17 @@
+/**
+ * db-backed-content — read-path rollout flag (Phase 2c, 2026-06-17).
+ *
+ * Default OFF so the player read path stays byte-identical to the compiled
+ * baseline: with the flag off the `/exercises` server boundary mounts NO
+ * `ExerciseCatalogProvider`, so every consumer falls through to the baseline
+ * `EXERCISES` default and never touches the DB.
+ *
+ * Turn on per environment with `CONTENT_OVERLAY_ENABLED=true`. Server-only on
+ * purpose (NOT `NEXT_PUBLIC_`): only the server component decides whether to
+ * call `getMergedCatalog()` and mount the provider; the client just consumes
+ * whatever pools it is handed. Single constant on purpose — easy to delete at
+ * cluster close once the overlay is the default. Do NOT build a flag framework
+ * around this.
+ */
+export const CONTENT_OVERLAY_ENABLED =
+  process.env.CONTENT_OVERLAY_ENABLED === "true";


### PR DESCRIPTION
## Phase 2c — mount + flag (db-backed-content)

Wires the merged (baseline ⊕ overlay) catalog into the player read path behind the **server-only `CONTENT_OVERLAY_ENABLED` flag (default OFF)**. Completes the seam that Phases 1/2a/2b-1/2b-2 plumbed.

### Changes
- **`lib/content/overlay-flag.ts`** (new): `CONTENT_OVERLAY_ENABLED` gate (no `NEXT_PUBLIC_` — only the server boundary reads it).
- **`/exercises/page.tsx`** → `async`:
  - Flag **ON**: `await getMergedCatalog()` (cached, tagged `"content"`) → mount `<ExerciseCatalogProvider value={merged.exercises}>` around `<ExercisesScreen>`; `pieceHasExercises` validates against the merged pools.
  - Flag **OFF**: render `<ExercisesScreen />` directly, no provider, **zero DB hits** → byte-identical to pre-2c.
- **Hydration contract** (red-team P0): merged pools serialized into the client boundary as the provider `value`, so SSR and first client render read the **same** catalog — no mismatch, no client re-fetch.
- `page.test.tsx`: flag OFF (baseline + no provider + no merged read) and flag ON (provider with merged pools, child screen, validation against merged pools) scenarios.

### Verification
- Suite **3894/3894** · `tsc --noEmit` clean · eslint clean.
- Cache-bust contract already proven across existing tests: `route.test.ts` revalidates `"content"` on write; `merged-catalog.test.ts` loader reflects fresh rows + baseline-only fallback.

### Out of 2c scope (follow-up)
- Descriptions + `LABYRINTHS` overlay injection — `ExerciseCatalogContext` carries exercise pools only (2b-2 decision).

### Before the Phase 3 flip (NOT in this PR)
- **Senda re-open UX** (spec §Open questions): overlay grows a completed pool → (a) keep completed + optional extra, or (b) re-open. Founder decision. Flag stays OFF so prod is unaffected.
- Migration `content_overlay` still **NOT applied to hosted**.

Wolfcito 🐾 @akawolfcito