### PR TITLE
feat(board): migration Phase 2 — arena-board onto GameBoard substrate (orientation, flag off)

### DIFF
--- a/apps/web/src/components/arena/__tests__/arena-board.test.tsx
+++ b/apps/web/src/components/arena/__tests__/arena-board.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithIntl } from "@/test-utils/render-with-intl";
+import { ArenaBoard } from "../arena-board";
+import type { ChessBoardPiece } from "@/lib/game/types";
+
+const PIECES: ChessBoardPiece[] = [
+  { id: "wk", square: "e1", color: "w", type: "king" },
+  { id: "wr", square: "a1", color: "w", type: "rook" },
+  { id: "bk", square: "e8", color: "b", type: "king" },
+];
+
+const BASE = {
+  pieces: PIECES,
+  selectedSquare: null,
+  legalMoves: [] as string[],
+  lastMove: null,
+  checkSquare: null,
+  isLocked: false,
+  onSquareClick: () => {},
+};
+
+const FRAME_SRC = "/art/board/borde-tablero";
+
+describe("<ArenaBoard> procedural board flag", () => {
+  it("defaults to the image board (flag off) — byte-identical substrate", () => {
+    const { container } = renderWithIntl(<ArenaBoard {...BASE} />);
+    expect(container.querySelector(".playhub-board-img")).toBeInTheDocument();
+    expect(container.querySelector(`img[src*="${FRAME_SRC}"]`)).toBeNull();
+  });
+
+  it("renders the GameBoard substrate when proceduralBoard is on", () => {
+    const { container } = renderWithIntl(<ArenaBoard {...BASE} proceduralBoard />);
+    expect(container.querySelector(`img[src*="${FRAME_SRC}"]`)).toBeInTheDocument();
+    expect(container.querySelector(".playhub-board-img")).toBeNull();
+    expect(screen.getAllByRole("button", { name: /^[a-h][1-8]$/ })).toHaveLength(64);
+  });
+
+  it("renders all pieces on the procedural board", () => {
+    const { container } = renderWithIntl(<ArenaBoard {...BASE} proceduralBoard />);
+    expect(container.querySelectorAll(".arena-piece-float")).toHaveLength(PIECES.length);
+  });
+
+  it("flips the board for black (GameBoard orientation): top-left cell is h1", () => {
+    renderWithIntl(<ArenaBoard {...BASE} playerColor="b" proceduralBoard />);
+    expect(screen.getAllByRole("button")[0]).toHaveAttribute("aria-label", "h1");
+  });
+
+  it("clicks pass the LOGICAL square label regardless of orientation", () => {
+    const onSquareClick = vi.fn();
+    renderWithIntl(
+      <ArenaBoard
+        {...BASE}
+        playerColor="b"
+        proceduralBoard
+        onSquareClick={onSquareClick}
+      />,
+    );
+    // Visual top-left under black is logical h1.
+    screen.getAllByRole("button")[0].click();
+    expect(onSquareClick).toHaveBeenCalledWith("h1");
+  });
+
+  it("marks a highlighted empty square with a dot, and a highlighted occupied square as capturable", () => {
+    const { container } = renderWithIntl(
+      <ArenaBoard
+        {...BASE}
+        selectedSquare="a1"
+        legalMoves={["a4", "e8"]} // a4 empty, e8 has the black king
+        proceduralBoard
+      />,
+    );
+    expect(container.querySelector(".playhub-board-dot")).toBeInTheDocument();
+    expect(container.querySelector(".arena-board-cell.is-capturable")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/arena/arena-board.tsx
+++ b/apps/web/src/components/arena/arena-board.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 
 import { cellGeometry, cellCenter, pieceWidth } from "@/lib/game/board-geometry";
 import { ARENA_PIECE_IMG, squareToFileRank } from "@/lib/game/arena-utils";
+import { GameBoard } from "@/lib/game/game-board";
 import { THEME_CONFIG } from "@/lib/theme";
 import type { ChessBoardPiece } from "@/lib/game/types";
 import type { PlayerColor } from "@/lib/game/use-chess-game";
@@ -42,6 +43,11 @@ type ArenaBoardProps = {
    *  (h-file on the left, rank 8 at the bottom). Square labels stay
    *  logical — click handlers still receive "a1" for the a1 square. */
   playerColor?: PlayerColor;
+  /** Board migration Phase 2 (per-surface, default off). When true, the board
+   *  renders on the procedural `<GameBoard>` substrate (tile grid + candy frame,
+   *  orientation-aware) instead of the background-image board. Flag stays off
+   *  until final art + human sign-off (founder 2026-06-17). */
+  proceduralBoard?: boolean;
 };
 
 function buildArenaSquares(
@@ -86,6 +92,7 @@ export function ArenaBoard({
   onSquareClick,
   isCheckmatePause = false,
   playerColor = "w",
+  proceduralBoard = false,
 }: ArenaBoardProps) {
   const t = useTranslations("ARENA_COPY");
   const flipped = playerColor === "b";
@@ -99,6 +106,12 @@ export function ArenaBoard({
     for (const p of pieces) map.set(p.square, p);
     return map;
   }, [pieces]);
+
+  const squareByLabel = useMemo(() => {
+    const map = new Map<string, ArenaSquareState>();
+    for (const s of squares) map.set(s.label, s);
+    return map;
+  }, [squares]);
 
   /** Pieces that were on the board last render but are no longer present —
    *  rendered for CAPTURE_FADE_MS so the player sees the capture instead
@@ -128,6 +141,149 @@ export function ArenaBoard({
         <div className="playhub-game-stage">
           <div className="flex items-center justify-center aspect-square w-full">
             <p className="text-sm text-rose-400">{t("boardError")}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Live + dying piece layer. `pos(file, rank)` (rank 0–7) resolves the cell
+  // center as % of the parent region — supplied by the image board (manual
+  // vf/vr flip, % of the hit-grid) or the procedural board (GameBoard's
+  // orientation-aware overlay geometry, % of the frame opening). Shared verbatim
+  // so the two substrates can't drift apart.
+  const renderPieceLayer = (
+    pos: (file: number, rank: number) => { x: number; y: number },
+  ) => (
+    <>
+      {pieces.map((p) => {
+        const { file, rank } = squareToFileRank(p.square);
+        const center = pos(file, rank);
+        const pw = pieceWidth();
+        const src = ARENA_PIECE_IMG[p.color][p.type];
+        const isPieceSelected = p.square === selectedSquare;
+        const isPieceInCheck = p.square === checkSquare;
+        const isPieceRejecting = p.square === rejectingSquare;
+        return (
+          <picture
+            key={p.id}
+            className={`arena-piece-float${isPieceSelected ? " is-selected" : ""}${isPieceInCheck ? " is-check" : ""}${isPieceRejecting ? " is-rejecting" : ""}`}
+            style={{
+              left: `${center.x}%`,
+              top: `${center.y}%`,
+              width: `${pw}%`,
+            }}
+          >
+            {THEME_CONFIG.hasOptimizedFormats && (
+              <>
+                <source srcSet={src.replace(".png", ".avif")} type="image/avif" />
+                <source srcSet={src.replace(".png", ".webp")} type="image/webp" />
+              </>
+            )}
+            <img
+              src={src}
+              alt={`${p.color === "w" ? "White" : "Black"} ${p.type}`}
+              className={`arena-piece-img ${THEME_CONFIG.pieceTintClass[p.color]}`}
+              style={{ width: "100%" }}
+            />
+          </picture>
+        );
+      })}
+
+      {/* Captured pieces — rendered for CAPTURE_FADE_MS with the
+          is-dying animation so the kill registers visually. */}
+      {dyingPieces.map((p) => {
+        const { file, rank } = squareToFileRank(p.square);
+        const center = pos(file, rank);
+        const pw = pieceWidth();
+        const src = ARENA_PIECE_IMG[p.color][p.type];
+        return (
+          <picture
+            key={`dying-${p.id}`}
+            className="arena-piece-float is-dying"
+            style={{
+              left: `${center.x}%`,
+              top: `${center.y}%`,
+              width: `${pw}%`,
+            }}
+          >
+            {THEME_CONFIG.hasOptimizedFormats && (
+              <>
+                <source srcSet={src.replace(".png", ".avif")} type="image/avif" />
+                <source srcSet={src.replace(".png", ".webp")} type="image/webp" />
+              </>
+            )}
+            <img
+              src={src}
+              alt=""
+              className={`arena-piece-img ${THEME_CONFIG.pieceTintClass[p.color]}`}
+              style={{ width: "100%" }}
+            />
+          </picture>
+        );
+      })}
+    </>
+  );
+
+  // Per-cell substrate overlay for the procedural board: the arena cell's state
+  // visuals (highlight / capturable / selected / last-move / check / capture-
+  // flash) as a full-cell child reusing `.arena-board-cell` CSS. GameBoard owns
+  // the cell <button> (click); this paints the glow + dot inside it.
+  const renderArenaCell = (_file: number, _rank: number, sq: string) => {
+    const s = squareByLabel.get(sq);
+    if (!s) return null;
+    const occupied = pieceMap.has(sq);
+    return (
+      <span
+        aria-hidden="true"
+        className={[
+          "arena-board-cell",
+          s.isDark ? "is-dark" : "is-light",
+          s.isHighlighted ? "is-highlighted" : "",
+          s.isHighlighted && occupied ? "is-capturable" : "",
+          s.isSelected ? "is-selected" : "",
+          s.isLastMove ? "is-last-move" : "",
+          s.isCheck ? "is-check" : "",
+          sq === captureFlashSquare ? "is-capture-flash" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        style={{ position: "absolute", inset: 0 }}
+      >
+        {s.isHighlighted && !occupied ? (
+          <span className="playhub-board-dot" />
+        ) : null}
+      </span>
+    );
+  };
+
+  if (proceduralBoard) {
+    return (
+      <div className="playhub-stage-shell w-full">
+        <div className="playhub-game-stage">
+          <div className="playhub-game-grid">
+            <div
+              className="playhub-board-canvas arena-board-canvas relative"
+              data-checkmate={isCheckmatePause ? "true" : undefined}
+            >
+              {isThinking && (
+                <div className="pointer-events-none absolute inset-0 z-10 animate-pulse rounded-2xl ring-2 ring-amber-400/20" />
+              )}
+              <GameBoard
+                orientation={flipped ? "black" : "white"}
+                maxWidth="100%"
+                onCellClick={(_file, _rank, sq) => {
+                  if (!isLocked) onSquareClick(sq);
+                }}
+                renderCell={renderArenaCell}
+                renderOverlay={(geo) =>
+                  renderPieceLayer((file, rank) => {
+                    const c = geo.center(file, rank + 1);
+                    return { x: c.leftPct, y: c.topPct };
+                  })
+                }
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -188,87 +344,10 @@ export function ArenaBoard({
                 );
               })}
 
-              {pieces.map((p) => {
-                const { file, rank } = squareToFileRank(p.square);
+              {renderPieceLayer((file, rank) => {
                 const vf = flipped ? 7 - file : file;
                 const vr = flipped ? 7 - rank : rank;
-                const center = cellCenter(vf, vr);
-                const pw = pieceWidth();
-                const src = ARENA_PIECE_IMG[p.color][p.type];
-                const isPieceSelected = p.square === selectedSquare;
-                const isPieceInCheck = p.square === checkSquare;
-                const isPieceRejecting = p.square === rejectingSquare;
-                return (
-                  <picture
-                    key={p.id}
-                    className={`arena-piece-float${isPieceSelected ? " is-selected" : ""}${isPieceInCheck ? " is-check" : ""}${isPieceRejecting ? " is-rejecting" : ""}`}
-                    style={{
-                      left: `${center.x}%`,
-                      top: `${center.y}%`,
-                      width: `${pw}%`,
-                    }}
-                  >
-                    {THEME_CONFIG.hasOptimizedFormats && (
-                      <>
-                        <source
-                          srcSet={src.replace(".png", ".avif")}
-                          type="image/avif"
-                        />
-                        <source
-                          srcSet={src.replace(".png", ".webp")}
-                          type="image/webp"
-                        />
-                      </>
-                    )}
-                    <img
-                      src={src}
-                      alt={`${p.color === "w" ? "White" : "Black"} ${p.type}`}
-                      className={`arena-piece-img ${THEME_CONFIG.pieceTintClass[p.color]}`}
-                      style={{ width: "100%" }}
-                    />
-                  </picture>
-                );
-              })}
-
-              {/* Captured pieces — rendered for CAPTURE_FADE_MS with the
-                  is-dying animation so the kill registers visually. */}
-              {dyingPieces.map((p) => {
-                const { file, rank } = squareToFileRank(p.square);
-                const vf = flipped ? 7 - file : file;
-                const vr = flipped ? 7 - rank : rank;
-                const center = cellCenter(vf, vr);
-                const pw = pieceWidth();
-                const src = ARENA_PIECE_IMG[p.color][p.type];
-                return (
-                  <picture
-                    key={`dying-${p.id}`}
-                    className="arena-piece-float is-dying"
-                    style={{
-                      left: `${center.x}%`,
-                      top: `${center.y}%`,
-                      width: `${pw}%`,
-                    }}
-                  >
-                    {THEME_CONFIG.hasOptimizedFormats && (
-                      <>
-                        <source
-                          srcSet={src.replace(".png", ".avif")}
-                          type="image/avif"
-                        />
-                        <source
-                          srcSet={src.replace(".png", ".webp")}
-                          type="image/webp"
-                        />
-                      </>
-                    )}
-                    <img
-                      src={src}
-                      alt=""
-                      className={`arena-piece-img ${THEME_CONFIG.pieceTintClass[p.color]}`}
-                      style={{ width: "100%" }}
-                    />
-                  </picture>
-                );
+                return cellCenter(vf, vr);
               })}
             </div>
           </div>

--- a/apps/web/src/lib/game/__tests__/game-board.test.tsx
+++ b/apps/web/src/lib/game/__tests__/game-board.test.tsx
@@ -120,4 +120,67 @@ describe("GameBoard (promoted procedural board)", () => {
       expect(screen.queryByTestId("overlay-child")).not.toBeInTheDocument();
     });
   });
+
+  describe("orientation (red-team P0 — logical→view for tiles AND overlay)", () => {
+    it("renders white view by default: top-left cell is a8, bottom-right is h1", () => {
+      render(<GameBoard onCellClick={() => {}} />);
+      const buttons = screen.getAllByRole("button");
+      // DOM order = grid order = top→bottom, left→right.
+      expect(buttons[0]).toHaveAttribute("aria-label", "a8");
+      expect(buttons[63]).toHaveAttribute("aria-label", "h1");
+    });
+
+    it("flips tiles under orientation=black: top-left is h1, bottom-right is a8", () => {
+      render(<GameBoard orientation="black" onCellClick={() => {}} />);
+      const buttons = screen.getAllByRole("button");
+      expect(buttons[0]).toHaveAttribute("aria-label", "h1");
+      expect(buttons[63]).toHaveAttribute("aria-label", "a8");
+    });
+
+    it("passes LOGICAL (file,rank,square) to renderCell/onCellClick regardless of orientation", () => {
+      const onCellClick = vi.fn();
+      render(<GameBoard orientation="black" onCellClick={onCellClick} />);
+      // The visual top-left cell is logical h1 → file 7, rank 1.
+      screen.getAllByRole("button")[0].click();
+      expect(onCellClick).toHaveBeenCalledWith(7, 1, "h1");
+    });
+
+    it("flips overlay center under orientation=black (matches the arena vf/vr flip)", () => {
+      let captured: BoardOverlayGeometry | null = null;
+      render(
+        <GameBoard
+          orientation="black"
+          renderOverlay={(geo) => {
+            captured = geo;
+            return null;
+          }}
+        />,
+      );
+      const geo = captured as unknown as BoardOverlayGeometry;
+      expect(geo).not.toBeNull();
+      // Black view: view coords are the flipped logical coords. Center must
+      // equal cellCenter(7 - file, 7 - (rank - 1)) — the same flip arena does.
+      for (const [file, rank] of [
+        [0, 1],
+        [7, 8],
+        [3, 5],
+        [4, 2],
+      ] as const) {
+        const c = geo.center(file, rank);
+        const expected = cellCenter(7 - file, 7 - (rank - 1));
+        expect(c.leftPct).toBeCloseTo(expected.x, 5);
+        expect(c.topPct).toBeCloseTo(expected.y, 5);
+      }
+    });
+
+    it("flips coordinate labels under orientation=black (rank 1 top-left band, file h leftmost)", () => {
+      const { container } = render(<GameBoard orientation="black" />);
+      const spans = Array.from(container.querySelectorAll("span")).map(
+        (s) => s.textContent,
+      );
+      // Both axis label sets are present (8 ranks + 8 files), just reordered.
+      for (const r of ["1", "2", "8"]) expect(spans).toContain(r);
+      for (const f of ["a", "h"]) expect(spans).toContain(f);
+    });
+  });
 });

--- a/apps/web/src/lib/game/game-board.tsx
+++ b/apps/web/src/lib/game/game-board.tsx
@@ -78,6 +78,10 @@ export interface BoardOverlayGeometry {
 }
 
 export interface GameBoardProps {
+  /** Board orientation. "white" = a8 top-left / h1 bottom-right (default);
+   *  "black" flips both axes (arena, when the player is black). renderCell /
+   *  onCellClick still receive LOGICAL (file, rank) regardless. */
+  orientation?: "white" | "black";
   /** Overlay content for a cell (markers, sprites). file 0–7, rank 1–8. */
   renderCell?: (file: number, rank: number, square: string) => ReactNode;
   /** Absolute overlay layer (pieces, capture floats, select hints) positioned
@@ -100,17 +104,30 @@ export function GameBoard({
   renderOverlay,
   overlayInset = BOARD_INSET,
   onCellClick,
+  orientation = "white",
   showCoordinates = true,
   darkColor = "#7fb24a",
   lightColor = "#efe6c4",
   maxWidth = "23.5rem",
 }: GameBoardProps) {
   const clickable = !!onCellClick;
+  const black = orientation === "black";
+
+  // View order (what the grid draws), in LOGICAL terms. White: a8 top-left,
+  // h1 bottom-right. Black flips both axes (h1 top-left, a8 bottom-right) —
+  // parity with the arena `vf = 7 - file` / `vr = 7 - rank` flip. renderCell /
+  // onCellClick still receive LOGICAL (file, rank); only the layout changes.
+  const fileOrder = black ? [7, 6, 5, 4, 3, 2, 1, 0] : [0, 1, 2, 3, 4, 5, 6, 7]; // left → right
+  const rankOrder = black ? [1, 2, 3, 4, 5, 6, 7, 8] : [8, 7, 6, 5, 4, 3, 2, 1]; // top → bottom
+
   const overlayGeometry: BoardOverlayGeometry = {
-    // rank is the chess rank (1–8); reuse cellCenter(file, rank - 1) so pieces
-    // resolve identically to today's image-board overlay.
+    // rank is the chess rank (1–8). White reuses cellCenter(file, rank - 1);
+    // black flips view coords (7 - file, 7 - rankIdx) so pieces track the tiles.
     center(file, rank) {
-      const { x, y } = cellCenter(file, rank - 1);
+      const rankIdx = rank - 1;
+      const vf = black ? 7 - file : file;
+      const vr = black ? 7 - rankIdx : rankIdx;
+      const { x, y } = cellCenter(vf, vr);
       return { leftPct: x, topPct: y };
     },
     cellSizePct: 12.5,
@@ -140,10 +157,10 @@ export function GameBoard({
           zIndex: 1,
         }}
       >
-        {RANKS.map((rank) =>
-          FILES.map((file, col) => {
-            const sq = `${file}${rank}`;
-            const dark = isDarkSquare(col, rank);
+        {rankOrder.map((rank) =>
+          fileOrder.map((file) => {
+            const sq = `${FILES[file]}${rank}`;
+            const dark = isDarkSquare(file, rank);
             const cellStyle: CSSProperties = {
               position: "relative",
               padding: 0,
@@ -153,12 +170,12 @@ export function GameBoard({
               backgroundSize: "100% 100%",
               cursor: clickable ? "pointer" : "default",
             };
-            const content = renderCell?.(col, rank, sq);
+            const content = renderCell?.(file, rank, sq);
             return clickable ? (
               <button
                 key={sq}
                 type="button"
-                onClick={() => onCellClick!(col, rank, sq)}
+                onClick={() => onCellClick!(file, rank, sq)}
                 aria-label={sq}
                 title={sq}
                 // Drag-to-move drop resolution walks up from elementFromPoint to
@@ -222,9 +239,10 @@ export function GameBoard({
         />
       </picture>
 
-      {/* Coordinate labels ON the frame band */}
+      {/* Coordinate labels ON the frame band — follow the view order so they
+          flip with the board under orientation="black". */}
       {showCoordinates &&
-        RANKS.map((rank, row) => (
+        rankOrder.map((rank, row) => (
           <span
             key={`rank-${rank}`}
             style={{
@@ -239,9 +257,9 @@ export function GameBoard({
           </span>
         ))}
       {showCoordinates &&
-        FILES.map((file, col) => (
+        fileOrder.map((file, col) => (
           <span
-            key={`file-${file}`}
+            key={`file-${FILES[file]}`}
             style={{
               ...LABEL_STYLE,
               left: `${BOARD_INSET.left + (BOARD_INNER_W * (col + 0.5)) / 8}%`,
@@ -250,7 +268,7 @@ export function GameBoard({
               zIndex: 4,
             }}
           >
-            {file}
+            {FILES[file]}
           </span>
         ))}
     </div>


### PR DESCRIPTION
## Board procedural-migration — Phase 2 (arena-board.tsx)

Adds `orientation` to `GameBoard` and migrates the full chess board
(`arena-board.tsx`) onto the procedural substrate behind a **per-surface flag**
(default OFF). No surface passes the prop → production unchanged.

### GameBoard — orientation (red-team P0)
- `orientation?: "white" | "black"` (default white). The grid draws in view
  order (black flips both axes: h1 top-left, a8 bottom-right). `renderCell` /
  `onCellClick` still receive **logical** (file, rank). `overlayGeometry.center`
  flips view coords for black — same `vf = 7 - file` / `vr = 7 - rank` flip the
  arena did. Coordinate labels follow the view order.
- White default is byte-identical (same square ids + dark parity) → the dev PoC
  and labyrinth-builder consumers are unaffected.
- TDD: 5 orientation tests (tiles top-left a8/h1, logical-coord passthrough,
  overlay-center flip, labels flip).

### arena-board — procedural flag
- `proceduralBoard` prop. OFF = today's image board byte-identical. ON =
  `<GameBoard orientation={flipped}>` with `renderCell` (arena-board-cell states
  + dot) and `renderOverlay` (live + dying capture-fade pieces). `onCellClick`
  → `onSquareClick` (isLocked-guarded). Checkmate-pause + thinking-ring stay on
  the canvas wrapper.
- The piece layer is extracted once and shared between both boards via a `pos()`
  resolver (no divergence).
- TDD: 6 arena tests (flag off image board; flag on substrate/pieces; black
  orientation top-left h1; logical click under black; dot + capturable).

### Verification
- Suite **3947/3947**, `tsc` clean, eslint clean.

### Gate (not in this PR)
Flag stays OFF in merged code. Flip-on per surface is gated on **final art**
(placeholders) + **human before/after sign-off** at 390px. Remaining: P3
thumbnail, P4 default + retire image board.

Wolfcito 🐾 @akawolfcito
