### PR TITLE
feat(content): staging model slice 5 — builder 'Saved as draft' copy

### DIFF
--- a/apps/web/src/app/dev/labyrinth-builder/page.tsx
+++ b/apps/web/src/app/dev/labyrinth-builder/page.tsx
@@ -386,8 +386,9 @@ export default function LabyrinthBuilderPage() {
     setIsSaving(true);
     try {
       // "Todo en 1": the publish proxy writes the baseline content/*.json AND
-      // publishes to the live overlay in one call (the ADMIN_TOKEN stays
-      // server-side). It returns a partial-aware { ok, baseline, overlay }.
+      // writes the overlay at stage='draft' in one call (the ADMIN_TOKEN stays
+      // server-side). A draft is NOT live to players — promote it to publish.
+      // Returns a partial-aware { ok, baseline, overlay }.
       const res = await fetch("/api/dev/publish", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -423,8 +424,8 @@ export default function LabyrinthBuilderPage() {
   // the list row directly so it never disturbs the current edit.
   async function handleToggleDisabled(rec: LabyrinthRecord) {
     try {
-      // Toggle through the publish proxy so the enable/disable also propagates
-      // live (baseline + overlay), same "todo en 1" path as Save.
+      // Toggle through the publish proxy so the enable/disable also lands in the
+      // draft overlay (baseline + overlay), same "todo en 1" path as Save.
       const res = await fetch("/api/dev/publish", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -439,10 +440,10 @@ export default function LabyrinthBuilderPage() {
       const id = rec.id ?? "record";
       setToast(
         data.overlay?.ok
-          ? { kind: "ok", text: `${id} ${verb} (live). Remember to commit content/*.json.` }
+          ? { kind: "ok", text: `${id} ${verb} as draft. Promote to publish. Remember to commit content/*.json.` }
           : {
               kind: "warn",
-              text: `${id} ${verb} in baseline; live update failed: ${(data.overlay?.errors ?? ["unknown"]).join("; ")}. Remember to commit content/*.json.`,
+              text: `${id} ${verb} in baseline; draft overlay update failed: ${(data.overlay?.errors ?? ["unknown"]).join("; ")}. Remember to commit content/*.json.`,
             },
       );
       void refreshRecords();
@@ -690,7 +691,7 @@ export default function LabyrinthBuilderPage() {
               disabled={!result.ok || isSaving}
               className="rounded bg-emerald-600 px-4 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-500"
             >
-              {isSaving ? "Publishing…" : "Save"}
+              {isSaving ? "Saving draft…" : "Save draft"}
             </button>
             {toast && (
               <span

--- a/apps/web/src/lib/labyrinth-builder/__tests__/publish-toast.test.ts
+++ b/apps/web/src/lib/labyrinth-builder/__tests__/publish-toast.test.ts
@@ -2,24 +2,27 @@ import { describe, expect, it } from "vitest";
 import { formatPublishResult } from "../publish-toast";
 
 describe("formatPublishResult", () => {
-  it("ok + revalidated → success toast with commit nudge", () => {
+  it("ok + revalidated → 'saved as draft' toast (NOT live) + commit + promote nudge", () => {
     const t = formatPublishResult({
       ok: true,
       baseline: { ok: true, id: "rook-1" },
       overlay: { ok: true, revalidated: true },
     });
     expect(t.kind).toBe("ok");
-    expect(t.text).toMatch(/live/i);
+    expect(t.text).toMatch(/draft/i);
+    expect(t.text).not.toMatch(/\blive\b/i); // staging: Save ≠ live to players
+    expect(t.text).toMatch(/promote/i);
     expect(t.text).toMatch(/commit/i);
   });
 
-  it("ok but not yet revalidated → success toast notes propagation", () => {
+  it("ok but not yet revalidated → draft toast notes propagation", () => {
     const t = formatPublishResult({
       ok: true,
       baseline: { ok: true, id: "rook-1" },
       overlay: { ok: true, revalidated: false },
     });
     expect(t.kind).toBe("ok");
+    expect(t.text).toMatch(/draft/i);
     expect(t.text).toMatch(/propagat/i);
   });
 

--- a/apps/web/src/lib/labyrinth-builder/publish-toast.ts
+++ b/apps/web/src/lib/labyrinth-builder/publish-toast.ts
@@ -1,11 +1,12 @@
 /**
  * Maps a /api/dev/publish result to a builder toast — db-content overlay-full
- * (Stage 7). Pure so the success / partial-failure / error copy is unit-tested
- * without rendering the builder page.
+ * (Stage 7), updated for the content-staging-model: a Save lands the overlay at
+ * `stage='draft'`, NOT live to players. Pure so the copy is unit-tested without
+ * rendering the builder page.
  *
- * - baseline fail            → "err"  (nothing published; show validation errors)
- * - baseline ok + overlay ok → "ok"   (live; remind to commit the json)
- * - baseline ok + overlay !ok→ "warn" (partial: saved to baseline, live failed)
+ * - baseline fail            → "err"  (nothing saved; show validation errors)
+ * - baseline ok + overlay ok → "ok"   (saved as draft; promote to publish)
+ * - baseline ok + overlay !ok→ "warn" (partial: saved to baseline, draft failed)
  */
 export type PublishToast = { kind: "ok" | "warn" | "err"; text: string };
 
@@ -23,12 +24,15 @@ export function formatPublishResult(r: PublishResultLike): PublishToast {
     return { kind: "err", text: `Save failed: ${errs}` };
   }
   if (r.overlay.ok) {
-    const note = r.overlay.revalidated ? "live now" : "saved, propagating";
-    return { kind: "ok", text: `Published (${note}) + saved to baseline. ${COMMIT_NUDGE}` };
+    const note = r.overlay.revalidated ? "visible in dev now" : "propagating";
+    return {
+      kind: "ok",
+      text: `Saved as draft (${note}) + baseline. Promote to publish for players. ${COMMIT_NUDGE}`,
+    };
   }
   const errs = (r.overlay.errors ?? ["unknown error"]).join("; ");
   return {
     kind: "warn",
-    text: `Saved to baseline, but live publish failed: ${errs}. ${COMMIT_NUDGE}`,
+    text: `Saved to baseline, but the draft overlay save failed: ${errs}. ${COMMIT_NUDGE}`,
   };
 }


### PR DESCRIPTION
A builder Save now lands the overlay at stage='draft' (not live), so the builder says so (red-team P1):
- publish-toast: 'Published (live now)' → 'Saved as draft … Promote to publish for players'; warn copy updated. Tests assert /draft/ + /promote/, NOT /live/.
- Save button: 'Save'/'Publishing…' → 'Save draft'/'Saving draft…'.
- Soft-delete toggle toast: '(live)' → 'as draft. Promote to publish.'

Remaining P1 (from-mismatch 404 listing stages) deferred WITH the promote UI (out of scope). Completes content-staging-model slices 1–5. Suite 3976/3976, tsc + eslint clean.

Wolfcito 🐾 @akawolfcito