### PR TITLE
feat(board): migration Phase 1 — board.tsx onto GameBoard substrate (flag off)

### DIFF
--- a/apps/web/src/components/__tests__/board.test.tsx
+++ b/apps/web/src/components/__tests__/board.test.tsx
@@ -266,4 +266,90 @@ describe("<Board>", () => {
       expect(piece.className).toContain("is-snap-back");
     });
   });
+
+  // ─── Procedural board flag (migration Phase 1, per-surface, default off) ──
+  const FRAME_SRC = "/art/board/borde-tablero";
+
+  describe("procedural board flag", () => {
+    it("defaults to the image board (flag off) — byte-identical substrate", () => {
+      const { container } = render(
+        <Board pieceType="rook" startPosition={{ file: 0, rank: 0 }} />,
+      );
+      // Image substrate present, procedural frame absent.
+      expect(container.querySelector(".playhub-board-img")).toBeInTheDocument();
+      expect(
+        container.querySelector(`img[src*="${FRAME_SRC}"]`),
+      ).toBeNull();
+    });
+
+    it("renders the GameBoard substrate when proceduralBoard is on", () => {
+      const { container } = render(
+        <Board
+          pieceType="rook"
+          startPosition={{ file: 0, rank: 0 }}
+          proceduralBoard
+        />,
+      );
+      // Procedural frame present, image substrate gone.
+      expect(
+        container.querySelector(`img[src*="${FRAME_SRC}"]`),
+      ).toBeInTheDocument();
+      expect(container.querySelector(".playhub-board-img")).toBeNull();
+      // Still 64 interactive cells.
+      expect(screen.getAllByRole("button", { name: /^[a-h][1-8]$/ })).toHaveLength(64);
+    });
+
+    it("places the floating piece on the procedural board", () => {
+      const { container } = render(
+        <Board
+          pieceType="rook"
+          startPosition={{ file: 0, rank: 0 }}
+          proceduralBoard
+        />,
+      );
+      const piece = container.querySelector(".playhub-board-piece-float");
+      expect(piece).toBeInTheDocument();
+      expect(piece?.querySelector("img")?.getAttribute("src")).toContain("rook");
+    });
+
+    it("highlights valid targets after the piece is selected (procedural)", () => {
+      const { container } = render(
+        <Board
+          pieceType="rook"
+          startPosition={{ file: 0, rank: 0 }}
+          proceduralBoard
+        />,
+      );
+      // No dots before selection.
+      expect(container.querySelector(".playhub-board-dot")).toBeNull();
+      // Select the rook (GameBoard cell aria-label is the bare square id).
+      fireEvent.click(screen.getByRole("button", { name: "a1" }));
+      expect(container.querySelectorAll(".playhub-board-dot").length).toBeGreaterThan(0);
+    });
+
+    it("renders the target star marker on the procedural board", () => {
+      const { container } = render(
+        <Board
+          pieceType="rook"
+          startPosition={{ file: 0, rank: 0 }}
+          targetPosition={{ file: 7, rank: 0 }}
+          proceduralBoard
+        />,
+      );
+      expect(container.querySelector(".playhub-board-target")).toBeInTheDocument();
+    });
+
+    it("paints labyrinth walls per cell on the procedural board", () => {
+      const { container } = render(
+        <Board
+          pieceType="rook"
+          startPosition={{ file: 0, rank: 0 }}
+          mode="labyrinth"
+          obstacles={[{ file: 3, rank: 3 }]}
+          proceduralBoard
+        />,
+      );
+      expect(container.querySelector(".playhub-board-cell.is-wall")).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/components/board.tsx
+++ b/apps/web/src/components/board.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/game/board";
 import type { BoardPosition, PieceId } from "@/lib/game/types";
 import { cellGeometry, cellCenter, pieceWidth } from "@/lib/game/board-geometry";
+import { GameBoard } from "@/lib/game/game-board";
 import { hapticTap, hapticReject, hapticSuccess } from "@/lib/haptics";
 import { ASSET_THEME, THEME_CONFIG } from "@/lib/theme";
 import { BOARD_HINT_COPY } from "@/lib/content/editorial";
@@ -89,6 +90,11 @@ type BoardProps = {
    *  Cleared by the parent after a short timer (~4s) so the hint
    *  doesn't linger forever. `null` = no active hint. */
   peonesHint?: BoardPosition | null;
+  /** Board migration Phase 1 (per-surface, default off). When true, the board
+   *  renders on the procedural `<GameBoard>` substrate (tile grid + candy frame)
+   *  instead of the background-image board. Flag stays off until final art +
+   *  human sign-off (founder 2026-06-17). */
+  proceduralBoard?: boolean;
 };
 
 export function Board({
@@ -103,6 +109,7 @@ export function Board({
   onMove,
   tutorialHints,
   peonesHint = null,
+  proceduralBoard = false,
 }: BoardProps) {
   const [piece, setPiece] = useState(() => makePiece(pieceType, startPosition));
   const [selectedPosition, setSelectedPosition] = useState<BoardPosition | null>(
@@ -192,6 +199,13 @@ export function Board({
     [piece, selectedPosition, targetPosition, validTargets]
   );
 
+  // Keyed lookup for the procedural board's renderCell (file,rank → square).
+  const squareByKey = useMemo(() => {
+    const map = new Map<string, (typeof squares)[number]>();
+    for (const s of squares) map.set(`${s.file},${s.rank}`, s);
+    return map;
+  }, [squares]);
+
   const handleSquarePress = (label: string) => {
     const isInteractive = mode === "practice" || mode === "labyrinth";
     if (!isInteractive || isLocked || !mountedRef.current) {
@@ -253,6 +267,343 @@ export function Board({
 
     setSelectedPosition(null);
   };
+
+  // Absolute overlay layer — capture marker, capture pickups, select hint, and
+  // the draggable floating piece. Positioned via cellCenter (% of the parent
+  // inset region). Shared verbatim between the image board (mounted in the
+  // hit-grid) and the procedural board (mounted in GameBoard's overlay region,
+  // inset to the frame opening). cellCenter resolves against whichever region
+  // wraps it, so each board stays aligned to its own grid.
+  const overlayLayer = (
+    <>
+      {/* Target piece — visible enemy piece for capture exercises */}
+      {isCapture && targetPosition && !(piece.position.file === targetPosition.file && piece.position.rank === targetPosition.rank) && (() => {
+        const tc = cellCenter(targetPosition.file, targetPosition.rank);
+        const tw = pieceWidth();
+        const targetImg = TARGET_MARKER_SRC;
+        return (
+          <picture
+            className="playhub-board-target-piece"
+            style={{
+              left: `${tc.x}%`,
+              top: `${tc.y}%`,
+              width: `${tw * 1.0}%`,
+            }}
+          >
+            {THEME_CONFIG.hasOptimizedFormats && (
+              <>
+                <source srcSet={targetImg.replace(".png", ".avif")} type="image/avif" />
+                <source srcSet={targetImg.replace(".png", ".webp")} type="image/webp" />
+              </>
+            )}
+            <img
+              src={targetImg}
+              alt="Capture target"
+              className="playhub-board-target-piece-img"
+              style={{ width: "100%" }}
+            />
+          </picture>
+        );
+      })()}
+
+      {/* Capture targets — capturable pickup markers. Rendered as
+          small glowing amber circles to indicate "land here to
+          capture". No lock icon; visually distinct from obstacles
+          which are desaturated pieces with a lock badge. */}
+      {mode === "labyrinth" && captureTargets && captureTargets.length > 0 && captureTargets.map((ct) => {
+        const cc = cellCenter(ct.file, ct.rank);
+        const cw = pieceWidth();
+        const key = `capture-${ct.file}-${ct.rank}`;
+        return (
+          <div
+            key={key}
+            aria-hidden="true"
+            className="playhub-board-piece-float"
+            style={{
+              left: `${cc.x}%`,
+              top: `${cc.y}%`,
+              width: `${cw}%`,
+              pointerEvents: "none",
+            }}
+          >
+            <span
+              className="block rounded-full"
+              style={{
+                width: "100%",
+                height: "100%",
+                background: "radial-gradient(circle, rgba(255, 200, 50, 0.35) 0%, rgba(255, 160, 20, 0.15) 70%, transparent 100%)",
+                boxShadow: "0 0 14px 4px rgba(255, 180, 40, 0.45), inset 0 0 8px 2px rgba(255, 200, 80, 0.25)",
+              }}
+            />
+          </div>
+        );
+      })}
+
+      {/* Contextual hint — appears next to the piece when the user
+          taps an empty cell without first selecting the piece.
+          Placement flips per piece location so the pill never
+          clips against the board edge. Pointer events disabled so
+          it never intercepts taps. */}
+      {showSelectHint && (() => {
+        const center = cellCenter(piece.position.file, piece.position.rank);
+        const placement = pickHintPlacement(piece.position.file, piece.position.rank);
+        return (
+          <div
+            role="status"
+            aria-live="polite"
+            className="playhub-board-select-hint"
+            data-placement={placement}
+            style={{
+              left: `${center.x}%`,
+              top: `${center.y}%`,
+            }}
+          >
+            {BOARD_HINT_COPY.selectPieceFirst}
+          </div>
+        );
+      })()}
+
+      {/* Floating piece layer — same element moves with transition.
+          Sprint 4 commit N — also the drag handle. Pointer events
+          enabled so the piece can capture pointerdown; the cell
+          buttons underneath still receive their own clicks via
+          the gridcell <button>. */}
+      {(() => {
+        const center = cellCenter(piece.position.file, piece.position.rank);
+        const pw = pieceWidth();
+        const isPieceSelected =
+          selectedPosition !== null &&
+          arePositionsEqual(selectedPosition, piece.position);
+        const isDragging = dragOffset !== null;
+        const dragStyle = isDragging
+          ? ({
+              ["--drag-dx" as string]: `${dragOffset.dx}px`,
+              ["--drag-dy" as string]: `${dragOffset.dy}px`,
+            } as Record<string, string>)
+          : undefined;
+        return (
+          <picture
+            className={[
+              "playhub-board-piece-float",
+              isPieceSelected ? "is-selected" : "",
+              isRejecting ? "piece-reject" : "",
+              isDragging ? "is-dragging" : "",
+              isSnappingBack ? "is-snap-back" : "",
+            ].filter(Boolean).join(" ")}
+            style={{
+              left: `${center.x}%`,
+              top: `${center.y}%`,
+              width: `${pw}%`,
+              pointerEvents: isLocked ? "none" : "auto",
+              touchAction: "none",
+              ...dragStyle,
+            }}
+            onPointerDown={(e) => {
+              if (isLocked || !mountedRef.current) return;
+              // Capture so subsequent move/up events come to us
+              // even if the finger leaves the piece bounds.
+              try {
+                e.currentTarget.setPointerCapture(e.pointerId);
+              } catch {
+                /* iOS Safari quirk — capture not always available */
+              }
+              if (snapBackTimerRef.current) {
+                clearTimeout(snapBackTimerRef.current);
+                snapBackTimerRef.current = null;
+              }
+              setIsSnappingBack(false);
+              dragStateRef.current = {
+                active: false,
+                startX: e.clientX,
+                startY: e.clientY,
+                pointerId: e.pointerId,
+              };
+            }}
+            onPointerMove={(e) => {
+              const state = dragStateRef.current;
+              if (!state || state.pointerId !== e.pointerId) return;
+              const dx = e.clientX - state.startX;
+              const dy = e.clientY - state.startY;
+              if (!state.active) {
+                if (Math.hypot(dx, dy) < DRAG_START_THRESHOLD_PX) return;
+                state.active = true;
+                // Auto-select the piece so validTargets light up.
+                if (
+                  !selectedPosition ||
+                  !arePositionsEqual(selectedPosition, piece.position)
+                ) {
+                  setSelectedPosition(piece.position);
+                }
+                if (selectHintTimerRef.current) {
+                  clearTimeout(selectHintTimerRef.current);
+                  selectHintTimerRef.current = null;
+                }
+                setShowSelectHint(false);
+              }
+              setDragOffset({ dx, dy });
+            }}
+            onPointerUp={(e) => {
+              const state = dragStateRef.current;
+              if (!state || state.pointerId !== e.pointerId) return;
+              dragStateRef.current = null;
+              try {
+                e.currentTarget.releasePointerCapture(e.pointerId);
+              } catch {
+                /* ignore */
+              }
+
+              if (!state.active) {
+                // No drag — treat as a tap on the piece's home
+                // cell. Same flow as before the drag was added.
+                setDragOffset(null);
+                handleSquarePress(getPositionLabel(piece.position));
+                return;
+              }
+
+              // Resolve the cell under the release point. Walk up
+              // from elementFromPoint to find the [data-square]
+              // attribute (covers cases where the actual hit was
+              // a child span / icon inside the cell button).
+              //
+              // Critical: the piece itself sits transformed under
+              // the finger (CSS transform participates in hit
+              // testing), so an unfiltered elementFromPoint would
+              // return the piece — which has no data-square — and
+              // every drop would snap back. Temporarily disable
+              // pointer-events on the piece so the query falls
+              // through to the cell underneath, then restore.
+              const pieceEl = e.currentTarget as HTMLElement;
+              const prevPointerEvents = pieceEl.style.pointerEvents;
+              pieceEl.style.pointerEvents = "none";
+              const hitEl = document.elementFromPoint(
+                e.clientX,
+                e.clientY,
+              ) as HTMLElement | null;
+              pieceEl.style.pointerEvents = prevPointerEvents;
+              const cellEl = hitEl?.closest("[data-square]") as
+                | HTMLElement
+                | null;
+              const label = cellEl?.dataset.square ?? null;
+
+              if (!label) {
+                // Released off-board → snap back.
+                triggerSnapBack();
+                return;
+              }
+
+              const target = parseLabel(label);
+              const isValid = validTargets.some((t) =>
+                arePositionsEqual(t, target),
+              );
+
+              if (isValid) {
+                // Successful drop. Clear the visual offset
+                // BEFORE the move so the piece transition starts
+                // from the home cell (avoids a one-frame
+                // teleport when the new center kicks in).
+                setDragOffset(null);
+                handleSquarePress(label);
+              } else {
+                triggerSnapBack();
+              }
+            }}
+            onPointerCancel={() => {
+              if (!dragStateRef.current) return;
+              const wasActive = dragStateRef.current.active;
+              dragStateRef.current = null;
+              if (wasActive) triggerSnapBack();
+              else setDragOffset(null);
+            }}
+          >
+            {THEME_CONFIG.hasOptimizedFormats && (
+              <>
+                <source srcSet={PIECE_IMG[piece.type].replace(".png", ".avif")} type="image/avif" />
+                <source srcSet={PIECE_IMG[piece.type].replace(".png", ".webp")} type="image/webp" />
+              </>
+            )}
+            <img
+              src={PIECE_IMG[piece.type]}
+              alt={`White ${piece.type}`}
+              className={PIECE_IMG_CLASS}
+              style={{ width: "100%" }}
+            />
+          </picture>
+        );
+      })()}
+    </>
+  );
+
+  // Per-cell substrate overlay for the procedural board: re-expresses the
+  // hit-grid cell's state visuals (highlight / selected / endpoint / wall /
+  // tutorial hint / peones hint) as a full-cell child so the existing
+  // `.playhub-board-cell` CSS applies without the absolute geometry. GameBoard
+  // owns the cell <button> (click + data-square for drag resolution); this only
+  // paints the glow + dot + target + peones marker inside it. (file 0–7, rank
+  // 1–8 chess rank → rankIdx = rank - 1.)
+  const renderProceduralCell = (file: number, rank: number) => {
+    const rankIdx = rank - 1;
+    const square = squareByKey.get(`${file},${rankIdx}`);
+    if (!square) return null;
+    const isWall =
+      mode === "labyrinth" && obstacleKeySet.has(`${file},${rankIdx}`);
+    const isPeones =
+      !!peonesHint && peonesHint.file === file && peonesHint.rank === rankIdx;
+    return (
+      <span
+        aria-hidden="true"
+        className={[
+          "playhub-board-cell",
+          square.isDark ? "is-dark" : "is-light",
+          square.isHighlighted ? "is-highlighted" : "",
+          square.isEndpoint ? "is-endpoint" : "",
+          square.isSelected ? "is-selected" : "",
+          isWall ? "is-wall" : "",
+          tutorialHints?.has(square.label) ? "is-tutorial-hint" : "",
+          isPeones ? "is-peones-hint" : "",
+        ].filter(Boolean).join(" ")}
+        style={{
+          position: "absolute",
+          inset: 0,
+          ...(square.isHighlighted && selectedPosition
+            ? {
+                ["--cell-stagger" as string]:
+                  Math.max(
+                    Math.abs(square.file - selectedPosition.file),
+                    Math.abs(square.rank - selectedPosition.rank),
+                  ) - 1,
+              }
+            : null),
+        }}
+      >
+        {square.isHighlighted ? <span className="playhub-board-dot" /> : null}
+        {square.isTarget && !square.piece && !isCapture ? (
+          <span className="playhub-board-target" />
+        ) : null}
+        {isPeones ? (
+          <span className="playhub-board-peones-hint" aria-hidden="true" />
+        ) : null}
+      </span>
+    );
+  };
+
+  if (proceduralBoard) {
+    return (
+      <div className="playhub-stage-shell w-full">
+        <div className="playhub-game-stage">
+          <div className="playhub-game-grid">
+            <div className="playhub-board-canvas">
+              <GameBoard
+                maxWidth="100%"
+                onCellClick={(_file, _rank, sq) => handleSquarePress(sq)}
+                renderCell={renderProceduralCell}
+                renderOverlay={() => overlayLayer}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="playhub-stage-shell w-full">
@@ -338,266 +689,7 @@ export function Board({
                     );
                   })()
                 )}
-              {/* Target piece — visible enemy piece for capture exercises */}
-              {isCapture && targetPosition && !(piece.position.file === targetPosition.file && piece.position.rank === targetPosition.rank) && (() => {
-                const tc = cellCenter(targetPosition.file, targetPosition.rank);
-                const tw = pieceWidth();
-                const targetImg = TARGET_MARKER_SRC;
-                return (
-                  <picture
-                    className="playhub-board-target-piece"
-                    style={{
-                      left: `${tc.x}%`,
-                      top: `${tc.y}%`,
-                      width: `${tw * 1.0}%`,
-                    }}
-                  >
-                    {THEME_CONFIG.hasOptimizedFormats && (
-                      <>
-                        <source srcSet={targetImg.replace(".png", ".avif")} type="image/avif" />
-                        <source srcSet={targetImg.replace(".png", ".webp")} type="image/webp" />
-                      </>
-                    )}
-                    <img
-                      src={targetImg}
-                      alt="Capture target"
-                      className="playhub-board-target-piece-img"
-                      style={{ width: "100%" }}
-                    />
-                  </picture>
-                );
-              })()}
-
-              {/* Labyrinth walls render AS the cell via the .is-wall class on
-                  the hit-grid button (stone tile) — see board.tsx className +
-                  globals.css .playhub-board-cell.is-wall. No floating piece /
-                  lock overlay: a stone-blocked square reads clearer for a
-                  beginner than a chained rook (founder 2026-06-16). */}
-
-              {/* Capture targets — capturable pickup markers. Rendered as
-                  small glowing amber circles to indicate "land here to
-                  capture". No lock icon; visually distinct from obstacles
-                  which are desaturated pieces with a lock badge. */}
-              {mode === "labyrinth" && captureTargets && captureTargets.length > 0 && captureTargets.map((ct) => {
-                const cc = cellCenter(ct.file, ct.rank);
-                const cw = pieceWidth();
-                const key = `capture-${ct.file}-${ct.rank}`;
-                return (
-                  <div
-                    key={key}
-                    aria-hidden="true"
-                    className="playhub-board-piece-float"
-                    style={{
-                      left: `${cc.x}%`,
-                      top: `${cc.y}%`,
-                      width: `${cw}%`,
-                      pointerEvents: "none",
-                    }}
-                  >
-                    <span
-                      className="block rounded-full"
-                      style={{
-                        width: "100%",
-                        height: "100%",
-                        background: "radial-gradient(circle, rgba(255, 200, 50, 0.35) 0%, rgba(255, 160, 20, 0.15) 70%, transparent 100%)",
-                        boxShadow: "0 0 14px 4px rgba(255, 180, 40, 0.45), inset 0 0 8px 2px rgba(255, 200, 80, 0.25)",
-                      }}
-                    />
-                  </div>
-                );
-              })}
-
-              {/* Contextual hint — appears next to the piece when the user
-                  taps an empty cell without first selecting the piece.
-                  Placement flips per piece location so the pill never
-                  clips against the board edge. Pointer events disabled so
-                  it never intercepts taps. */}
-              {showSelectHint && (() => {
-                const center = cellCenter(piece.position.file, piece.position.rank);
-                const placement = pickHintPlacement(piece.position.file, piece.position.rank);
-                return (
-                  <div
-                    role="status"
-                    aria-live="polite"
-                    className="playhub-board-select-hint"
-                    data-placement={placement}
-                    style={{
-                      left: `${center.x}%`,
-                      top: `${center.y}%`,
-                    }}
-                  >
-                    {BOARD_HINT_COPY.selectPieceFirst}
-                  </div>
-                );
-              })()}
-
-              {/* Floating piece layer — same element moves with transition.
-                  Sprint 4 commit N — also the drag handle. Pointer events
-                  enabled so the piece can capture pointerdown; the cell
-                  buttons underneath still receive their own clicks via
-                  the gridcell <button>. */}
-              {(() => {
-                const center = cellCenter(piece.position.file, piece.position.rank);
-                const pw = pieceWidth();
-                const isPieceSelected =
-                  selectedPosition !== null &&
-                  arePositionsEqual(selectedPosition, piece.position);
-                const isDragging = dragOffset !== null;
-                const dragStyle = isDragging
-                  ? ({
-                      ["--drag-dx" as string]: `${dragOffset.dx}px`,
-                      ["--drag-dy" as string]: `${dragOffset.dy}px`,
-                    } as Record<string, string>)
-                  : undefined;
-                return (
-                  <picture
-                    className={[
-                      "playhub-board-piece-float",
-                      isPieceSelected ? "is-selected" : "",
-                      isRejecting ? "piece-reject" : "",
-                      isDragging ? "is-dragging" : "",
-                      isSnappingBack ? "is-snap-back" : "",
-                    ].filter(Boolean).join(" ")}
-                    style={{
-                      left: `${center.x}%`,
-                      top: `${center.y}%`,
-                      width: `${pw}%`,
-                      pointerEvents: isLocked ? "none" : "auto",
-                      touchAction: "none",
-                      ...dragStyle,
-                    }}
-                    onPointerDown={(e) => {
-                      if (isLocked || !mountedRef.current) return;
-                      // Capture so subsequent move/up events come to us
-                      // even if the finger leaves the piece bounds.
-                      try {
-                        e.currentTarget.setPointerCapture(e.pointerId);
-                      } catch {
-                        /* iOS Safari quirk — capture not always available */
-                      }
-                      if (snapBackTimerRef.current) {
-                        clearTimeout(snapBackTimerRef.current);
-                        snapBackTimerRef.current = null;
-                      }
-                      setIsSnappingBack(false);
-                      dragStateRef.current = {
-                        active: false,
-                        startX: e.clientX,
-                        startY: e.clientY,
-                        pointerId: e.pointerId,
-                      };
-                    }}
-                    onPointerMove={(e) => {
-                      const state = dragStateRef.current;
-                      if (!state || state.pointerId !== e.pointerId) return;
-                      const dx = e.clientX - state.startX;
-                      const dy = e.clientY - state.startY;
-                      if (!state.active) {
-                        if (Math.hypot(dx, dy) < DRAG_START_THRESHOLD_PX) return;
-                        state.active = true;
-                        // Auto-select the piece so validTargets light up.
-                        if (
-                          !selectedPosition ||
-                          !arePositionsEqual(selectedPosition, piece.position)
-                        ) {
-                          setSelectedPosition(piece.position);
-                        }
-                        if (selectHintTimerRef.current) {
-                          clearTimeout(selectHintTimerRef.current);
-                          selectHintTimerRef.current = null;
-                        }
-                        setShowSelectHint(false);
-                      }
-                      setDragOffset({ dx, dy });
-                    }}
-                    onPointerUp={(e) => {
-                      const state = dragStateRef.current;
-                      if (!state || state.pointerId !== e.pointerId) return;
-                      dragStateRef.current = null;
-                      try {
-                        e.currentTarget.releasePointerCapture(e.pointerId);
-                      } catch {
-                        /* ignore */
-                      }
-
-                      if (!state.active) {
-                        // No drag — treat as a tap on the piece's home
-                        // cell. Same flow as before the drag was added.
-                        setDragOffset(null);
-                        handleSquarePress(getPositionLabel(piece.position));
-                        return;
-                      }
-
-                      // Resolve the cell under the release point. Walk up
-                      // from elementFromPoint to find the [data-square]
-                      // attribute (covers cases where the actual hit was
-                      // a child span / icon inside the cell button).
-                      //
-                      // Critical: the piece itself sits transformed under
-                      // the finger (CSS transform participates in hit
-                      // testing), so an unfiltered elementFromPoint would
-                      // return the piece — which has no data-square — and
-                      // every drop would snap back. Temporarily disable
-                      // pointer-events on the piece so the query falls
-                      // through to the cell underneath, then restore.
-                      const pieceEl = e.currentTarget as HTMLElement;
-                      const prevPointerEvents = pieceEl.style.pointerEvents;
-                      pieceEl.style.pointerEvents = "none";
-                      const hitEl = document.elementFromPoint(
-                        e.clientX,
-                        e.clientY,
-                      ) as HTMLElement | null;
-                      pieceEl.style.pointerEvents = prevPointerEvents;
-                      const cellEl = hitEl?.closest("[data-square]") as
-                        | HTMLElement
-                        | null;
-                      const label = cellEl?.dataset.square ?? null;
-
-                      if (!label) {
-                        // Released off-board → snap back.
-                        triggerSnapBack();
-                        return;
-                      }
-
-                      const target = parseLabel(label);
-                      const isValid = validTargets.some((t) =>
-                        arePositionsEqual(t, target),
-                      );
-
-                      if (isValid) {
-                        // Successful drop. Clear the visual offset
-                        // BEFORE the move so the piece transition starts
-                        // from the home cell (avoids a one-frame
-                        // teleport when the new center kicks in).
-                        setDragOffset(null);
-                        handleSquarePress(label);
-                      } else {
-                        triggerSnapBack();
-                      }
-                    }}
-                    onPointerCancel={() => {
-                      if (!dragStateRef.current) return;
-                      const wasActive = dragStateRef.current.active;
-                      dragStateRef.current = null;
-                      if (wasActive) triggerSnapBack();
-                      else setDragOffset(null);
-                    }}
-                  >
-                    {THEME_CONFIG.hasOptimizedFormats && (
-                      <>
-                        <source srcSet={PIECE_IMG[piece.type].replace(".png", ".avif")} type="image/avif" />
-                        <source srcSet={PIECE_IMG[piece.type].replace(".png", ".webp")} type="image/webp" />
-                      </>
-                    )}
-                    <img
-                      src={PIECE_IMG[piece.type]}
-                      alt={`White ${piece.type}`}
-                      className={PIECE_IMG_CLASS}
-                      style={{ width: "100%" }}
-                    />
-                  </picture>
-                );
-              })()}
+              {overlayLayer}
               </div>
             </div>
           </div>

--- a/apps/web/src/lib/game/__tests__/game-board.test.tsx
+++ b/apps/web/src/lib/game/__tests__/game-board.test.tsx
@@ -4,8 +4,11 @@ import {
   GameBoard,
   FILES,
   RANKS,
+  BOARD_INSET,
   isDarkSquare,
+  type BoardOverlayGeometry,
 } from "@/lib/game/game-board";
+import { cellCenter, pieceWidth } from "@/lib/game/board-geometry";
 
 describe("GameBoard (promoted procedural board)", () => {
   it("exports the 8 files and 8 ranks (top→bottom)", () => {
@@ -31,5 +34,90 @@ describe("GameBoard (promoted procedural board)", () => {
     render(<GameBoard onCellClick={onCellClick} />);
     const buttons = screen.getAllByRole("button");
     expect(buttons).toHaveLength(64);
+  });
+
+  describe("overlay layer (renderOverlay + BoardOverlayGeometry)", () => {
+    it("renders renderOverlay output inside a region inset to the frame opening", () => {
+      render(
+        <GameBoard
+          renderOverlay={() => (
+            <div data-testid="overlay-child">piece</div>
+          )}
+        />,
+      );
+      const child = screen.getByTestId("overlay-child");
+      expect(child).toBeInTheDocument();
+
+      // The overlay child must live inside a region inset to BOARD_INSET so
+      // cellCenter percentages resolve against the same area as the tiles.
+      const region = child.parentElement as HTMLElement;
+      expect(region.style.top).toBe(`${BOARD_INSET.top}%`);
+      expect(region.style.right).toBe(`${BOARD_INSET.right}%`);
+      expect(region.style.bottom).toBe(`${BOARD_INSET.bottom}%`);
+      expect(region.style.left).toBe(`${BOARD_INSET.left}%`);
+      expect(region.style.position).toBe("absolute");
+    });
+
+    it("honors a per-surface overlayInset (red-team P0 piece-drift)", () => {
+      const inset = { top: 5.25, right: 10.25, bottom: 12.75, left: 9.25 };
+      render(
+        <GameBoard
+          overlayInset={inset}
+          renderOverlay={() => <div data-testid="overlay-child" />}
+        />,
+      );
+      const region = screen.getByTestId("overlay-child").parentElement as HTMLElement;
+      expect(region.style.top).toBe(`${inset.top}%`);
+      expect(region.style.right).toBe(`${inset.right}%`);
+      expect(region.style.bottom).toBe(`${inset.bottom}%`);
+      expect(region.style.left).toBe(`${inset.left}%`);
+    });
+
+    it("exposes geometry whose center matches cellCenter (logical file 0–7, rank 1–8)", () => {
+      let captured: BoardOverlayGeometry | null = null;
+      render(
+        <GameBoard
+          renderOverlay={(geo) => {
+            captured = geo;
+            return null;
+          }}
+        />,
+      );
+      const geo = captured as unknown as BoardOverlayGeometry;
+      expect(geo).not.toBeNull();
+      expect(geo.cellSizePct).toBe(12.5);
+      expect(geo.pieceWidthPct).toBe(pieceWidth());
+
+      // center(file, rank) — rank is the chess rank (1–8). Must equal the
+      // existing cellCenter(file, rankIndex) where rankIndex = rank - 1.
+      for (const [file, rank] of [
+        [0, 1],
+        [7, 8],
+        [3, 5],
+        [4, 2],
+      ] as const) {
+        const c = geo.center(file, rank);
+        const expected = cellCenter(file, rank - 1);
+        expect(c.leftPct).toBeCloseTo(expected.x, 5);
+        expect(c.topPct).toBeCloseTo(expected.y, 5);
+      }
+    });
+
+    it("layers the overlay above the tile grid but below the candy frame", () => {
+      const { container } = render(
+        <GameBoard renderOverlay={() => <div data-testid="overlay-child" />} />,
+      );
+      const region = screen.getByTestId("overlay-child").parentElement as HTMLElement;
+      const grid = screen.getByRole("grid", { name: /chess board/i });
+      const frame = container.querySelector("img") as HTMLElement;
+      const z = (el: HTMLElement) => Number(el.style.zIndex);
+      expect(z(grid)).toBeLessThan(z(region));
+      expect(z(region)).toBeLessThan(z(frame));
+    });
+
+    it("renders no overlay region when renderOverlay is omitted", () => {
+      render(<GameBoard />);
+      expect(screen.queryByTestId("overlay-child")).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/lib/game/game-board.tsx
+++ b/apps/web/src/lib/game/game-board.tsx
@@ -161,12 +161,22 @@ export function GameBoard({
                 onClick={() => onCellClick!(col, rank, sq)}
                 aria-label={sq}
                 title={sq}
+                // Drag-to-move drop resolution walks up from elementFromPoint to
+                // the nearest [data-square]; expose it so overlay pieces resolve.
+                data-square={sq}
                 style={cellStyle}
               >
                 {content}
               </button>
             ) : (
-              <div key={sq} role="gridcell" aria-label={sq} title={sq} style={cellStyle}>
+              <div
+                key={sq}
+                role="gridcell"
+                aria-label={sq}
+                title={sq}
+                data-square={sq}
+                style={cellStyle}
+              >
                 {content}
               </div>
             );

--- a/apps/web/src/lib/game/game-board.tsx
+++ b/apps/web/src/lib/game/game-board.tsx
@@ -20,6 +20,8 @@
  */
 import type { CSSProperties, ReactNode } from "react";
 
+import { cellCenter, pieceWidth } from "@/lib/game/board-geometry";
+
 export const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
 export const RANKS = [8, 7, 6, 5, 4, 3, 2, 1]; // top → bottom
 
@@ -58,9 +60,32 @@ export function isDarkSquare(file: number, rank: number): boolean {
   return (file + (8 - rank)) % 2 === 0;
 }
 
+/** Per-surface overlay inset (red-team P0 piece-drift). The overlay region is
+ *  NOT one global inset — each surface passes its own so pieces don't drift when
+ *  its framing differs (the thumbnail inset is asymmetric today). Defaults to the
+ *  frame opening BOARD_INSET. */
+export type OverlayInset = { top: number; right: number; bottom: number; left: number };
+
+export interface BoardOverlayGeometry {
+  /** Center of a logical cell as % of the OVERLAY region. file 0–7, rank 1–8
+   *  (chess rank). Mirrors the existing `cellCenter(file, rank - 1)` contract so
+   *  pieces/floats positioned via this helper land on the same cell as today. */
+  center(file: number, rank: number): { leftPct: number; topPct: number };
+  /** Cell edge length as % of the region (uniform 12.5% grid). */
+  cellSizePct: number;
+  /** Piece width as % of the region (from board-geometry, not re-hardcoded). */
+  pieceWidthPct: number;
+}
+
 export interface GameBoardProps {
   /** Overlay content for a cell (markers, sprites). file 0–7, rank 1–8. */
   renderCell?: (file: number, rank: number, square: string) => ReactNode;
+  /** Absolute overlay layer (pieces, capture floats, select hints) positioned
+   *  via the supplied geometry against the frame-opening inset region. Renders
+   *  above the tiles, below the candy frame. */
+  renderOverlay?: (geo: BoardOverlayGeometry) => ReactNode;
+  /** Inset for the overlay region (default BOARD_INSET = frame opening). */
+  overlayInset?: OverlayInset;
   /** Click handler — when set, cells become buttons. */
   onCellClick?: (file: number, rank: number, square: string) => void;
   showCoordinates?: boolean;
@@ -72,6 +97,8 @@ export interface GameBoardProps {
 
 export function GameBoard({
   renderCell,
+  renderOverlay,
+  overlayInset = BOARD_INSET,
   onCellClick,
   showCoordinates = true,
   darkColor = "#7fb24a",
@@ -79,6 +106,16 @@ export function GameBoard({
   maxWidth = "23.5rem",
 }: GameBoardProps) {
   const clickable = !!onCellClick;
+  const overlayGeometry: BoardOverlayGeometry = {
+    // rank is the chess rank (1–8); reuse cellCenter(file, rank - 1) so pieces
+    // resolve identically to today's image-board overlay.
+    center(file, rank) {
+      const { x, y } = cellCenter(file, rank - 1);
+      return { leftPct: x, topPct: y };
+    },
+    cellSizePct: 12.5,
+    pieceWidthPct: pieceWidth(),
+  };
   return (
     <div
       style={{
@@ -137,6 +174,25 @@ export function GameBoard({
         )}
       </div>
 
+      {/* Absolute overlay layer (pieces, capture floats, select hints) — inset
+          to the same frame opening as the grid so cellCenter percentages
+          resolve identically. Above the tiles (z1), below the frame (z3). */}
+      {renderOverlay && (
+        <div
+          style={{
+            position: "absolute",
+            top: `${overlayInset.top}%`,
+            right: `${overlayInset.right}%`,
+            bottom: `${overlayInset.bottom}%`,
+            left: `${overlayInset.left}%`,
+            zIndex: 2,
+            pointerEvents: "none",
+          }}
+        >
+          {renderOverlay(overlayGeometry)}
+        </div>
+      )}
+
       {/* Candy frame — supplied PNG (transparent center), on top */}
       <picture>
         <source srcSet={`${ASSET}/borde-tablero-chesscito1.avif`} type="image/avif" />
@@ -150,7 +206,7 @@ export function GameBoard({
             inset: 0,
             width: "100%",
             height: "100%",
-            zIndex: 2,
+            zIndex: 3,
             pointerEvents: "none",
           }}
         />
@@ -181,7 +237,7 @@ export function GameBoard({
               left: `${BOARD_INSET.left + (BOARD_INNER_W * (col + 0.5)) / 8}%`,
               top: `${100 - BOARD_INSET.bottom / 2}%`,
               transform: "translate(-50%, -50%)",
-              zIndex: 3,
+              zIndex: 4,
             }}
           >
             {file}


### PR DESCRIPTION
## Board procedural-migration — Phase 1 (board.tsx)

Migrates the exercises/labyrinth board (`components/board.tsx`) onto the
procedural `<GameBoard>` substrate behind a **per-surface flag** (default OFF).
No surface passes the prop yet → production is unchanged.

### Stage 1–2 — GameBoard overlay layer (`07d59b26`)
- `renderOverlay(geo)` + `overlayInset` (default `BOARD_INSET`, per-surface to
  dodge red-team P0 piece-drift). Overlay region inset to the frame opening so
  `center(file, rank)` resolves against the same area as the tiles (mirrors
  `cellCenter(file, rank-1)`). Z-order: tiles(1) < overlay(2) < frame(3) < labels(4).
- SDD: `OverlayInset` + `BoardOverlayGeometry`. TDD: 5 tests.

### Stage 3–4 — flag board.tsx onto GameBoard (`77e5e552`)
- `proceduralBoard` prop (per-surface, default off). OFF = today's image board
  byte-identical. ON = `<GameBoard>` in the same canvas chrome.
- `renderCell` re-expresses cell state visuals (highlight/selected/endpoint/wall/
  tutorial/peones + dot/target/marker) reusing `.playhub-board-cell` CSS.
- `renderOverlay` mounts the shared overlay layer (capture marker, pickups,
  select hint, draggable piece). GameBoard cells gained `data-square` so
  drag-to-move drop resolution works.
- Overlay layer extracted once, shared verbatim between both boards (no divergence).
- TDD: 6 tests.

### Verification
- Suite **3936/3936**, `tsc` clean, eslint clean.
- Visual check at 390px on `/exercises` (temporary prop): tiles + candy frame +
  frame-band coords + pieces/highlights/drag all aligned. ✅

### Gate (not in this PR)
Flag stays OFF in merged code. Flip-on per surface is gated on **final art**
(tiles/frame are dev placeholders) + **human before/after sign-off** (founder
2026-06-17). Remaining: P2 arena (orientation), P3 thumbnail, P4 default+retire.

Wolfcito 🐾 @akawolfcito
