### PR TITLE
feat(content): staging model slice 4 — promote/demote route

### DIFF
--- a/apps/web/src/app/api/admin/content/stage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/content/stage/__tests__/route.test.ts
@@ -1,0 +1,130 @@
+/**
+ * POST /api/admin/content/stage — content-staging-model slice 4.
+ *
+ * Promote/demote one puzzle version by calling the transactional `promote_content`
+ * RPC, then revalidate THIS deployment's `content` tag (no cross-deployment
+ * fan-out — other envs refresh on the TTL). ADMIN_TOKEN-gated + rate-limited.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+vi.mock("@/lib/server/demo-signing", () => ({
+  enforceRateLimit: vi.fn(),
+  getRequestIp: vi.fn(() => "127.0.0.1"),
+}));
+
+const supabaseMock = vi.hoisted(() => ({ rpc: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseServer: vi.fn(() => supabaseMock),
+}));
+
+import { POST } from "../route";
+import { revalidateTag } from "next/cache";
+import { enforceRateLimit } from "@/lib/server/demo-signing";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+const mockedRevalidate = vi.mocked(revalidateTag);
+const mockedRate = vi.mocked(enforceRateLimit);
+const mockedSupabase = vi.mocked(getSupabaseServer);
+
+const TOKEN = "s3cr3t-admin-token";
+
+function req(body: unknown, headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/admin/content/stage", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function authed(body: unknown) {
+  return req(body, { "x-admin-token": TOKEN });
+}
+
+const VALID = { kind: "exercise", id: "rook-1", from: "draft", to: "published" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabaseMock.rpc.mockResolvedValue({ data: 1, error: null });
+  mockedSupabase.mockReturnValue(supabaseMock as never);
+  process.env.ADMIN_TOKEN = TOKEN;
+});
+
+afterEach(() => {
+  delete process.env.ADMIN_TOKEN;
+});
+
+describe("POST /api/admin/content/stage", () => {
+  it("503 and no RPC when ADMIN_TOKEN is unset", async () => {
+    delete process.env.ADMIN_TOKEN;
+    const res = await POST(authed(VALID));
+    expect(res.status).toBe(503);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it("403 and no RPC on a bad/absent token", async () => {
+    const res = await POST(req(VALID, { "x-admin-token": "wrong" }));
+    expect(res.status).toBe(403);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it("429 when the rate limit is exceeded", async () => {
+    mockedRate.mockRejectedValueOnce(new Error("Rate limit exceeded"));
+    const res = await POST(authed(VALID));
+    expect(res.status).toBe(429);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it("400 on an invalid stage value", async () => {
+    const res = await POST(authed({ ...VALID, to: "prod" }));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it("400 when from === to (no-op rejected)", async () => {
+    const res = await POST(authed({ ...VALID, from: "draft", to: "draft" }));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it("400 on a missing id", async () => {
+    const res = await POST(authed({ kind: "exercise", from: "draft", to: "preview" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when the RPC reports the `from` version is absent (returns 0)", async () => {
+    supabaseMock.rpc.mockResolvedValue({ data: 0, error: null });
+    const res = await POST(authed(VALID));
+    expect(res.status).toBe(404);
+    expect(mockedRevalidate).not.toHaveBeenCalled();
+  });
+
+  it("promotes via the transactional RPC, revalidates content, returns from/to", async () => {
+    const res = await POST(authed(VALID));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, from: "draft", to: "published" });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith("promote_content", {
+      p_kind: "exercise",
+      p_id: "rook-1",
+      p_from: "draft",
+      p_to: "published",
+    });
+    expect(mockedRevalidate).toHaveBeenCalledWith("content");
+  });
+
+  it("supports a demote (published → draft)", async () => {
+    const res = await POST(authed({ ...VALID, from: "published", to: "draft" }));
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "promote_content",
+      expect.objectContaining({ p_from: "published", p_to: "draft" }),
+    );
+  });
+
+  it("500 when the RPC errors", async () => {
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: "boom" } });
+    const res = await POST(authed(VALID));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/admin/content/stage/route.ts
+++ b/apps/web/src/app/api/admin/content/stage/route.ts
@@ -1,0 +1,107 @@
+/**
+ * POST /api/admin/content/stage — content-staging-model slice 4 (promote/demote).
+ *
+ * Moves one puzzle version up (promote) or down (demote) the maturity ladder by
+ * calling the transactional `promote_content` RPC (delete supersede + stage
+ * update in ONE transaction), then revalidates THIS deployment's `content` tag.
+ * There is NO cross-deployment fan-out — other envs refresh on the cache TTL.
+ *
+ * Founder-only: gated on the server-only ADMIN_TOKEN shared secret (never
+ * NEXT_PUBLIC_) + rate-limited. Fail-closed: 503 token-unset / store-down, 403
+ * bad token, 429 rate-limited, 400 malformed/no-op, 404 when the `from` version
+ * is absent (the RPC returns 0 and NOTHING was deleted), 500 on a DB error.
+ */
+import { NextResponse } from "next/server";
+import { createHash, timingSafeEqual } from "node:crypto";
+import { revalidateTag } from "next/cache";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { enforceRateLimit, getRequestIp } from "@/lib/server/demo-signing";
+import type {
+  ContentKind,
+  ContentStage,
+  ContentStageRequest,
+} from "@/lib/content/overlay-types";
+
+export const runtime = "nodejs";
+
+const CONTENT_TAG = "content";
+
+/** Constant-time compare via fixed-length sha256 digests (length not leaked). */
+function tokenMatches(provided: string | null, expected: string): boolean {
+  if (!provided) return false;
+  const sha = (s: string) => createHash("sha256").update(s).digest();
+  return timingSafeEqual(sha(provided), sha(expected));
+}
+
+function err(errors: string[], status: number) {
+  return NextResponse.json({ ok: false, errors }, { status });
+}
+
+function isStage(v: unknown): v is ContentStage {
+  return v === "draft" || v === "preview" || v === "published";
+}
+
+export async function POST(request: Request) {
+  const expected = process.env.ADMIN_TOKEN;
+  if (!expected) return err(["admin writes disabled"], 503);
+
+  const provided = request.headers.get("x-admin-token");
+  if (!tokenMatches(provided, expected)) return err(["forbidden"], 403);
+
+  try {
+    await enforceRateLimit(getRequestIp(request));
+  } catch {
+    return err(["rate limit exceeded"], 429);
+  }
+
+  let body: ContentStageRequest;
+  try {
+    body = (await request.json()) as ContentStageRequest;
+  } catch {
+    return err(["invalid JSON"], 400);
+  }
+
+  const kind: ContentKind = body?.kind === "labyrinth" ? "labyrinth" : "exercise";
+  const id = body?.id;
+  const from = body?.from;
+  const to = body?.to;
+  if (!id || typeof id !== "string") return err(["missing id"], 400);
+  if (!isStage(from) || !isStage(to)) return err(["invalid stage"], 400);
+  if (from === to) return err(["from and to are the same stage (no-op)"], 400);
+
+  const supabase = getSupabaseServer();
+  if (!supabase) return err(["content store unavailable"], 503);
+
+  // The whole move is one transaction inside the RPC; it returns 1 when a version
+  // was moved, 0 when `from` was absent (and in that case nothing was deleted).
+  const { data, error } = await supabase.rpc("promote_content", {
+    p_kind: kind,
+    p_id: id,
+    p_from: from,
+    p_to: to,
+  });
+  if (error) return err([error.message], 500);
+  if (data === 0) {
+    return err([`no '${from}' version of ${kind} ${id} to promote`], 404);
+  }
+
+  // Revalidate only THIS deployment (no fan-out); other envs pick it up on TTL.
+  let revalidated = false;
+  try {
+    revalidateTag(CONTENT_TAG);
+    revalidated = true;
+  } catch {
+    revalidated = false;
+  }
+
+  console.info("[admin/content/stage] move", {
+    id,
+    kind,
+    from,
+    to,
+    revalidated,
+    actor: createHash("sha256").update(provided ?? "").digest("hex").slice(0, 12),
+  });
+
+  return NextResponse.json({ ok: true, from, to });
+}


### PR DESCRIPTION
`POST /api/admin/content/stage` moves a puzzle version up/down the ladder via the transactional `promote_content` RPC, then revalidates THIS deployment's `content` tag (no fan-out — other envs refresh on the 60s TTL).

ADMIN_TOKEN-gated + rate-limited. Fail-closed: 503/403/429/400 (incl. from===to no-op + invalid stage)/404 (RPC returns 0 = absent from, nothing deleted)/500. Any from→to allowed (skip-stage + demote); supersede enforced in the DB.

TDD: 10 tests. Suite 3976/3976, tsc + eslint clean. RPC behavior covered by the slice-2 integration test (deferred to CI).

Wolfcito 🐾 @akawolfcito