### PR TITLE
fix(board): pieces above frame (z-order) + arena board fits without clip

### DIFF
--- a/apps/web/src/components/arena/arena-board.tsx
+++ b/apps/web/src/components/arena/arena-board.tsx
@@ -265,6 +265,18 @@ export function ArenaBoard({
             <div
               className="playhub-board-canvas arena-board-canvas relative"
               data-checkmate={isCheckmatePause ? "true" : undefined}
+              // GameBoard is a rigid square; unlike the image board it can't
+              // squish to a height-clamped rectangle. Size the canvas to the
+              // SMALLER of the available width and height so the board stays
+              // square AND never overflows `.playhub-game-stage` (overflow:hidden
+              // would clip rank 8 / rank 1). Mirrors the image board's
+              // `calc(100dvh - 22rem)` chrome budget.
+              style={{
+                width: "min(100%, 23.5rem, calc(100dvh - 22rem))",
+                aspectRatio: "1 / 1",
+                maxHeight: "none",
+                margin: "0 auto",
+              }}
             >
               {isThinking && (
                 <div className="pointer-events-none absolute inset-0 z-10 animate-pulse rounded-2xl ring-2 ring-amber-400/20" />

--- a/apps/web/src/lib/game/__tests__/game-board.test.tsx
+++ b/apps/web/src/lib/game/__tests__/game-board.test.tsx
@@ -103,7 +103,7 @@ describe("GameBoard (promoted procedural board)", () => {
       }
     });
 
-    it("layers the overlay above the tile grid but below the candy frame", () => {
+    it("layers the overlay above the tile grid AND the candy frame (pieces never clipped by the border)", () => {
       const { container } = render(
         <GameBoard renderOverlay={() => <div data-testid="overlay-child" />} />,
       );
@@ -111,8 +111,8 @@ describe("GameBoard (promoted procedural board)", () => {
       const grid = screen.getByRole("grid", { name: /chess board/i });
       const frame = container.querySelector("img") as HTMLElement;
       const z = (el: HTMLElement) => Number(el.style.zIndex);
-      expect(z(grid)).toBeLessThan(z(region));
-      expect(z(region)).toBeLessThan(z(frame));
+      expect(z(grid)).toBeLessThan(z(frame));
+      expect(z(frame)).toBeLessThan(z(region));
     });
 
     it("renders no overlay region when renderOverlay is omitted", () => {

--- a/apps/web/src/lib/game/game-board.tsx
+++ b/apps/web/src/lib/game/game-board.tsx
@@ -201,26 +201,10 @@ export function GameBoard({
         )}
       </div>
 
-      {/* Absolute overlay layer (pieces, capture floats, select hints) — inset
-          to the same frame opening as the grid so cellCenter percentages
-          resolve identically. Above the tiles (z1), below the frame (z3). */}
-      {renderOverlay && (
-        <div
-          style={{
-            position: "absolute",
-            top: `${overlayInset.top}%`,
-            right: `${overlayInset.right}%`,
-            bottom: `${overlayInset.bottom}%`,
-            left: `${overlayInset.left}%`,
-            zIndex: 2,
-            pointerEvents: "none",
-          }}
-        >
-          {renderOverlay(overlayGeometry)}
-        </div>
-      )}
-
-      {/* Candy frame — supplied PNG (transparent center), on top */}
+      {/* Candy frame — supplied PNG (transparent center). Sits ABOVE the tiles
+          (z1) but BELOW the overlay pieces (z4), mirroring the old image board
+          where pieces painted on top of the (baked-in) frame — so a piece on an
+          edge rank/file overhangs the border instead of being clipped by it. */}
       <picture>
         <source srcSet={`${ASSET}/borde-tablero-chesscito1.avif`} type="image/avif" />
         <source srcSet={`${ASSET}/borde-tablero-chesscito1.webp`} type="image/webp" />
@@ -233,11 +217,31 @@ export function GameBoard({
             inset: 0,
             width: "100%",
             height: "100%",
-            zIndex: 3,
+            zIndex: 2,
             pointerEvents: "none",
           }}
         />
       </picture>
+
+      {/* Absolute overlay layer (pieces, capture floats, select hints) — inset
+          to the same frame opening as the grid so cellCenter percentages
+          resolve identically. ABOVE the tiles, frame, and labels (z4) so pieces
+          are never clipped by the border. */}
+      {renderOverlay && (
+        <div
+          style={{
+            position: "absolute",
+            top: `${overlayInset.top}%`,
+            right: `${overlayInset.right}%`,
+            bottom: `${overlayInset.bottom}%`,
+            left: `${overlayInset.left}%`,
+            zIndex: 4,
+            pointerEvents: "none",
+          }}
+        >
+          {renderOverlay(overlayGeometry)}
+        </div>
+      )}
 
       {/* Coordinate labels ON the frame band — follow the view order so they
           flip with the board under orientation="black". */}
@@ -265,7 +269,7 @@ export function GameBoard({
               left: `${BOARD_INSET.left + (BOARD_INNER_W * (col + 0.5)) / 8}%`,
               top: `${100 - BOARD_INSET.bottom / 2}%`,
               transform: "translate(-50%, -50%)",
-              zIndex: 4,
+              zIndex: 3,
             }}
           >
             {FILES[file]}


### PR DESCRIPTION
Two findings from the human visual sign-off at 390px (board migration P1/P2):

1. **Pieces clipped by the candy frame** — GameBoard layered the frame above the overlay; the old image board had pieces on top of the (baked-in) frame. Reorder z to tiles(1) < frame(2) < labels(3) < pieces(4).
2. **Arena board overflowed / clipped top+bottom** — GameBoard is a rigid square and can't squish to a height-clamped rectangle, so it overflowed `.playhub-game-stage` (overflow:hidden). Size the arena canvas to `min(100%, 23.5rem, calc(100dvh - 22rem))` so it stays square AND fits. No chrome reduction needed.

Suite 3947/3947, tsc + eslint clean. Flags still off (gated on final art + sign-off).

Wolfcito 🐾 @akawolfcito