### PR TITLE
fix(board): procedural tiles render texture (image-set was invalid CSS)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2698,6 +2698,46 @@
     box-shadow: none;
   }
 
+  /* Procedural board tiles (GameBoard). The textured square art is referenced
+     via the dual `-webkit-image-set` + `image-set` pattern (same as `.is-wall`)
+     because an inline React `background-image` can only hold ONE value — it
+     can't carry both the prefixed and unprefixed forms, and a bare
+     `url() type()` list (no `image-set(...)` wrapper) is invalid CSS, which is
+     why the tiles previously fell back to the flat fill. The cell's inline
+     `background-color` stays as the load/fallback tint. */
+  .game-board-tile-light,
+  .game-board-tile-dark {
+    background-size: 100% 100%;
+    background-position: center;
+  }
+
+  .game-board-tile-light {
+    background-image: url("/art/board/casilla-clara.png");
+    background-image: -webkit-image-set(
+      url("/art/board/casilla-clara.avif") type("image/avif"),
+      url("/art/board/casilla-clara.webp") type("image/webp"),
+      url("/art/board/casilla-clara.png") type("image/png")
+    );
+    background-image: image-set(
+      url("/art/board/casilla-clara.avif") type("image/avif"),
+      url("/art/board/casilla-clara.webp") type("image/webp"),
+      url("/art/board/casilla-clara.png") type("image/png")
+    );
+  }
+
+  .game-board-tile-dark {
+    background-image: url("/art/board/casilla-oscura.png");
+    background-image: -webkit-image-set(
+      url("/art/board/casilla-oscura.avif") type("image/avif"),
+      url("/art/board/casilla-oscura.webp") type("image/webp"),
+      url("/art/board/casilla-oscura.png") type("image/png")
+    );
+    background-image: image-set(
+      url("/art/board/casilla-oscura.avif") type("image/avif"),
+      url("/art/board/casilla-oscura.webp") type("image/webp"),
+      url("/art/board/casilla-oscura.png") type("image/png")
+    );
+  }
 
   .playhub-board-cell {
     position: absolute;

--- a/apps/web/src/lib/game/game-board.tsx
+++ b/apps/web/src/lib/game/game-board.tsx
@@ -32,17 +32,6 @@ export const BOARD_INNER_H = 100 - BOARD_INSET.top - BOARD_INSET.bottom; // 92.6
 
 const ASSET = "/art/board";
 
-/** One cached image-set per tile color (avif → webp → png), not 64 requests. */
-function tileImageSet(name: string): string {
-  return [
-    `url("${ASSET}/${name}.avif") type("image/avif")`,
-    `url("${ASSET}/${name}.webp") type("image/webp")`,
-    `url("${ASSET}/${name}.png") type("image/png")`,
-  ].join(", ");
-}
-const TILE_LIGHT = tileImageSet("casilla-clara");
-const TILE_DARK = tileImageSet("casilla-oscura");
-
 const LABEL_STYLE: CSSProperties = {
   position: "absolute",
   fontSize: "1rem",
@@ -161,13 +150,15 @@ export function GameBoard({
           fileOrder.map((file) => {
             const sq = `${FILES[file]}${rank}`;
             const dark = isDarkSquare(file, rank);
+            // Texture comes from `.game-board-tile-{light,dark}` (dual image-set
+            // in CSS — inline can't carry the -webkit- + unprefixed pair). The
+            // inline background-color is the load/fallback tint underneath.
+            const tileClass = dark ? "game-board-tile-dark" : "game-board-tile-light";
             const cellStyle: CSSProperties = {
               position: "relative",
               padding: 0,
               border: "none",
               backgroundColor: dark ? darkColor : lightColor,
-              backgroundImage: dark ? TILE_DARK : TILE_LIGHT,
-              backgroundSize: "100% 100%",
               cursor: clickable ? "pointer" : "default",
             };
             const content = renderCell?.(file, rank, sq);
@@ -180,6 +171,7 @@ export function GameBoard({
                 key={sq}
                 type="button"
                 role="gridcell"
+                className={tileClass}
                 onClick={() => onCellClick!(file, rank, sq)}
                 aria-label={cellLabel}
                 title={sq}
@@ -194,6 +186,7 @@ export function GameBoard({
               <div
                 key={sq}
                 role="gridcell"
+                className={tileClass}
                 aria-label={cellLabel}
                 title={sq}
                 data-square={sq}


### PR DESCRIPTION
GameBoard set the cell `background-image` to a bare `url() type(), …` list with NO `image-set(...)` wrapper → invalid CSS → tiles fell back to the flat `background-color` (texture never showed). Latent since Phase 0.

Move tile art to `.game-board-tile-{light,dark}` CSS classes with the dual `-webkit-image-set` + `image-set` declaration (same as `.is-wall`), robust on WebKit/MiniPay; inline `background-color` stays as fallback tint.

VR baselines refreshed (hub-clean + hub-daily-tactic, minipay + desktop) — tiles now show texture. tsc + game-board tests green.

Wolfcito 🐾 @akawolfcito