### PR TITLE
feat(db-content): overlay-full — labyrinths + descriptions + builder publish

### DIFF
--- a/apps/web/src/app/[locale]/exercises/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/exercises/__tests__/page.test.tsx
@@ -12,8 +12,8 @@ vi.mock("@/components/exercises/exercises-screen", () => ({
   ExercisesScreen: (props: unknown) => ({ type: "ExercisesScreen", props }),
 }));
 vi.mock("@/lib/content/catalog-context", () => ({
-  ExerciseCatalogProvider: (props: unknown) => ({
-    type: "ExerciseCatalogProvider",
+  ContentCatalogProvider: (props: unknown) => ({
+    type: "ContentCatalogProvider",
     props,
   }),
 }));
@@ -116,10 +116,17 @@ describe("/exercises page (server) — flag ON (overlay)", () => {
     getMergedCatalog.mockResolvedValue(mergedPools);
   });
 
-  it("mounts ExerciseCatalogProvider with the merged exercise pools", async () => {
+  it("mounts ContentCatalogProvider with the full merged read catalog", async () => {
     const el = await renderPage({});
-    expect((el.type as { name: string }).name).toBe("ExerciseCatalogProvider");
-    expect(el.props.value).toBe(mergedPools.exercises);
+    expect((el.type as { name: string }).name).toBe("ContentCatalogProvider");
+    const value = el.props.value as {
+      exercises: unknown;
+      labyrinths: unknown;
+      descriptions: unknown;
+    };
+    expect(value.exercises).toBe(mergedPools.exercises);
+    expect(value.labyrinths).toBe(mergedPools.labyrinths);
+    expect(value.descriptions).toBe(mergedPools.descriptions);
     expect(getMergedCatalog).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/app/[locale]/exercises/page.tsx
+++ b/apps/web/src/app/[locale]/exercises/page.tsx
@@ -2,7 +2,7 @@ import {
   ExercisesScreen,
   type ExercisesInitialSheet,
 } from "@/components/exercises/exercises-screen";
-import { ExerciseCatalogProvider } from "@/lib/content/catalog-context";
+import { ContentCatalogProvider } from "@/lib/content/catalog-context";
 import { getMergedCatalog } from "@/lib/content/merged-catalog";
 import { CONTENT_OVERLAY_ENABLED } from "@/lib/content/overlay-flag";
 import { EXERCISES } from "@/lib/game/exercises";
@@ -59,15 +59,15 @@ function parseInitialSheet(raw: string | undefined): ExercisesInitialSheet | und
  * Server component on purpose: reading `searchParams` from props avoids
  * `useSearchParams()` + Suspense overhead.
  *
- * db-backed-content Phase 2c (the server boundary / hydration contract):
- * when `CONTENT_OVERLAY_ENABLED` is on, this boundary is the single source
- * of the catalog — it calls the cached `getMergedCatalog()` (baseline ⊕
- * overlay, tagged `"content"`) and mounts `<ExerciseCatalogProvider>` with
- * the merged exercise pools serialized into the client boundary, so SSR and
- * the first client render read the SAME pools (no hydration mismatch, no
- * client re-fetch). With the flag off no provider is mounted and every
- * consumer falls through to the baseline `EXERCISES` default — byte-identical
- * to the pre-2c read path, with zero DB hits.
+ * db-backed-content (server boundary / hydration contract): when
+ * `CONTENT_OVERLAY_ENABLED` is on, this boundary is the single source of the
+ * catalog — it calls the cached `getMergedCatalog()` (baseline ⊕ overlay,
+ * tagged `"content"`) and mounts `<ContentCatalogProvider>` with the full
+ * merged read catalog (exercises + labyrinths + descriptions) serialized into
+ * the client boundary, so SSR and the first client render read the SAME
+ * catalog (no hydration mismatch, no client re-fetch). With the flag off no
+ * provider is mounted and every consumer falls through to the baseline default
+ * — byte-identical to the pre-overlay read path, with zero DB hits.
  */
 export default async function ExercisesPage({
   searchParams,
@@ -92,8 +92,14 @@ export default async function ExercisesPage({
   if (!merged) return screen;
 
   return (
-    <ExerciseCatalogProvider value={merged.exercises}>
+    <ContentCatalogProvider
+      value={{
+        exercises: merged.exercises,
+        labyrinths: merged.labyrinths,
+        descriptions: merged.descriptions,
+      }}
+    >
       {screen}
-    </ExerciseCatalogProvider>
+    </ContentCatalogProvider>
   );
 }

--- a/apps/web/src/app/api/dev/labyrinth/route.ts
+++ b/apps/web/src/app/api/dev/labyrinth/route.ts
@@ -1,48 +1,22 @@
 import { NextResponse } from "next/server";
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { upsertRecord, type LabyrinthRecord } from "@/lib/labyrinth-builder/store";
-import { puzzleId } from "@/lib/game/fen-puzzle";
-import { parseCsv, buildCatalog, renderGeneratedModule } from "@/lib/content/catalog";
+import type { LabyrinthRecord } from "@/lib/labyrinth-builder/store";
+import type { ContentKind } from "@/lib/content/overlay-types";
+import {
+  readBaselineRecords,
+  writeBaselineRecord,
+  type KindedRecord,
+} from "@/lib/content/baseline-write";
 
 export const runtime = "nodejs";
-
-const ROOT = resolve(process.cwd());
-const LABS_PATH = resolve(ROOT, "content/labyrinths.json");
-const EXERCISES_PATH = resolve(ROOT, "content/exercises.json");
-const CSV_PATH = resolve(ROOT, "content/puzzles.csv");
-const GEN_PATH = resolve(ROOT, "src/lib/game/generated/puzzles.generated.ts");
-
-type PuzzleKind = "labyrinth" | "exercise";
-
-// Records carry an optional `kind` selecting the bucket they belong to. The
-// on-disk JSON files do NOT store `kind` (it is implied by the file), so we
-// strip it before persisting.
-type KindedRecord = LabyrinthRecord & { kind?: PuzzleKind };
-
-function readRecords(path: string): LabyrinthRecord[] {
-  return existsSync(path)
-    ? (JSON.parse(readFileSync(path, "utf8")) as LabyrinthRecord[])
-    : [];
-}
 
 export async function GET(req: Request) {
   if (process.env.NODE_ENV === "production") {
     return new NextResponse("Not found", { status: 404 });
   }
-  const url = new URL(req.url);
-  const filter = url.searchParams.get("kind");
-  const wantLabs = filter !== "exercise";
-  const wantExercises = filter !== "labyrinth";
-
-  const records: KindedRecord[] = [];
-  if (wantLabs) {
-    for (const r of readRecords(LABS_PATH)) records.push({ ...r, kind: "labyrinth" });
-  }
-  if (wantExercises) {
-    for (const r of readRecords(EXERCISES_PATH)) records.push({ ...r, kind: "exercise" });
-  }
-  return NextResponse.json({ ok: true, records });
+  const filter = new URL(req.url).searchParams.get("kind");
+  const kind: ContentKind | undefined =
+    filter === "exercise" || filter === "labyrinth" ? filter : undefined;
+  return NextResponse.json({ ok: true, records: readBaselineRecords(kind) });
 }
 
 export async function POST(req: Request) {
@@ -55,40 +29,15 @@ export async function POST(req: Request) {
   } catch {
     return NextResponse.json({ ok: false, errors: ["invalid JSON"] }, { status: 400 });
   }
-  // `kind` selects the bucket; default to "labyrinth" for back-compat. It is
-  // not persisted — the file the record lands in implies it.
-  const kind: PuzzleKind = body.kind === "exercise" ? "exercise" : "labyrinth";
+  // `kind` selects the bucket (default "labyrinth" for back-compat); it is not
+  // persisted — the file the record lands in implies it.
+  const kind: ContentKind = body.kind === "exercise" ? "exercise" : "labyrinth";
   const { kind: _kind, ...rec } = body;
-  // Auto-assign a stable, content-addressed id when none is supplied so the
-  // record can be overwritten on future saves (no duplicate "(no id)" rows).
-  // Uses the SAME scheme as the build, so the assigned id equals the
-  // generated id (keyed by the active kind).
-  if (!rec.id) {
-    rec.id = puzzleId(rec.piece, `${kind}|${rec.fen}|${rec.target}|${rec.mover ?? ""}`);
+
+  const result = writeBaselineRecord(kind, rec as LabyrinthRecord);
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, errors: result.errors }, { status: 400 });
   }
-
-  const targetPath = kind === "exercise" ? EXERCISES_PATH : LABS_PATH;
-  // Read-modify-write the active bucket; merge-by-id preserves any unknown
-  // fields on records we are not touching, and upsertRecord replaces the
-  // matching record wholesale (the caller is responsible for sending a
-  // complete record on edit, incl. exercise-only fields like tier/tags).
-  const targetRecs = readRecords(targetPath);
-  const nextTarget = upsertRecord(targetRecs, rec);
-
-  // The generated catalog is built from BOTH buckets (+ the CSV), so we must
-  // re-read the other bucket as-is and feed both to buildCatalog.
-  const labs = kind === "exercise" ? readRecords(LABS_PATH) : nextTarget;
-  const exercises = kind === "exercise" ? nextTarget : readRecords(EXERCISES_PATH);
-
-  const csvRows = existsSync(CSV_PATH)
-    ? parseCsv(readFileSync(CSV_PATH, "utf8"))
-    : [["kind", "piece", "fen", "target", "mover", "tier", "tags", "explanation", "id"]];
-  const cat = buildCatalog(csvRows, labs, exercises);
-  if (cat.errors.length) {
-    return NextResponse.json({ ok: false, errors: cat.errors }, { status: 400 });
-  }
-  mkdirSync(dirname(GEN_PATH), { recursive: true });
-  writeFileSync(targetPath, JSON.stringify(nextTarget, null, 2) + "\n");
-  writeFileSync(GEN_PATH, renderGeneratedModule(cat));
-  return NextResponse.json({ ok: true, saved: rec, warnings: cat.warnings });
+  // `rec` was mutated in place to carry the resolved id.
+  return NextResponse.json({ ok: true, saved: rec, warnings: result.warnings });
 }

--- a/apps/web/src/app/api/dev/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/dev/publish/__tests__/route.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock node:fs so writeBaselineRecord never touches the real filesystem.
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+vi.mock("node:fs", () => ({ ...fsMocks, default: fsMocks }));
+
+import { POST } from "../route";
+
+const SOLVABLE_EXERCISE = {
+  piece: "rook",
+  fen: "8/8/8/8/8/8/8/R7 w - - 0 1",
+  target: "h1",
+  mover: "a1",
+  tier: "easy",
+  order: 1,
+  id: "rook-pub",
+};
+
+// Boxed rook → unsolvable.
+const UNSOLVABLE = {
+  piece: "rook",
+  fen: "8/8/8/8/8/1R6/RRR5/1R6 w - - 0 1",
+  target: "a8",
+  mover: "b2",
+  order: 1,
+  id: "rook-boxed",
+};
+
+function req(body: unknown): Request {
+  return new Request("http://x/api/dev/publish", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fsMocks.readFileSync.mockReset();
+  fsMocks.writeFileSync.mockReset();
+  fsMocks.existsSync.mockReset();
+  fsMocks.mkdirSync.mockReset();
+  fsMocks.existsSync.mockReturnValue(false);
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubEnv("NODE_ENV", "development");
+  vi.stubEnv("ADMIN_TOKEN", "secret-token");
+  vi.stubEnv("OVERLAY_PUBLISH_BASE_URL", "https://preview.chesscito.com/");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/dev/publish", () => {
+  it("404s in production and never writes or fetches", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const res = await POST(req({ kind: "exercise", record: SOLVABLE_EXERCISE }));
+    expect(res.status).toBe(404);
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("dual-writes: baseline + overlay publish, normalizing the base URL", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, revalidated: true }),
+    });
+    const res = await POST(req({ kind: "exercise", record: SOLVABLE_EXERCISE }));
+    const body = (await res.json()) as {
+      ok: boolean;
+      baseline: { ok: boolean; id?: string };
+      overlay: { ok: boolean; revalidated?: boolean };
+    };
+    expect(body.baseline.ok).toBe(true);
+    expect(body.baseline.id).toBe("rook-pub");
+    expect(body.overlay.ok).toBe(true);
+    expect(body.overlay.revalidated).toBe(true);
+    expect(body.ok).toBe(true);
+    // Trailing slash normalized, correct path + token header.
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://preview.chesscito.com/api/admin/content");
+    expect((init.headers as Record<string, string>)["x-admin-token"]).toBe("secret-token");
+  });
+
+  it("baseline succeeds but overlay is skipped when the target is not configured", async () => {
+    vi.stubEnv("OVERLAY_PUBLISH_BASE_URL", "");
+    const res = await POST(req({ kind: "exercise", record: SOLVABLE_EXERCISE }));
+    const body = (await res.json()) as {
+      ok: boolean;
+      baseline: { ok: boolean };
+      overlay: { ok: boolean; errors: string[] };
+    };
+    expect(body.baseline.ok).toBe(true);
+    expect(body.overlay.ok).toBe(false);
+    expect(body.overlay.errors.join(" ")).toMatch(/not configured/i);
+    expect(body.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails the baseline write on an unsolvable record and never attempts overlay", async () => {
+    const res = await POST(req({ kind: "labyrinth", record: UNSOLVABLE }));
+    const body = (await res.json()) as {
+      ok: boolean;
+      baseline: { ok: boolean; errors: string[] };
+      overlay: { ok: boolean };
+    };
+    expect(res.status).toBe(400);
+    expect(body.baseline.ok).toBe(false);
+    expect(body.baseline.errors.some((e) => e.includes("unsolvable"))).toBe(true);
+    expect(body.overlay.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes overlay failures (no raw upstream body / secrets leaked)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        ok: false,
+        errors: ["postgresql://user:pa55w0rd@db.internal:5432 connection refused"],
+      }),
+    });
+    const res = await POST(req({ kind: "exercise", record: SOLVABLE_EXERCISE }));
+    const body = (await res.json()) as { overlay: { ok: boolean; errors: string[] } };
+    expect(body.overlay.ok).toBe(false);
+    const joined = body.overlay.errors.join(" ");
+    expect(joined).not.toContain("pa55w0rd");
+    expect(joined).not.toContain("db.internal");
+    expect(joined).toMatch(/500/);
+  });
+
+  it("never echoes the admin token back to the client", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, revalidated: true }),
+    });
+    const res = await POST(req({ kind: "exercise", record: SOLVABLE_EXERCISE }));
+    const raw = await res.text();
+    expect(raw).not.toContain("secret-token");
+  });
+});

--- a/apps/web/src/app/api/dev/publish/route.ts
+++ b/apps/web/src/app/api/dev/publish/route.ts
@@ -1,0 +1,136 @@
+/**
+ * POST /api/dev/publish — db-content overlay-full (Stage 6).
+ *
+ * Dev-only "todo en 1" publish: writes the baseline `content/*.json` (so the
+ * puzzle is versioned in git) AND publishes it to the live overlay (so it is
+ * live without a redeploy), in one action. The ADMIN_TOKEN is read server-side
+ * and forwarded to the overlay write route — it NEVER reaches the browser.
+ *
+ * Fail-closed + partial-failure aware:
+ *  - 404 in production (NODE_ENV guard) — same as /api/dev/labyrinth.
+ *  - Baseline write first (local, reliable). If it fails (e.g. unsolvable),
+ *    NOTHING is published and the overlay step is skipped.
+ *  - Overlay second (network). A baseline success + overlay failure is a
+ *    PARTIAL result, not fatal — the founder can retry publish or commit json.
+ *  - Overlay errors are sanitized (curated by status) — the raw upstream body
+ *    (which may carry DB connection strings) and the token are never echoed.
+ */
+import { NextResponse } from "next/server";
+import type { LabyrinthRecord } from "@/lib/labyrinth-builder/store";
+import type { ContentKind } from "@/lib/content/overlay-types";
+import { writeBaselineRecord } from "@/lib/content/baseline-write";
+
+export const runtime = "nodejs";
+
+type PublishBody = { kind?: ContentKind; record?: LabyrinthRecord };
+
+type OverlayResult = { ok: boolean; revalidated?: boolean; errors: string[] };
+
+/** Curated, leak-free message per upstream status. We never echo the raw
+ *  admin-route body (it may include DB error detail) or the token. */
+function overlayErrorForStatus(status: number): string {
+  switch (status) {
+    case 403:
+      return "overlay publish rejected: admin token rejected (403)";
+    case 429:
+      return "overlay publish rejected: rate limited (429)";
+    case 400:
+      return "overlay publish rejected: record rejected by validation (400)";
+    case 503:
+      return "overlay publish unavailable: store or admin writes disabled (503)";
+    case 500:
+      return "overlay publish failed: server error (500)";
+    default:
+      return `overlay publish failed: HTTP ${status}`;
+  }
+}
+
+async function publishToOverlay(
+  kind: ContentKind,
+  record: LabyrinthRecord,
+): Promise<OverlayResult> {
+  const token = process.env.ADMIN_TOKEN;
+  const base = process.env.OVERLAY_PUBLISH_BASE_URL?.replace(/\/+$/, "");
+  if (!token || !base) {
+    return { ok: false, errors: ["overlay target not configured (set OVERLAY_PUBLISH_BASE_URL + ADMIN_TOKEN)"] };
+  }
+  try {
+    const res = await fetch(`${base}/api/admin/content`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-admin-token": token },
+      body: JSON.stringify({ kind, record }),
+    });
+    if (!res.ok) return { ok: false, errors: [overlayErrorForStatus(res.status)] };
+    const data = (await res.json().catch(() => null)) as
+      | { ok?: boolean; revalidated?: boolean }
+      | null;
+    if (!data?.ok) return { ok: false, errors: [overlayErrorForStatus(res.status)] };
+    return { ok: true, revalidated: Boolean(data.revalidated), errors: [] };
+  } catch {
+    // Network/abort — never surface the underlying error object.
+    return { ok: false, errors: ["overlay publish failed: network error reaching the target"] };
+  }
+}
+
+export async function POST(req: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  let body: PublishBody;
+  try {
+    body = (await req.json()) as PublishBody;
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        baseline: { ok: false, errors: ["invalid JSON"] },
+        overlay: { ok: false, errors: ["skipped: invalid request"] },
+      },
+      { status: 400 },
+    );
+  }
+
+  const kind: ContentKind = body.kind === "exercise" ? "exercise" : "labyrinth";
+  const record = body.record;
+  if (!record || typeof record !== "object") {
+    return NextResponse.json(
+      {
+        ok: false,
+        baseline: { ok: false, errors: ["missing record"] },
+        overlay: { ok: false, errors: ["skipped: no record"] },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Step 1 — baseline (local, reliable). On failure, do NOT publish.
+  const baseline = writeBaselineRecord(kind, record);
+  if (!baseline.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        baseline: { ok: false, errors: baseline.errors },
+        overlay: { ok: false, errors: ["skipped: baseline write failed"] },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Step 2 — overlay (network). `record` now carries the resolved id.
+  const overlay = await publishToOverlay(kind, { ...record, id: baseline.id });
+
+  // Audit — never log the token.
+  console.info("[dev/publish]", {
+    id: baseline.id,
+    kind,
+    baseline: baseline.ok,
+    overlay: overlay.ok,
+  });
+
+  return NextResponse.json({
+    ok: overlay.ok,
+    baseline: { ok: true, id: baseline.id, warnings: baseline.warnings },
+    overlay,
+  });
+}

--- a/apps/web/src/app/dev/labyrinth-builder/page.tsx
+++ b/apps/web/src/app/dev/labyrinth-builder/page.tsx
@@ -10,6 +10,10 @@ import {
 import type { LabyrinthRecord } from "@/lib/labyrinth-builder/store";
 import { validateBuilder } from "@/lib/labyrinth-builder/validate";
 import {
+  formatPublishResult,
+  type PublishResultLike,
+} from "@/lib/labyrinth-builder/publish-toast";
+import {
   parseFenBoard,
   posToSquare,
   squareToPos,
@@ -203,9 +207,13 @@ export default function LabyrinthBuilderPage() {
   const [moverInput, setMoverInput] = useState("");
   const [loadNote, setLoadNote] = useState<string | null>(null);
   const [records, setRecords] = useState<LabyrinthRecord[]>([]);
-  const [toast, setToast] = useState<{ kind: "ok" | "err"; text: string } | null>(
-    null,
-  );
+  const [toast, setToast] = useState<{
+    kind: "ok" | "warn" | "err";
+    text: string;
+  } | null>(null);
+  /** Debounce: block re-entrant Save while a publish round-trip is in flight
+   *  (a double-click would otherwise race two read-modify-write passes). */
+  const [isSaving, setIsSaving] = useState(false);
 
   const refreshRecords = useCallback(async () => {
     try {
@@ -372,37 +380,38 @@ export default function LabyrinthBuilderPage() {
   }
 
   async function handleSave() {
-    if (!result.ok || !fenBlock) return;
+    if (!result.ok || !fenBlock || isSaving) return;
+    setIsSaving(true);
     try {
-      const res = await fetch("/api/dev/labyrinth", {
+      // "Todo en 1": the publish proxy writes the baseline content/*.json AND
+      // publishes to the live overlay in one call (the ADMIN_TOKEN stays
+      // server-side). It returns a partial-aware { ok, baseline, overlay }.
+      const res = await fetch("/api/dev/publish", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          // Preserved exercise-only / unknown fields (tier, tags, …) first, so
-          // an edit never drops them; explicit fields below win on conflict.
-          ...editExtras,
           kind,
-          id: state.id || undefined,
-          piece: state.piece,
-          ...fenBlock,
-          explanation: state.explanation || undefined,
-          tier: state.tier || undefined,
-          tags: state.tags && state.tags.length ? state.tags : undefined,
-          order: state.order,
+          record: {
+            // Preserved exercise-only / unknown fields (tier, tags, …) first,
+            // so an edit never drops them; explicit fields below win.
+            ...editExtras,
+            id: state.id || undefined,
+            piece: state.piece,
+            ...fenBlock,
+            explanation: state.explanation || undefined,
+            tier: state.tier || undefined,
+            tags: state.tags && state.tags.length ? state.tags : undefined,
+            order: state.order,
+          },
         }),
       });
-      const data = await res.json();
-      if (data?.ok) {
-        setToast({ kind: "ok", text: "Saved — reload /exercises to see it" });
-        void refreshRecords();
-      } else {
-        const errs = Array.isArray(data?.errors)
-          ? data.errors.join("; ")
-          : "Save failed";
-        setToast({ kind: "err", text: errs });
-      }
+      const data = (await res.json()) as PublishResultLike;
+      setToast(formatPublishResult(data));
+      if (data?.baseline?.ok) void refreshRecords();
     } catch (e) {
       setToast({ kind: "err", text: (e as Error).message });
+    } finally {
+      setIsSaving(false);
     }
   }
 
@@ -412,24 +421,29 @@ export default function LabyrinthBuilderPage() {
   // the list row directly so it never disturbs the current edit.
   async function handleToggleDisabled(rec: LabyrinthRecord) {
     try {
-      const res = await fetch("/api/dev/labyrinth", {
+      // Toggle through the publish proxy so the enable/disable also propagates
+      // live (baseline + overlay), same "todo en 1" path as Save.
+      const res = await fetch("/api/dev/publish", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ...rec, kind, disabled: !rec.disabled }),
+        body: JSON.stringify({ kind, record: { ...rec, disabled: !rec.disabled } }),
       });
-      const data = await res.json();
-      if (data?.ok) {
-        setToast({
-          kind: "ok",
-          text: `${rec.id ?? "record"} ${rec.disabled ? "enabled" : "disabled"}`,
-        });
-        void refreshRecords();
-      } else {
-        const errs = Array.isArray(data?.errors)
-          ? data.errors.join("; ")
-          : "Toggle failed";
-        setToast({ kind: "err", text: errs });
+      const data = (await res.json()) as PublishResultLike;
+      if (!data?.baseline?.ok) {
+        setToast(formatPublishResult(data));
+        return;
       }
+      const verb = rec.disabled ? "enabled" : "disabled";
+      const id = rec.id ?? "record";
+      setToast(
+        data.overlay?.ok
+          ? { kind: "ok", text: `${id} ${verb} (live). Remember to commit content/*.json.` }
+          : {
+              kind: "warn",
+              text: `${id} ${verb} in baseline; live update failed: ${(data.overlay?.errors ?? ["unknown"]).join("; ")}. Remember to commit content/*.json.`,
+            },
+      );
+      void refreshRecords();
     } catch (e) {
       setToast({ kind: "err", text: (e as Error).message });
     }
@@ -670,15 +684,19 @@ export default function LabyrinthBuilderPage() {
             <button
               type="button"
               onClick={handleSave}
-              disabled={!result.ok}
+              disabled={!result.ok || isSaving}
               className="rounded bg-emerald-600 px-4 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-500"
             >
-              Save
+              {isSaving ? "Publishing…" : "Save"}
             </button>
             {toast && (
               <span
                 className={
-                  toast.kind === "ok" ? "text-emerald-400" : "text-red-400"
+                  toast.kind === "ok"
+                    ? "text-emerald-400"
+                    : toast.kind === "warn"
+                      ? "text-amber-400"
+                      : "text-red-400"
                 }
               >
                 {toast.text}

--- a/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { fireEvent } from "@testing-library/react";
 import { renderWithIntl as render, screen } from "@/test-utils/render-with-intl";
 import { ExerciseDrawer } from "../exercise-drawer";
-import { EXERCISES } from "@/lib/game/exercises";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
+import { ContentCatalogProvider } from "@/lib/content/catalog-context";
 import { buildTrainingPath } from "@/lib/training/path";
 
 /** Build an id-keyed best-stars map from a positional star count per pool
@@ -219,5 +221,33 @@ describe("ExerciseDrawer — labyrinth nodes (Slice 3D)", () => {
     expect(labAt).toBeGreaterThan(-1);
     expect(thirdExerciseAt).toBeGreaterThan(-1);
     expect(labAt).toBeLessThan(thirdExerciseAt);
+  });
+});
+
+describe("ExerciseDrawer — overlay descriptions (db-content)", () => {
+  it("renders an overlay description from ContentCatalogProvider over the baseline text", () => {
+    // rook-1 resolves to "Horizontal move" from the baseline generated map.
+    // An overlay description for rook-1 must win when the drawer threads the
+    // injected descriptions map from context.
+    const overlay = {
+      exercises: EXERCISES,
+      labyrinths: LABYRINTHS,
+      descriptions: {
+        ...GENERATED_EXERCISE_DESCRIPTIONS,
+        "rook-1": "Overlay rook description",
+      },
+    };
+    render(
+      <ContentCatalogProvider value={overlay}>
+        <ExerciseDrawer {...baseProps} onNavigate={vi.fn()} />
+      </ContentCatalogProvider>,
+    );
+    expect(screen.getByText("Overlay rook description")).toBeInTheDocument();
+    expect(screen.queryByText("Horizontal move")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the baseline description with no provider", () => {
+    render(<ExerciseDrawer {...baseProps} onNavigate={vi.fn()} />);
+    expect(screen.getByText("Horizontal move")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/exercises/exercise-drawer.tsx
+++ b/apps/web/src/components/exercises/exercise-drawer.tsx
@@ -11,6 +11,7 @@ import { ContextualHeader } from "@/components/ui/contextual-header";
 import { TileIconSlot } from "@/components/ui/tile-icon-slot";
 import type { Exercise, PieceId, PieceProgress } from "@/lib/game/types";
 import { BADGE_THRESHOLD, resolveExerciseDescription } from "@/lib/game/exercises";
+import { useExerciseDescriptions } from "@/lib/content/catalog-context";
 import { PIECE_IMAGES } from "@/lib/content/editorial";
 import {
   interleaveTrainingRows,
@@ -86,6 +87,9 @@ export function ExerciseDrawer({
   const tPiece = useTranslations("PIECE_LABELS");
   const tPath = useTranslations("TRAINING_PATH_COPY");
   const descriptions = useTranslations("EXERCISE_DESCRIPTIONS");
+  // Overlay-aware descriptions map (baseline default with no provider). An
+  // overlay-edited `explanation` overrides the baseline generated text.
+  const overlayDescriptions = useExerciseDescriptions();
   const maxStars = exercises.length * 3;
   // Stars are an id-map (sparse; absent id = not played → 0). The senda
   // lock is positional, so resolve each pool slot's best by exercise id.
@@ -312,6 +316,7 @@ export function ExerciseDrawer({
               // missing-message console warning.
               (eid) => (descriptions.has(eid) ? descriptions(eid) : null),
               (n) => t("exerciseFallbackFormat", { n }),
+              overlayDescriptions,
             );
 
             return (

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -61,7 +61,7 @@ import {
   subscribeToShieldChanges,
 } from "@/lib/shop/shield-events";
 import { useExerciseProgress } from "@/hooks/use-exercise-progress";
-import { useExerciseCatalog } from "@/lib/content/catalog-context";
+import { useExerciseCatalog, useLabyrinthCatalog } from "@/lib/content/catalog-context";
 import { useRotationSteering } from "@/hooks/use-rotation-steering";
 import { useSaveScoreState } from "@/hooks/use-save-score-state";
 import { ConnectPromptToast } from "@/components/connect-prompt/connect-prompt-toast";
@@ -125,7 +125,7 @@ import { Button } from "@/components/ui/button";
 import { track } from "@/lib/telemetry";
 import { classifyTxError, classifyTxErrorKind, isTransactionTimeout, isUserCancellation, type TxErrorKind } from "@/lib/errors";
 import { getContextAction, getRewardActions } from "@/lib/game/context-action";
-import { BADGE_THRESHOLD, LABYRINTHS, labyrinthStars } from "@/lib/game/exercises";
+import { BADGE_THRESHOLD, labyrinthStars } from "@/lib/game/exercises";
 import {
   areAllLabyrinthsSolved,
   getLabyrinthBest,
@@ -922,6 +922,10 @@ export function ExercisesScreen({
   // this screen's pool reads agree with the hook's. Phase 2c mounts the
   // provider with merged pools at the /exercises server boundary.
   const catalog = useExerciseCatalog();
+  // Labyrinth pools from the same provider, so the screen's labyrinth reads
+  // (list, king-gate, training path) agree with the merged catalog under the
+  // flag — and stay baseline (byte-identical) when no provider is mounted.
+  const labyrinthCatalog = useLabyrinthCatalog();
 
   // Progress is keyed by exerciseId (currentId). Derive the pool index for
   // the index-based affordances (drawer activeIndex, tutorial-hint gate,
@@ -2240,7 +2244,7 @@ export function ExercisesScreen({
    *  taps (the old `labyrinthList[0]` hardcode and the 10★
    *  labyrinthAvailable gate are gone — unlock now lives in the path
    *  node statuses: first lab at 6★, then chain by completion). */
-  const labyrinthList = LABYRINTHS[selectedPiece] ?? [];
+  const labyrinthList = labyrinthCatalog[selectedPiece] ?? [];
   const activeLabyrinth =
     labyrinthMode && selectedLabyrinthId
       ? labyrinthList.find((lab) => lab.id === selectedLabyrinthId) ?? null
@@ -2261,9 +2265,10 @@ export function ExercisesScreen({
         labyrinthList.map((lab) => [lab.id, getLabyrinthBest(selectedPiece, lab.id)]),
       ),
       badgeClaimed: badgesClaimed[selectedPiece] === true,
+      catalog: { exercises: catalog, labyrinths: labyrinthCatalog },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPiece, progress, badgesClaimed, labyrinthCompleted]);
+  }, [selectedPiece, progress, badgesClaimed, labyrinthCompleted, catalog, labyrinthCatalog]);
 
   /** Always-fresh mirror of the path for callbacks that fire from
    *  timers (success auto-advance) — the 1500ms closure would
@@ -2875,7 +2880,7 @@ export function ExercisesScreen({
               selectedPiece === "king" &&
               areAllLabyrinthsSolved(
                 "king",
-                LABYRINTHS.king.map((l) => l.id),
+                labyrinthCatalog.king.map((l) => l.id),
               )
                 ? () => {
                     setLabyrinthCompleted(null);

--- a/apps/web/src/lib/content/__tests__/baseline-write.test.ts
+++ b/apps/web/src/lib/content/__tests__/baseline-write.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock node:fs so the helper never touches the real filesystem and we can
+// assert exactly when (and whether) it writes.
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({ ...fsMocks, default: fsMocks }));
+
+import { writeBaselineRecord } from "../baseline-write";
+import type { LabyrinthRecord } from "@/lib/labyrinth-builder/store";
+
+const VALID_EXERCISE: LabyrinthRecord = {
+  piece: "rook",
+  fen: "8/8/8/8/8/8/8/R7 w - - 0 1",
+  target: "h1",
+  mover: "a1",
+  tier: "easy",
+  tags: ["straight-line"],
+  order: 2,
+  id: "rook-ex",
+};
+
+// Boxed rook with no path from b2 to a8 — unsolvable.
+const UNSOLVABLE: LabyrinthRecord = {
+  piece: "rook",
+  fen: "8/8/8/8/8/1R6/RRR5/1R6 w - - 0 1",
+  target: "a8",
+  mover: "b2",
+  order: 1,
+  id: "rook-boxed",
+};
+
+describe("writeBaselineRecord", () => {
+  beforeEach(() => {
+    fsMocks.readFileSync.mockReset();
+    fsMocks.writeFileSync.mockReset();
+    fsMocks.existsSync.mockReset();
+    fsMocks.mkdirSync.mockReset();
+    fsMocks.existsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("validates + writes a solvable exercise (json + generated module) and returns the id", () => {
+    const result = writeBaselineRecord("exercise", { ...VALID_EXERCISE });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.id).toBe("rook-ex");
+    const written = fsMocks.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(written.some((p) => p.endsWith("content/exercises.json"))).toBe(true);
+    expect(
+      written.some((p) => p.endsWith("src/lib/game/generated/puzzles.generated.ts")),
+    ).toBe(true);
+    expect(written.some((p) => p.endsWith("content/labyrinths.json"))).toBe(false);
+  });
+
+  it("rejects an unsolvable record with errors and never writes", () => {
+    const result = writeBaselineRecord("labyrinth", { ...UNSOLVABLE });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.some((e) => e.includes("unsolvable"))).toBe(true);
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("auto-assigns a content-addressed id when none is supplied", () => {
+    const { id: _omit, ...noId } = VALID_EXERCISE;
+    const result = writeBaselineRecord("exercise", noId as LabyrinthRecord);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.id).toMatch(/^rook-gen-/);
+  });
+});

--- a/apps/web/src/lib/content/__tests__/catalog-context.test.tsx
+++ b/apps/web/src/lib/content/__tests__/catalog-context.test.tsx
@@ -1,35 +1,82 @@
 /**
- * ExerciseCatalogContext — db-backed-content Phase 2b-2 (client seam).
+ * ContentCatalogContext — db-backed-content (Phase 2b-2 seam + overlay-full).
  *
- * The context carries the by-piece exercise pools (`ExerciseCatalog`).
- * Its default value is the compiled baseline `EXERCISES`, so any consumer
- * rendered WITHOUT a provider behaves byte-identically to a direct
- * `EXERCISES` import. Phase 2c mounts the provider with the merged
- * (baseline ⊕ overlay) pools at the /exercises server boundary.
+ * The context carries the full read catalog: by-piece exercise pools,
+ * labyrinth pools, and the descriptions map. Its default value is the
+ * compiled baseline, so any consumer rendered WITHOUT a provider behaves
+ * byte-identically to a direct baseline import. The /exercises server
+ * boundary mounts the provider with the merged (baseline ⊕ overlay) catalog.
  *
  * Coverage:
- *  - No provider → `useExerciseCatalog()` returns the baseline EXERCISES.
- *  - With a provider → returns the injected catalog (proves the seam, not
- *    just the default).
+ *  - No provider → selectors return the baseline (EXERCISES / LABYRINTHS /
+ *    GENERATED_EXERCISE_DESCRIPTIONS).
+ *  - With a provider → selectors return the injected catalog (proves the
+ *    seam, not just the default).
+ *  - Back-compat: the exercises-only `ExerciseCatalogProvider` still works.
  */
 
 import { describe, expect, it } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import {
+  ContentCatalogProvider,
   ExerciseCatalogProvider,
   useExerciseCatalog,
+  useExerciseDescriptions,
+  useLabyrinthCatalog,
+  type ContentCatalog,
 } from "@/lib/content/catalog-context";
-import { EXERCISES } from "@/lib/game/exercises";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
 import type { ExerciseCatalog } from "@/lib/game/rotation";
 
-describe("ExerciseCatalogContext", () => {
-  it("returns the baseline EXERCISES when no provider is mounted", () => {
+describe("ContentCatalogContext — no provider (baseline default)", () => {
+  it("useExerciseCatalog returns the baseline EXERCISES", () => {
     const { result } = renderHook(() => useExerciseCatalog());
     expect(result.current).toBe(EXERCISES);
   });
 
-  it("returns the injected catalog when wrapped in a provider", () => {
+  it("useLabyrinthCatalog returns the baseline LABYRINTHS", () => {
+    const { result } = renderHook(() => useLabyrinthCatalog());
+    expect(result.current).toBe(LABYRINTHS);
+  });
+
+  it("useExerciseDescriptions returns the baseline descriptions", () => {
+    const { result } = renderHook(() => useExerciseDescriptions());
+    expect(result.current).toBe(GENERATED_EXERCISE_DESCRIPTIONS);
+  });
+});
+
+describe("ContentCatalogContext — with ContentCatalogProvider", () => {
+  const injected: ContentCatalog = {
+    exercises: { ...EXERCISES, rook: EXERCISES.rook.slice(0, 1) },
+    labyrinths: { ...LABYRINTHS, rook: LABYRINTHS.rook.slice(0, 1) },
+    descriptions: { "rook-overlay": "Overlay description" },
+  };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ContentCatalogProvider value={injected}>{children}</ContentCatalogProvider>
+  );
+
+  it("useExerciseCatalog returns the injected exercise pools", () => {
+    const { result } = renderHook(() => useExerciseCatalog(), { wrapper });
+    expect(result.current).toBe(injected.exercises);
+    expect(result.current.rook).toHaveLength(1);
+  });
+
+  it("useLabyrinthCatalog returns the injected labyrinth pools", () => {
+    const { result } = renderHook(() => useLabyrinthCatalog(), { wrapper });
+    expect(result.current).toBe(injected.labyrinths);
+    expect(result.current.rook).toHaveLength(1);
+  });
+
+  it("useExerciseDescriptions returns the injected descriptions", () => {
+    const { result } = renderHook(() => useExerciseDescriptions(), { wrapper });
+    expect(result.current["rook-overlay"]).toBe("Overlay description");
+  });
+});
+
+describe("ContentCatalogContext — back-compat ExerciseCatalogProvider", () => {
+  it("the exercises-only provider still drives useExerciseCatalog", () => {
     const injected: ExerciseCatalog = {
       ...EXERCISES,
       rook: EXERCISES.rook.slice(0, 1),
@@ -42,5 +89,16 @@ describe("ExerciseCatalogContext", () => {
     const { result } = renderHook(() => useExerciseCatalog(), { wrapper });
     expect(result.current).toBe(injected);
     expect(result.current.rook).toHaveLength(1);
+  });
+
+  it("leaves labyrinths + descriptions at baseline when only exercises are provided", () => {
+    const injected: ExerciseCatalog = { ...EXERCISES };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ExerciseCatalogProvider value={injected}>
+        {children}
+      </ExerciseCatalogProvider>
+    );
+    const lab = renderHook(() => useLabyrinthCatalog(), { wrapper });
+    expect(lab.result.current).toBe(LABYRINTHS);
   });
 });

--- a/apps/web/src/lib/content/baseline-write.ts
+++ b/apps/web/src/lib/content/baseline-write.ts
@@ -1,0 +1,93 @@
+/**
+ * Baseline content write — db-content overlay-full (Stage 5).
+ *
+ * Server-only, dev-only helper (callers guard `NODE_ENV`). Owns the fs
+ * read-modify-write of `content/{exercises,labyrinths}.json` plus the
+ * regeneration of the generated catalog module, reusing the shared BFS
+ * validator (`buildCatalog`). Extracted from `/api/dev/labyrinth` so BOTH the
+ * dev route AND the dev publish proxy go through ONE path — no divergence
+ * between "save" and "publish to live" (red-team P0).
+ *
+ * NEVER import from a non-dev surface: it touches the working tree.
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { upsertRecord, type LabyrinthRecord } from "@/lib/labyrinth-builder/store";
+import { puzzleId } from "@/lib/game/fen-puzzle";
+import { parseCsv, buildCatalog, renderGeneratedModule } from "@/lib/content/catalog";
+import type { ContentKind } from "@/lib/content/overlay-types";
+
+const ROOT = resolve(process.cwd());
+const LABS_PATH = resolve(ROOT, "content/labyrinths.json");
+const EXERCISES_PATH = resolve(ROOT, "content/exercises.json");
+const CSV_PATH = resolve(ROOT, "content/puzzles.csv");
+const GEN_PATH = resolve(ROOT, "src/lib/game/generated/puzzles.generated.ts");
+
+/** A builder record tagged with the bucket it belongs to. The on-disk JSON
+ *  files do NOT store `kind` (it is implied by the file). */
+export type KindedRecord = LabyrinthRecord & { kind?: ContentKind };
+
+export type BaselineWriteResult =
+  | { ok: true; id: string; warnings: string[] }
+  | { ok: false; errors: string[] };
+
+function readRecords(path: string): LabyrinthRecord[] {
+  return existsSync(path)
+    ? (JSON.parse(readFileSync(path, "utf8")) as LabyrinthRecord[])
+    : [];
+}
+
+/** Read both buckets (kind-tagged), optionally filtered. Powers the dev GET. */
+export function readBaselineRecords(filter?: ContentKind): KindedRecord[] {
+  const wantLabs = filter !== "exercise";
+  const wantExercises = filter !== "labyrinth";
+  const out: KindedRecord[] = [];
+  if (wantLabs) {
+    for (const r of readRecords(LABS_PATH)) out.push({ ...r, kind: "labyrinth" });
+  }
+  if (wantExercises) {
+    for (const r of readRecords(EXERCISES_PATH)) out.push({ ...r, kind: "exercise" });
+  }
+  return out;
+}
+
+/**
+ * Validate (BFS, via buildCatalog) and persist one record to its bucket, then
+ * regenerate the catalog module. The record is mutated in place to carry a
+ * resolved id (auto-assigned with the build's content-addressed scheme when
+ * absent), and that id is returned. On a validation failure NOTHING is written.
+ */
+export function writeBaselineRecord(
+  kind: ContentKind,
+  record: LabyrinthRecord,
+): BaselineWriteResult {
+  // Auto-assign a stable, content-addressed id so future saves overwrite the
+  // same record (no duplicate "(no id)" rows). Same scheme as the build.
+  if (!record.id) {
+    record.id = puzzleId(
+      record.piece,
+      `${kind}|${record.fen}|${record.target}|${record.mover ?? ""}`,
+    );
+  }
+
+  const targetPath = kind === "exercise" ? EXERCISES_PATH : LABS_PATH;
+  // Read-modify-write the active bucket; upsertRecord replaces a matching
+  // record wholesale (caller sends a complete record on edit).
+  const nextTarget = upsertRecord(readRecords(targetPath), record);
+
+  // The generated catalog is built from BOTH buckets (+ the CSV), so re-read
+  // the other bucket as-is and feed both to buildCatalog.
+  const labs = kind === "exercise" ? readRecords(LABS_PATH) : nextTarget;
+  const exercises = kind === "exercise" ? nextTarget : readRecords(EXERCISES_PATH);
+
+  const csvRows = existsSync(CSV_PATH)
+    ? parseCsv(readFileSync(CSV_PATH, "utf8"))
+    : [["kind", "piece", "fen", "target", "mover", "tier", "tags", "explanation", "id"]];
+  const cat = buildCatalog(csvRows, labs, exercises);
+  if (cat.errors.length) return { ok: false, errors: cat.errors };
+
+  mkdirSync(dirname(GEN_PATH), { recursive: true });
+  writeFileSync(targetPath, JSON.stringify(nextTarget, null, 2) + "\n");
+  writeFileSync(GEN_PATH, renderGeneratedModule(cat));
+  return { ok: true, id: record.id, warnings: cat.warnings };
+}

--- a/apps/web/src/lib/content/catalog-context.tsx
+++ b/apps/web/src/lib/content/catalog-context.tsx
@@ -1,46 +1,91 @@
 "use client";
 
 /**
- * ExerciseCatalogContext — db-backed-content Phase 2b-2 (client seam).
+ * ContentCatalogContext — db-backed-content (Phase 2b-2 seam + overlay-full).
  *
- * Carries the by-piece exercise pools (`ExerciseCatalog`) that the client
- * surfaces read. The default value is the compiled baseline `EXERCISES`,
- * so a consumer rendered WITHOUT a provider behaves byte-identically to a
- * direct `EXERCISES` import — this is what keeps the flag-off read path
- * unchanged in Phase 2b.
+ * Carries the full read catalog the client surfaces consume: by-piece
+ * exercise pools, labyrinth pools, and the descriptions map. The default
+ * value is the compiled baseline, so a consumer rendered WITHOUT a provider
+ * behaves byte-identically to a direct baseline import — this is what keeps
+ * the flag-off read path unchanged.
  *
- * Phase 2c mounts `<ExerciseCatalogProvider>` at the /exercises server
- * boundary with the merged (baseline ⊕ overlay) pools, behind
+ * The /exercises server boundary mounts `<ContentCatalogProvider>` with the
+ * merged (baseline ⊕ overlay) catalog from `getMergedCatalog()`, behind
  * `CONTENT_OVERLAY_ENABLED`. Until then no provider is mounted and every
- * consumer falls through to the baseline default.
+ * selector falls through to the baseline default.
  *
- * Note: unlike most context hooks here, `useExerciseCatalog` does NOT
- * throw when consumed outside a provider — the baseline default is the
- * intended fallback, not a misuse.
+ * Note: unlike most context hooks here, the selectors do NOT throw when
+ * consumed outside a provider — the baseline default is the intended
+ * fallback, not a misuse.
  */
 
 import { createContext, useContext, type ReactNode } from "react";
-import { EXERCISES } from "@/lib/game/exercises";
-import type { ExerciseCatalog } from "@/lib/game/rotation";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
+import type { Exercise, PieceId } from "@/lib/game/types";
 
-const ExerciseCatalogContext = createContext<ExerciseCatalog>(EXERCISES);
+/** The full read catalog (same fields the merged loader exposes). */
+export interface ContentCatalog {
+  exercises: Record<PieceId, Exercise[]>;
+  labyrinths: Record<PieceId, Exercise[]>;
+  descriptions: Record<string, string>;
+}
 
+const DEFAULT_CATALOG: ContentCatalog = {
+  exercises: EXERCISES,
+  labyrinths: LABYRINTHS,
+  descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
+};
+
+const ContentCatalogContext = createContext<ContentCatalog>(DEFAULT_CATALOG);
+
+export function ContentCatalogProvider({
+  value,
+  children,
+}: {
+  value: ContentCatalog;
+  children: ReactNode;
+}) {
+  return (
+    <ContentCatalogContext.Provider value={value}>
+      {children}
+    </ContentCatalogContext.Provider>
+  );
+}
+
+/** Active by-piece exercise pools. Baseline `EXERCISES` with no provider.
+ *  Return shape unchanged from the Phase 2b-2 seam (back-compat). */
+export function useExerciseCatalog(): Record<PieceId, Exercise[]> {
+  return useContext(ContentCatalogContext).exercises;
+}
+
+/** Active by-piece labyrinth pools. Baseline `LABYRINTHS` with no provider. */
+export function useLabyrinthCatalog(): Record<PieceId, Exercise[]> {
+  return useContext(ContentCatalogContext).labyrinths;
+}
+
+/** Active exercise descriptions map. Baseline generated map with no provider. */
+export function useExerciseDescriptions(): Record<string, string> {
+  return useContext(ContentCatalogContext).descriptions;
+}
+
+/**
+ * Back-compat provider for the Phase 2c exercises-only mount. Wraps the full
+ * `ContentCatalogProvider`, supplying the given exercise pools while leaving
+ * labyrinths + descriptions at baseline. Kept so the read path stays green
+ * across stages; the /exercises boundary moves to `ContentCatalogProvider`
+ * with the full merged catalog in the overlay-full follow-up.
+ */
 export function ExerciseCatalogProvider({
   value,
   children,
 }: {
-  value: ExerciseCatalog;
+  value: Record<PieceId, Exercise[]>;
   children: ReactNode;
 }) {
   return (
-    <ExerciseCatalogContext.Provider value={value}>
+    <ContentCatalogProvider value={{ ...DEFAULT_CATALOG, exercises: value }}>
       {children}
-    </ExerciseCatalogContext.Provider>
+    </ContentCatalogProvider>
   );
-}
-
-/** Returns the active by-piece exercise pools. Baseline `EXERCISES` when
- *  no provider is mounted (Phase 2b flag-off path). */
-export function useExerciseCatalog(): ExerciseCatalog {
-  return useContext(ExerciseCatalogContext);
 }

--- a/apps/web/src/lib/game/__tests__/resolve-exercise-description.test.ts
+++ b/apps/web/src/lib/game/__tests__/resolve-exercise-description.test.ts
@@ -56,4 +56,19 @@ describe("resolveExerciseDescription", () => {
     const out = resolveExerciseDescription("blank-id", 0, i18n, fallback);
     expect(out).toBe("Exercise 1");
   });
+
+  it("prefers an injected descriptions map over the baseline generated map", () => {
+    const i18n = vi.fn(() => "should-not-be-called");
+    const injected = { "rook-1": "Overlay text for rook-1" };
+    const out = resolveExerciseDescription("rook-1", 0, i18n, fallback, injected);
+    expect(out).toBe("Overlay text for rook-1");
+    expect(i18n).not.toHaveBeenCalled();
+  });
+
+  it("with an injected map, an absent id falls through to i18n then fallback", () => {
+    const injected = { "rook-1": "x" };
+    const i18n = (id: string) => `i18n:${id}`;
+    const out = resolveExerciseDescription("rook-2", 1, i18n, fallback, injected);
+    expect(out).toBe("i18n:rook-2");
+  });
 });

--- a/apps/web/src/lib/game/exercises.ts
+++ b/apps/web/src/lib/game/exercises.ts
@@ -88,6 +88,11 @@ export const LABYRINTHS: Record<PieceId, Exercise[]> = {
  * "Exercise N" fallback. Pure — `i18n`/`fallback` are injected so this is
  * unit-testable without a translator context.
  *
+ * `descriptions` defaults to the compiled baseline map but is injectable so
+ * the overlay read path can pass the merged (baseline ⊕ overlay) descriptions
+ * — an overlay-edited `explanation` then overrides the baseline text. With the
+ * default it is byte-identical to the pre-overlay resolver.
+ *
  * `i18n` returns `null` (or an empty string) when the id has no
  * translation. The caller is expected to guard the translator (e.g.
  * `descriptions.has(id)`) and pass `null` for unknown ids, so a builder-
@@ -100,8 +105,9 @@ export function resolveExerciseDescription(
   index: number,
   i18n: (id: string) => string | null,
   fallback: (n: number) => string,
+  descriptions: Record<string, string> = GENERATED_EXERCISE_DESCRIPTIONS,
 ): string {
-  const gen = GENERATED_EXERCISE_DESCRIPTIONS[id];
+  const gen = descriptions[id];
   if (gen) return gen;
   const translated = i18n(id);
   if (translated) return translated;

--- a/apps/web/src/lib/labyrinth-builder/__tests__/publish-toast.test.ts
+++ b/apps/web/src/lib/labyrinth-builder/__tests__/publish-toast.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatPublishResult } from "../publish-toast";
+
+describe("formatPublishResult", () => {
+  it("ok + revalidated → success toast with commit nudge", () => {
+    const t = formatPublishResult({
+      ok: true,
+      baseline: { ok: true, id: "rook-1" },
+      overlay: { ok: true, revalidated: true },
+    });
+    expect(t.kind).toBe("ok");
+    expect(t.text).toMatch(/live/i);
+    expect(t.text).toMatch(/commit/i);
+  });
+
+  it("ok but not yet revalidated → success toast notes propagation", () => {
+    const t = formatPublishResult({
+      ok: true,
+      baseline: { ok: true, id: "rook-1" },
+      overlay: { ok: true, revalidated: false },
+    });
+    expect(t.kind).toBe("ok");
+    expect(t.text).toMatch(/propagat/i);
+  });
+
+  it("baseline ok but overlay failed → partial (warn) toast surfacing the overlay error", () => {
+    const t = formatPublishResult({
+      ok: false,
+      baseline: { ok: true, id: "rook-1" },
+      overlay: { ok: false, errors: ["overlay publish rejected: admin token rejected (403)"] },
+    });
+    expect(t.kind).toBe("warn");
+    expect(t.text).toMatch(/saved to baseline/i);
+    expect(t.text).toMatch(/403/);
+    expect(t.text).toMatch(/commit/i);
+  });
+
+  it("baseline failed → error toast with the validation errors", () => {
+    const t = formatPublishResult({
+      ok: false,
+      baseline: { ok: false, errors: ["rook-boxed: unsolvable"] },
+      overlay: { ok: false, errors: ["skipped: baseline write failed"] },
+    });
+    expect(t.kind).toBe("err");
+    expect(t.text).toMatch(/unsolvable/i);
+  });
+});

--- a/apps/web/src/lib/labyrinth-builder/publish-toast.ts
+++ b/apps/web/src/lib/labyrinth-builder/publish-toast.ts
@@ -1,0 +1,34 @@
+/**
+ * Maps a /api/dev/publish result to a builder toast — db-content overlay-full
+ * (Stage 7). Pure so the success / partial-failure / error copy is unit-tested
+ * without rendering the builder page.
+ *
+ * - baseline fail            → "err"  (nothing published; show validation errors)
+ * - baseline ok + overlay ok → "ok"   (live; remind to commit the json)
+ * - baseline ok + overlay !ok→ "warn" (partial: saved to baseline, live failed)
+ */
+export type PublishToast = { kind: "ok" | "warn" | "err"; text: string };
+
+export interface PublishResultLike {
+  ok: boolean;
+  baseline: { ok: boolean; id?: string; errors?: string[] };
+  overlay: { ok: boolean; revalidated?: boolean; errors?: string[] };
+}
+
+const COMMIT_NUDGE = "Remember to commit content/*.json.";
+
+export function formatPublishResult(r: PublishResultLike): PublishToast {
+  if (!r.baseline.ok) {
+    const errs = (r.baseline.errors ?? ["unknown error"]).join("; ");
+    return { kind: "err", text: `Save failed: ${errs}` };
+  }
+  if (r.overlay.ok) {
+    const note = r.overlay.revalidated ? "live now" : "saved, propagating";
+    return { kind: "ok", text: `Published (${note}) + saved to baseline. ${COMMIT_NUDGE}` };
+  }
+  const errs = (r.overlay.errors ?? ["unknown error"]).join("; ");
+  return {
+    kind: "warn",
+    text: `Saved to baseline, but live publish failed: ${errs}. ${COMMIT_NUDGE}`,
+  };
+}

--- a/apps/web/src/lib/training/__tests__/path.test.ts
+++ b/apps/web/src/lib/training/__tests__/path.test.ts
@@ -272,6 +272,31 @@ describe("buildTrainingPath — catalog coverage and ordering", () => {
   });
 });
 
+describe("buildTrainingPath — injected overlay catalog (db-content)", () => {
+  // Regression lock for the overlay-full read path: the screen passes the
+  // merged catalog through `input.catalog`, so labyrinth nodes (and their
+  // unlock gate) must derive from `catalog.labyrinths`, never the baseline.
+  it("derives labyrinth nodes from catalog.labyrinths, not the baseline", () => {
+    const overlayLab = { ...LABYRINTHS.rook[0], id: "rook-overlay-lab" };
+    const allStars = Object.fromEntries(EXERCISES.rook.map((e) => [e.id, 3]));
+    const path = buildTrainingPath({
+      piece: "rook",
+      progress: { piece: "rook", currentId: null, stars: allStars },
+      labyrinthBests: {},
+      badgeClaimed: false,
+      catalog: {
+        exercises: EXERCISES,
+        labyrinths: { ...LABYRINTHS, rook: [overlayLab] },
+      },
+    });
+    const labs = path.filter((n) => n.kind === "labyrinth");
+    expect(labs).toHaveLength(1);
+    expect(labs[0].id).toBe("rook-overlay-lab");
+    // 24★ (all rook exercises at 3★) ≥ 6★ → list AND gate agree: "available".
+    expect(labs[0].status).toBe("available");
+  });
+});
+
 describe("getNextChallenge — next-node recommendation (Slice 3D)", () => {
   function pathFor(piece: PieceId, input: Partial<TrainingPathInput> = {}) {
     return buildTrainingPath({


### PR DESCRIPTION
## db-content overlay-full (follow-up to Phases 1–2c)

Completes overlay coverage and wires the builder to publish live in one action.
Spec: `docs/specs/db-content-overlay-full.md` (+ red-team, 3 P0s folded in).
All behind the existing `CONTENT_OVERLAY_ENABLED` flag (default OFF → byte-identical).

### Stages (TDD, atomic commits)
1. **Widen catalog-context** → `ContentCatalog {exercises,labyrinths,descriptions}` + `ContentCatalogProvider`; `useExerciseCatalog()` return unchanged (back-compat) + new `useLabyrinthCatalog()` / `useExerciseDescriptions()`.
2. **Inject descriptions** → `resolveExerciseDescription` 5th param (default baseline).
3. **page boundary** → mounts the full `ContentCatalogProvider` (exercises + labyrinths + descriptions) under the flag.
4. **screen + drawer** → labyrinth list, king-gate (`:2878`) and `buildTrainingPath` all read `useLabyrinthCatalog()` (list AND gate share one source — red-team P0); drawer threads `useExerciseDescriptions()`.
5. **extract `writeBaselineRecord`** helper → dev route is a thin wrapper; one write path (red-team P0).
6. **`/api/dev/publish` proxy** (dev-only) → baseline json + live overlay in one call; `ADMIN_TOKEN` server-side only, sanitized errors, normalized `OVERLAY_PUBLISH_BASE_URL` (red-team P0).
7. **builder Save** → publishes via the proxy with ok/warn/err toasts + commit nudge + debounce; disable/enable toggle also propagates live.

### New env (local builder only)
- `OVERLAY_PUBLISH_BASE_URL` — where the local builder publishes (e.g. `https://preview.chesscito.com`). Plus `ADMIN_TOKEN` (already used by the admin route). Both server-side.

### Verification
- Suite **3918/3918** · `tsc --noEmit` clean · eslint clean.
- Flag OFF → no provider → baseline default (byte-identical, zero DB hits).

### Founder-confirmed decisions
- Senda re-open = **(a)** (already true via id-keyed progress — no code).
- Publish model = **todo en 1** (dual-write baseline + overlay); manual git commit with a builder nudge.

Wolfcito 🐾 @akawolfcito