### PR TITLE
feat(content): staging model slice 1 — stage types + pure helpers

### DIFF
--- a/apps/web/src/app/api/admin/content/route.ts
+++ b/apps/web/src/app/api/admin/content/route.ts
@@ -108,6 +108,9 @@ export async function POST(request: Request) {
     disabled: Boolean(record.disabled),
     optimal_moves: built.optimalMoves,
     updated_at,
+    // Save always lands at `draft` (content-staging-model Behavior 1); promotion
+    // is a separate step on /api/admin/content/stage.
+    stage: "draft",
   };
 
   const supabase = getSupabaseServer();

--- a/apps/web/src/lib/content/__tests__/merged-catalog.test.ts
+++ b/apps/web/src/lib/content/__tests__/merged-catalog.test.ts
@@ -45,6 +45,7 @@ function row(over: Partial<ContentOverlayRow> = {}): ContentOverlayRow {
     disabled: false,
     optimal_moves: 1, // a1 → a8 (or h1) is one rook move
     updated_at: "2026-06-17T00:00:00Z",
+    stage: "published",
     ...over,
   };
 }

--- a/apps/web/src/lib/content/__tests__/stage.test.ts
+++ b/apps/web/src/lib/content/__tests__/stage.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  visibleStages,
+  envStageFloor,
+  resolveVisibleRows,
+} from "../stage";
+import type { ContentOverlayRow, ContentStage } from "../overlay-types";
+
+describe("visibleStages — the maturity ladder", () => {
+  it("draft floor sees all three stages", () => {
+    expect(visibleStages("draft")).toEqual(["draft", "preview", "published"]);
+  });
+
+  it("preview floor sees preview + published (not draft)", () => {
+    expect(visibleStages("preview")).toEqual(["preview", "published"]);
+  });
+
+  it("published floor sees only published", () => {
+    expect(visibleStages("published")).toEqual(["published"]);
+  });
+});
+
+describe("envStageFloor — reads CONTENT_STAGE (kill-switch on unset/invalid)", () => {
+  const original = process.env.CONTENT_STAGE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.CONTENT_STAGE;
+    else process.env.CONTENT_STAGE = original;
+  });
+
+  it("returns the valid stage", () => {
+    process.env.CONTENT_STAGE = "preview";
+    expect(envStageFloor()).toBe("preview");
+  });
+
+  it("returns null when unset (→ baseline-only kill-switch)", () => {
+    delete process.env.CONTENT_STAGE;
+    expect(envStageFloor()).toBeNull();
+  });
+
+  it("returns null on an invalid value", () => {
+    process.env.CONTENT_STAGE = "prod"; // typo
+    expect(envStageFloor()).toBeNull();
+  });
+});
+
+describe("resolveVisibleRows — one row per id (freshest that reached this env)", () => {
+  const mk = (
+    id: string,
+    stage: ContentStage,
+    extra: Partial<ContentOverlayRow> = {},
+  ): ContentOverlayRow => ({
+    id,
+    kind: "exercise",
+    piece: "rook",
+    fen: "8/8/8/8/8/8/8/R7 w - - 0 1",
+    target: "a8",
+    mover: "a1",
+    tier: "easy",
+    tags: null,
+    explanation: null,
+    order: 0,
+    disabled: false,
+    optimal_moves: 1,
+    updated_at: "2026-06-17T00:00:00Z",
+    stage,
+    ...extra,
+  });
+
+  it("dev (draft floor) picks the draft over the live published of the same id", () => {
+    const rows = [mk("x", "published"), mk("x", "draft")];
+    const out = resolveVisibleRows(rows, "draft");
+    expect(out).toHaveLength(1);
+    expect(out[0].stage).toBe("draft");
+  });
+
+  it("prod (published floor) only ever resolves the published row", () => {
+    const rows = [mk("x", "published"), mk("x", "draft")];
+    const out = resolveVisibleRows(rows, "published");
+    expect(out).toHaveLength(1);
+    expect(out[0].stage).toBe("published");
+  });
+
+  it("preview (preview floor) ignores the draft and shows the published when no preview exists", () => {
+    const rows = [mk("x", "published"), mk("x", "draft")];
+    const out = resolveVisibleRows(rows, "preview");
+    expect(out).toHaveLength(1);
+    expect(out[0].stage).toBe("published");
+  });
+
+  it("preview picks the preview row over published for the same id", () => {
+    const rows = [mk("x", "published"), mk("x", "preview")];
+    const out = resolveVisibleRows(rows, "preview");
+    expect(out[0].stage).toBe("preview");
+  });
+
+  it("a draft-only new puzzle does NOT leak to preview or prod", () => {
+    const rows = [mk("new", "draft")];
+    expect(resolveVisibleRows(rows, "preview")).toHaveLength(0);
+    expect(resolveVisibleRows(rows, "published")).toHaveLength(0);
+    expect(resolveVisibleRows(rows, "draft")).toHaveLength(1);
+  });
+
+  it("keeps distinct ids independent", () => {
+    const rows = [mk("a", "published"), mk("b", "draft")];
+    const out = resolveVisibleRows(rows, "draft");
+    expect(out.map((r) => r.id).sort()).toEqual(["a", "b"]);
+  });
+});

--- a/apps/web/src/lib/content/overlay-types.ts
+++ b/apps/web/src/lib/content/overlay-types.ts
@@ -11,6 +11,20 @@ import type { Exercise, ExerciseTier, PieceId } from "@/lib/game/types";
 
 export type ContentKind = "exercise" | "labyrinth";
 
+/**
+ * Content maturity ladder (content-staging-model). Lower rank = less mature
+ * (closer to "being edited"). A puzzle can hold one version per stage, e.g. a
+ * live `published` + an in-progress `draft` of the same id.
+ */
+export type ContentStage = "draft" | "preview" | "published";
+
+/** Total order for the visibility ladder. */
+export const STAGE_RANK: Record<ContentStage, number> = {
+  draft: 0,
+  preview: 1,
+  published: 2,
+};
+
 /** The compiled baseline catalog shape (mirrors the generated module). Input to
  *  the overlay merge; also the fallback when the overlay is unavailable. */
 export interface BaselineCatalog {
@@ -52,6 +66,8 @@ export interface ContentOverlayRow {
   optimal_moves: number;
   /** ISO timestamp; audit + cache-key hint. Server-assigned on upsert. */
   updated_at: string;
+  /** Maturity of THIS version. Part of the PK `(kind, id, stage)`. */
+  stage: ContentStage;
 }
 
 /**
@@ -61,9 +77,27 @@ export interface ContentOverlayRow {
  */
 export interface ContentWriteRequest {
   kind: ContentKind;
-  record: Omit<ContentOverlayRow, "optimal_moves" | "updated_at">;
+  /** Save always lands at `draft`; the server assigns stage, so the client never
+   *  supplies it (nor the BFS-derived / audit fields). */
+  record: Omit<ContentOverlayRow, "optimal_moves" | "updated_at" | "stage">;
 }
 
 export type ContentWriteResult =
   | { ok: true; saved: ContentOverlayRow; revalidated: boolean }
+  | { ok: false; errors: string[] };
+
+/**
+ * Promote (from < to) or demote (from > to) one puzzle version. Moves the
+ * `from`-stage row to `to`, replacing + superseding anything at stage-rank ≤ `to`
+ * for that id (content-staging-model Behavior 4). Runs as one transaction.
+ */
+export interface ContentStageRequest {
+  kind: ContentKind;
+  id: string;
+  from: ContentStage;
+  to: ContentStage;
+}
+
+export type ContentStageResult =
+  | { ok: true; from: ContentStage; to: ContentStage }
   | { ok: false; errors: string[] };

--- a/apps/web/src/lib/content/stage.ts
+++ b/apps/web/src/lib/content/stage.ts
@@ -1,0 +1,55 @@
+/**
+ * content-staging-model — pure stage helpers (no DB, no React).
+ *
+ * Each deployment has a `CONTENT_STAGE` maturity floor (the minimum maturity it
+ * displays); `CONTENT_STAGE` replaces the old on/off `CONTENT_OVERLAY_ENABLED`
+ * flag. With it unset/invalid the read path serves baseline-only (kill-switch).
+ *
+ * Two-version model: a puzzle id may hold one row per stage (a live `published`
+ * + an in-progress `draft`). `resolveVisibleRows` collapses the rows an env can
+ * see to ONE per id — the freshest version that has reached this env.
+ */
+import { STAGE_RANK, type ContentOverlayRow, type ContentStage } from "./overlay-types";
+
+const STAGES: ContentStage[] = ["draft", "preview", "published"]; // rank-ascending
+
+/** Stages an env at `floor` displays: the floor and everything above it. */
+export function visibleStages(floor: ContentStage): ContentStage[] {
+  return STAGES.filter((s) => STAGE_RANK[s] >= STAGE_RANK[floor]);
+}
+
+/** The maturity floor this deployment displays, from `CONTENT_STAGE`. Returns
+ *  null when unset or invalid → the read path serves baseline-only. */
+export function envStageFloor(): ContentStage | null {
+  const value = process.env.CONTENT_STAGE;
+  if (value === "draft" || value === "preview" || value === "published") {
+    return value;
+  }
+  if (value) {
+    // Loud signal: a typo here silently drops ALL overlay content on this env.
+    console.warn(`[content-stage] invalid CONTENT_STAGE="${value}" → baseline-only`);
+  }
+  return null;
+}
+
+/**
+ * Collapse overlay rows to ONE per (kind,id) for an env at `floor`: among the
+ * rows that have reached this env (stage-rank ≥ floor), the freshest (LOWEST
+ * stage-rank). Rows below the floor are invisible (a draft never leaks to prod).
+ */
+export function resolveVisibleRows(
+  rows: ContentOverlayRow[],
+  floor: ContentStage,
+): ContentOverlayRow[] {
+  const floorRank = STAGE_RANK[floor];
+  const best = new Map<string, ContentOverlayRow>();
+  for (const row of rows) {
+    if (STAGE_RANK[row.stage] < floorRank) continue; // too immature for this env
+    const key = `${row.kind}:${row.id}`;
+    const current = best.get(key);
+    if (!current || STAGE_RANK[row.stage] < STAGE_RANK[current.stage]) {
+      best.set(key, row);
+    }
+  }
+  return [...best.values()];
+}


### PR DESCRIPTION
First slice of content-staging-model. Pure layer (no read-path/DB wiring yet).

SDD: `ContentStage` + `STAGE_RANK`, `stage` field on `ContentOverlayRow`, `ContentStageRequest`/`ContentStageResult`, write request omits stage.
TDD (stage.ts, 12 tests): `visibleStages` (ladder), `envStageFloor` (kill-switch on unset/invalid), `resolveVisibleRows` (two-version: freshest-per-id ≥ floor; draft never leaks to preview/prod).
EDD: write route sets `stage:'draft'` on Save.

Suite 3963/3963, tsc + eslint clean.

Wolfcito 🐾 @akawolfcito