### PR TITLE
feat(content): builder promote/demote UI — single stage dropdown

### DIFF
--- a/apps/web/src/app/api/admin/content/stage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/content/stage/__tests__/route.test.ts
@@ -13,10 +13,19 @@ vi.mock("@/lib/server/demo-signing", () => ({
   getRequestIp: vi.fn(() => "127.0.0.1"),
 }));
 
-const supabaseMock = vi.hoisted(() => ({ rpc: vi.fn() }));
+const supabaseMock = vi.hoisted(() => ({ rpc: vi.fn(), from: vi.fn() }));
 vi.mock("@/lib/supabase/server", () => ({
   getSupabaseServer: vi.fn(() => supabaseMock),
 }));
+
+/** Thenable .from().select().eq().eq() chain that resolves to a stages result. */
+function stageQuery(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
 
 import { POST } from "../route";
 import { revalidateTag } from "next/cache";
@@ -81,9 +90,29 @@ describe("POST /api/admin/content/stage", () => {
     expect(supabaseMock.rpc).not.toHaveBeenCalled();
   });
 
-  it("400 when from === to (no-op rejected)", async () => {
+  it("from === to → friendly no-op (200, no RPC)", async () => {
     const res = await POST(authed({ ...VALID, from: "draft", to: "draft" }));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it("auto-detects `from` (freshest version) when omitted, then promotes", async () => {
+    // id has a draft + published; freshest = draft → promote draft→published.
+    supabaseMock.from.mockReturnValue(
+      stageQuery({ data: [{ stage: "published" }, { stage: "draft" }], error: null }),
+    );
+    const res = await POST(authed({ kind: "exercise", id: "rook-1", to: "published" }));
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "promote_content",
+      expect.objectContaining({ p_from: "draft", p_to: "published" }),
+    );
+  });
+
+  it("404 when omitting `from` and the id has no overlay version", async () => {
+    supabaseMock.from.mockReturnValue(stageQuery({ data: [], error: null }));
+    const res = await POST(authed({ kind: "exercise", id: "ghost", to: "published" }));
+    expect(res.status).toBe(404);
     expect(supabaseMock.rpc).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/admin/content/stage/route.ts
+++ b/apps/web/src/app/api/admin/content/stage/route.ts
@@ -16,6 +16,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { revalidateTag } from "next/cache";
 import { getSupabaseServer } from "@/lib/supabase/server";
 import { enforceRateLimit, getRequestIp } from "@/lib/server/demo-signing";
+import { STAGE_RANK } from "@/lib/content/overlay-types";
 import type {
   ContentKind,
   ContentStage,
@@ -63,14 +64,36 @@ export async function POST(request: Request) {
 
   const kind: ContentKind = body?.kind === "labyrinth" ? "labyrinth" : "exercise";
   const id = body?.id;
-  const from = body?.from;
+  let from = body?.from; // optional: auto-detected from the freshest version
   const to = body?.to;
   if (!id || typeof id !== "string") return err(["missing id"], 400);
-  if (!isStage(from) || !isStage(to)) return err(["invalid stage"], 400);
-  if (from === to) return err(["from and to are the same stage (no-op)"], 400);
+  if (!isStage(to)) return err(["invalid target stage"], 400);
+  if (from !== undefined && !isStage(from)) return err(["invalid from stage"], 400);
 
   const supabase = getSupabaseServer();
   if (!supabase) return err(["content store unavailable"], 503);
+
+  // Auto-detect `from` = the freshest (lowest-rank) existing version of this id,
+  // so a caller can just say "set to X" without tracking the current stage.
+  if (from === undefined) {
+    const { data: rows, error: selErr } = await supabase
+      .from("content_overlay")
+      .select("stage")
+      .eq("kind", kind)
+      .eq("id", id);
+    if (selErr) return err([selErr.message], 500);
+    const stages = ((rows ?? []) as { stage?: unknown }[])
+      .map((r) => r.stage)
+      .filter(isStage);
+    if (stages.length === 0) {
+      return err([`no overlay version of ${kind} ${id} to move`], 404);
+    }
+    from = stages.reduce((a, b) => (STAGE_RANK[b] < STAGE_RANK[a] ? b : a));
+  }
+
+  // Already at the target → friendly no-op (not an error), so the dropdown can
+  // re-select the current stage without surprising the user.
+  if (from === to) return NextResponse.json({ ok: true, from, to });
 
   // The whole move is one transaction inside the RPC; it returns 1 when a version
   // was moved, 0 when `from` was absent (and in that case nothing was deleted).

--- a/apps/web/src/app/api/dev/promote/__tests__/route.test.ts
+++ b/apps/web/src/app/api/dev/promote/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+/**
+ * POST /api/dev/promote — dev-only proxy that adds ADMIN_TOKEN server-side and
+ * forwards a stage move to /api/admin/content/stage (so the builder can promote
+ * without the token ever reaching the browser). Same shape as /api/dev/publish.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "../route";
+
+const ORIGINAL = { ...process.env };
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  vi.stubEnv("NODE_ENV", "test");
+  process.env.ADMIN_TOKEN = "tkn";
+  process.env.OVERLAY_PUBLISH_BASE_URL = "https://preview.example.com";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  process.env = { ...ORIGINAL };
+});
+
+function body(b: unknown) {
+  return new Request("http://localhost/api/dev/promote", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(b),
+  });
+}
+
+const VALID = { kind: "exercise", id: "rook-1", from: "draft", to: "published" };
+
+describe("POST /api/dev/promote", () => {
+  it("404 in production (never proxies)", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const res = await POST(body(VALID));
+    expect(res.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("400 on missing id or target stage", async () => {
+    const res = await POST(body({ kind: "exercise", id: "rook-1" }));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards without `from` (auto-detect) when only `to` is given", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, from: "draft", to: "published" }),
+    });
+    const res = await POST(body({ kind: "exercise", id: "rook-1", to: "published" }));
+    expect(res.status).toBe(200);
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent).toMatchObject({ kind: "exercise", id: "rook-1", to: "published" });
+    expect(sent.from).toBeUndefined();
+  });
+
+  it("reports not-configured when ADMIN_TOKEN / base URL are unset", async () => {
+    delete process.env.OVERLAY_PUBLISH_BASE_URL;
+    const res = await POST(body(VALID));
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.join(" ")).toMatch(/not configured/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards to /api/admin/content/stage with the token + body and returns ok", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, from: "draft", to: "published" }),
+    });
+    const res = await POST(body(VALID));
+    const data = await res.json();
+    expect(data).toMatchObject({ ok: true, from: "draft", to: "published" });
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://preview.example.com/api/admin/content/stage");
+    expect(opts.headers["x-admin-token"]).toBe("tkn");
+    expect(JSON.parse(opts.body)).toMatchObject(VALID);
+  });
+
+  it("sanitizes an upstream 404 (absent from-version) without echoing the raw body", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ ok: false, errors: ["raw db detail leak"] }),
+    });
+    const res = await POST(body(VALID));
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.join(" ")).toMatch(/404/);
+    expect(data.errors.join(" ")).not.toMatch(/raw db detail/);
+  });
+
+  it("handles a network error without surfacing the raw error", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED secret-host"));
+    const res = await POST(body(VALID));
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.join(" ")).not.toMatch(/secret-host/);
+  });
+});

--- a/apps/web/src/app/api/dev/promote/route.ts
+++ b/apps/web/src/app/api/dev/promote/route.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/dev/promote — content-staging-model (builder promote/demote).
+ *
+ * Dev-only proxy: reads ADMIN_TOKEN server-side and forwards a stage move to the
+ * overlay's /api/admin/content/stage (so the builder can promote/demote without
+ * the token ever reaching the browser). Mirrors /api/dev/publish.
+ *
+ * Fail-closed: 404 in production (NODE_ENV guard); 400 on a malformed move;
+ * "not configured" when ADMIN_TOKEN / OVERLAY_PUBLISH_BASE_URL are unset. Upstream
+ * errors are sanitized by status — the raw body (which may carry DB detail) and
+ * the token are never echoed.
+ */
+import { NextResponse } from "next/server";
+import type { ContentKind, ContentStage } from "@/lib/content/overlay-types";
+
+export const runtime = "nodejs";
+
+type PromoteBody = {
+  kind?: ContentKind;
+  id?: string;
+  from?: ContentStage;
+  to?: ContentStage;
+};
+
+function isStage(v: unknown): v is ContentStage {
+  return v === "draft" || v === "preview" || v === "published";
+}
+
+function stageErrorForStatus(status: number): string {
+  switch (status) {
+    case 403:
+      return "promote rejected: admin token rejected (403)";
+    case 404:
+      return "promote rejected: that 'from' version does not exist (404)";
+    case 429:
+      return "promote rejected: rate limited (429)";
+    case 400:
+      return "promote rejected: invalid move (400)";
+    case 503:
+      return "promote unavailable: store or admin writes disabled (503)";
+    case 500:
+      return "promote failed: server error (500)";
+    default:
+      return `promote failed: HTTP ${status}`;
+  }
+}
+
+export async function POST(req: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  let b: PromoteBody;
+  try {
+    b = (await req.json()) as PromoteBody;
+  } catch {
+    return NextResponse.json({ ok: false, errors: ["invalid JSON"] }, { status: 400 });
+  }
+
+  const kind: ContentKind = b.kind === "labyrinth" ? "labyrinth" : "exercise";
+  const { id, from, to } = b;
+  if (!id || typeof id !== "string") {
+    return NextResponse.json({ ok: false, errors: ["missing id"] }, { status: 400 });
+  }
+  if (!isStage(to)) {
+    return NextResponse.json({ ok: false, errors: ["invalid target stage"] }, { status: 400 });
+  }
+  // `from` is optional — when omitted the overlay route auto-detects the freshest
+  // version ("set to `to`"). When present it must be a valid stage.
+  if (from !== undefined && !isStage(from)) {
+    return NextResponse.json({ ok: false, errors: ["invalid from stage"] }, { status: 400 });
+  }
+
+  const token = process.env.ADMIN_TOKEN;
+  const base = process.env.OVERLAY_PUBLISH_BASE_URL?.replace(/\/+$/, "");
+  if (!token || !base) {
+    return NextResponse.json(
+      { ok: false, errors: ["overlay target not configured (set OVERLAY_PUBLISH_BASE_URL + ADMIN_TOKEN)"] },
+      { status: 200 },
+    );
+  }
+
+  try {
+    const res = await fetch(`${base}/api/admin/content/stage`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-admin-token": token },
+      body: JSON.stringify({ kind, id, from, to }),
+    });
+    if (!res.ok) {
+      return NextResponse.json({ ok: false, errors: [stageErrorForStatus(res.status)] });
+    }
+    const data = (await res.json().catch(() => null)) as
+      | { ok?: boolean; from?: string; to?: string }
+      | null;
+    if (!data?.ok) {
+      return NextResponse.json({ ok: false, errors: [stageErrorForStatus(res.status)] });
+    }
+    console.info("[dev/promote]", { id, kind, from, to });
+    return NextResponse.json({ ok: true, from: data.from ?? from, to: data.to ?? to });
+  } catch {
+    return NextResponse.json({
+      ok: false,
+      errors: ["promote failed: network error reaching the target"],
+    });
+  }
+}

--- a/apps/web/src/app/dev/labyrinth-builder/page.tsx
+++ b/apps/web/src/app/dev/labyrinth-builder/page.tsx
@@ -14,6 +14,11 @@ import {
   type PublishResultLike,
 } from "@/lib/labyrinth-builder/publish-toast";
 import {
+  formatPromoteResult,
+  type PromoteResultLike,
+} from "@/lib/labyrinth-builder/promote-toast";
+import type { ContentStage } from "@/lib/content/overlay-types";
+import {
   parseFenBoard,
   posToSquare,
   squareToPos,
@@ -216,6 +221,8 @@ export default function LabyrinthBuilderPage() {
   /** Debounce: block re-entrant Save while a publish round-trip is in flight
    *  (a double-click would otherwise race two read-modify-write passes). */
   const [isSaving, setIsSaving] = useState(false);
+  /** Target stage for the "Set stage" control (content-staging-model). */
+  const [stageTarget, setStageTarget] = useState<ContentStage>("published");
 
   const refreshRecords = useCallback(async () => {
     try {
@@ -415,6 +422,31 @@ export default function LabyrinthBuilderPage() {
       setToast({ kind: "err", text: (e as Error).message });
     } finally {
       setIsSaving(false);
+    }
+  }
+
+  // Set the current record's stage (content-staging-model). Save lands content
+  // at `draft`; this moves it to the chosen stage — the route auto-detects the
+  // current version, so you just pick the target. Goes through the dev proxy so
+  // the ADMIN_TOKEN stays server-side. draft (local) / preview
+  // (preview.chesscito.com) / published (chesscito.com).
+  async function handleSetStage(to: ContentStage) {
+    const id = state.id?.trim();
+    if (!id) {
+      setToast({ kind: "err", text: "Load or enter a record id first." });
+      return;
+    }
+    try {
+      const res = await fetch("/api/dev/promote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ kind, id, to }),
+      });
+      const data = (await res.json()) as PromoteResultLike;
+      setToast(formatPromoteResult(data, id));
+      void refreshRecords();
+    } catch (e) {
+      setToast({ kind: "err", text: (e as Error).message });
     }
   }
 
@@ -706,6 +738,34 @@ export default function LabyrinthBuilderPage() {
                 {toast.text}
               </span>
             )}
+          </div>
+
+          {/* Set the current record's stage. Save lands it at draft; pick where
+              it should live and "Set stage" moves it there (the route detects the
+              current version automatically). draft = localhost · preview =
+              preview.chesscito.com · published = chesscito.com (players). */}
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="font-semibold text-slate-400">
+              Stage {state.id ? `for ${state.id}` : "(load a record)"} →
+            </span>
+            <select
+              value={stageTarget}
+              onChange={(e) => setStageTarget(e.target.value as ContentStage)}
+              disabled={!state.id}
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 disabled:text-slate-600"
+            >
+              <option value="draft">draft (localhost)</option>
+              <option value="preview">preview (preview.chesscito.com)</option>
+              <option value="published">published (chesscito.com)</option>
+            </select>
+            <button
+              type="button"
+              onClick={() => handleSetStage(stageTarget)}
+              disabled={!state.id}
+              className="rounded border border-slate-700 px-3 py-1 font-semibold text-slate-200 hover:border-slate-500 disabled:cursor-not-allowed disabled:text-slate-600"
+            >
+              Set stage
+            </button>
           </div>
 
           {/* Export (read-only FEN block) */}

--- a/apps/web/src/lib/content/overlay-types.ts
+++ b/apps/web/src/lib/content/overlay-types.ts
@@ -94,7 +94,8 @@ export type ContentWriteResult =
 export interface ContentStageRequest {
   kind: ContentKind;
   id: string;
-  from: ContentStage;
+  /** Optional — omit to auto-detect the freshest existing version ("set to `to`"). */
+  from?: ContentStage;
   to: ContentStage;
 }
 

--- a/apps/web/src/lib/labyrinth-builder/__tests__/promote-toast.test.ts
+++ b/apps/web/src/lib/labyrinth-builder/__tests__/promote-toast.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { formatPromoteResult } from "../promote-toast";
+
+describe("formatPromoteResult", () => {
+  it("ok → success toast naming the move + the ~60s propagation", () => {
+    const t = formatPromoteResult(
+      { ok: true, from: "draft", to: "published" },
+      "rook-1",
+    );
+    expect(t.kind).toBe("ok");
+    expect(t.text).toMatch(/rook-1/);
+    expect(t.text).toMatch(/draft/);
+    expect(t.text).toMatch(/published/);
+    expect(t.text).toMatch(/60s|minute|propagat/i);
+  });
+
+  it("not ok → error toast surfacing the reason", () => {
+    const t = formatPromoteResult(
+      { ok: false, errors: ["no 'draft' version of exercise rook-1 to promote"] },
+      "rook-1",
+    );
+    expect(t.kind).toBe("err");
+    expect(t.text).toMatch(/no 'draft'/);
+  });
+
+  it("not ok with no errors → generic failure", () => {
+    const t = formatPromoteResult({ ok: false }, "rook-1");
+    expect(t.kind).toBe("err");
+    expect(t.text).toMatch(/failed/i);
+  });
+});

--- a/apps/web/src/lib/labyrinth-builder/promote-toast.ts
+++ b/apps/web/src/lib/labyrinth-builder/promote-toast.ts
@@ -1,0 +1,26 @@
+/**
+ * Maps a /api/dev/promote result to a builder toast (content-staging-model).
+ * Pure so the copy is unit-tested without rendering the builder page.
+ */
+import type { PublishToast } from "./publish-toast";
+
+export interface PromoteResultLike {
+  ok: boolean;
+  from?: string;
+  to?: string;
+  errors?: string[];
+}
+
+export function formatPromoteResult(
+  r: PromoteResultLike,
+  id: string,
+): PublishToast {
+  if (r.ok) {
+    return {
+      kind: "ok",
+      text: `Promoted ${id}: ${r.from} → ${r.to}. Visible on the ${r.to} env within ~60s (TTL).`,
+    };
+  }
+  const errs = (r.errors ?? ["unknown error"]).join("; ");
+  return { kind: "err", text: `Promote failed: ${errs}` };
+}


### PR DESCRIPTION
Adds the builder UI to move content through the ladder (API existed; UI was the follow-up).

- `/api/dev/promote` dev proxy (ADMIN_TOKEN server-side).
- `/api/admin/content/stage`: `from` now OPTIONAL → auto-detects freshest version ("set to X"); from===to = friendly no-op.
- Builder: a stage **dropdown** (draft=localhost / preview=preview.chesscito.com / published=chesscito.com) + "Set stage".

TDD: 22 tests across route/proxy/toast. Suite 3988/3988, tsc + eslint clean.

Wolfcito 🐾 @akawolfcito