### PR TITLE
docs: Focus Passport P1 spec + implementation plan

### DIFF
--- a/docs/specs/2026-06-20-focus-passport-p1-implementation-plan.md
+++ b/docs/specs/2026-06-20-focus-passport-p1-implementation-plan.md
@@ -1,0 +1,160 @@
+# Implementation Plan — Focus Passport P1 (streak-based)
+
+**Date:** 2026-06-20
+**Status:** PLAN ONLY — no code yet
+**Spec:** `docs/specs/2026-06-20-focus-passport-p1.md`
+**Scope guard:** streak-based only · no `completedDates[]` · no backend · no
+on-chain · Lite-only · Full untouched.
+
+---
+
+## 1. Diagnóstico del código actual
+
+- **Store:** `apps/web/src/lib/daily/progress.ts` → key `chesscito:daily-progress`,
+  tipo `DailyProgress { streak, lastCompletedDate, totalCompleted }`. Parser
+  defensivo + `getDailyProgress()`, `recordDailyCompletion()`, `todayUtc()`.
+- **Consumidores actuales de streak/last/total:**
+  - `components/daily/daily-tactic-slot.tsx` — escribe (record) + lee streak.
+  - `components/hub/hub-daily-tile.tsx` — lee para el tile diario.
+  - `components/hub/hub-scaffold-client.tsx` — lee señales (`isCompletedToday()`,
+    `getDailyHistoryCount()`) para el hero CTA.
+  - `lib/daily/telemetry.ts` — eventos de streak.
+- **Lite gate:** flag de build `CHESSCITO_LITE_MODE` (`@/lib/feature-flags`),
+  usado como `{CHESSCITO_LITE_MODE && …}` / `{!CHESSCITO_LITE_MODE && …}` en
+  `hub-scaffold.tsx`. ⇒ render condicional = Lite-only, Full intacto.
+- **Patrón anti-hydration ya establecido** (`hub-scaffold-client.tsx` ~L289):
+  `useState<T|null>(null)` → `useEffect` lee localStorage → mientras `null`
+  pinta default seguro. **Reusar tal cual.**
+- **UI base reutilizable:** patrón `vitrine-hero-band` (cream-amber) +
+  CSS por superficie en `apps/web/src/styles/hub.css`.
+
+> Conclusión: la data y los patrones ya existen. P1 es ensamblaje, no
+> infraestructura.
+
+---
+
+## 2. Plan de implementación
+
+**SDD → TDD → EDD.** Pasos atómicos:
+
+1. **Pure helper** `derivePassportView(progress, today)` en
+   `lib/daily/passport.ts` (o dentro de `progress.ts`):
+   - `filledSlots = clamp(streak, 0, 7)`
+   - `todayDone = lastCompletedDate === today`
+   - `tier = 0 | 1 | "2-6" | "7+"` (para copy/estado)
+   - **Función pura → testeable sin DOM** (TDD primero).
+2. **Componente presentacional** `components/hub/focus-passport.tsx`:
+   - Props: `{ streak, totalCompleted, todayDone, isLoading }`. Sin acceso
+     directo a localStorage (testeable, sin hydration en sí mismo).
+   - Renderiza hero card + 7 slots + copy por tier.
+3. **Wiring** en `hub-scaffold-client.tsx`:
+   - Añadir al `useEffect` de mount la lectura `getDailyProgress()` →
+     `useState<DailyProgress|null>(null)`. Mientras `null` → `isLoading`.
+   - Pasar props a `<HubScaffold>`.
+4. **Mount Lite-only** en `hub-scaffold.tsx`:
+   - `{CHESSCITO_LITE_MODE && wrap("FocusPassport", <FocusPassport … />)}`
+     en una posición alta del stack (ver §4). Full nunca lo monta.
+5. **CSS** en `apps/web/src/styles/hub.css` (solo hub lo usa) — clases
+   `.focus-passport*`. No tocar `globals.css`.
+6. **Copy / i18n** — strings en el catálogo de copy del hub (mismo lugar que
+   el resto del hub Lite), sin "verified"/"on-chain"/médico (ver §… abajo).
+7. **Tests** (§7) → **Smoke lite-preview** → VR baseline hub Lite.
+
+---
+
+## 3. Archivos afectados
+
+| Archivo | Cambio |
+|---|---|
+| `lib/daily/passport.ts` (NEW) | pure `derivePassportView()` + tipos |
+| `components/hub/focus-passport.tsx` (NEW) | componente presentacional |
+| `components/hub/hub-scaffold-client.tsx` | hidratar progress + pasar props |
+| `components/hub/hub-scaffold.tsx` | montar Passport Lite-only |
+| `styles/hub.css` | clases `.focus-passport*` |
+| copy/i18n del hub | strings del Passport |
+| `__tests__/*` (NEW) | unit del helper + del componente |
+
+No se toca: `progress.ts` schema (sin campos nuevos), env, contratos, pagos,
+rutas, Full surfaces.
+
+---
+
+## 4. UI propuesta
+
+- **Dónde:** Hub Lite, **arriba** (ancla de retorno), encima/junto al daily
+  tile. Reusar shell `vitrine-hero-band` cream-amber.
+- **Layout:**
+  - Línea 1: streak grande ("🔥 N day streak" / "Start your streak").
+  - Línea 2: fila de **7 slots** (lleno = sello/llama; vacío = outline).
+  - Subline: "Current streak" (no "estos 7 días").
+- **Reflejo en Trophies/Progress (DECISIÓN):** **opcional, mismo PR si trivial.**
+  El componente es reutilizable; si encaja en el hero band de Trophies sin
+  refactor, incluirlo; si requiere adaptación → diferir a follow-up. P1 mínimo
+  = solo Hub. (Recomendado: Hub-only primero, reflejo como follow-up de 1 línea.)
+
+---
+
+## 5. Estados (por streak)
+
+- **0** (`isLoading` o streak 0): 7 slots vacíos + "Start your streak. Solve
+  today's focus." Mientras `null` → mismo render vacío (sin parpadeo, sin días
+  falsos).
+- **1**: 1 slot lleno + "Day 1. Come back tomorrow."
+- **2–6**: N slots llenos + "N day streak. Keep going."
+- **7+**: 7 slots llenos (milestone) + "7-day focus. Nice." Semana 2 repite.
+- **todayDone=true**: slot de hoy resaltado/celebrado. **false** (streak>0):
+  slot de hoy "pendiente" + CTA suave.
+- **Streak roto**: se maneja solo (el store ya resetea a 1 al próximo solve);
+  copy neutro, sin "perdiste".
+
+---
+
+## 6. Riesgos
+
+- **Hydration flicker** → mitigado por patrón `null`-default existente; SSR pinta
+  vacío, cliente rellena. No leer localStorage en render.
+- **Días falsos** → slots = `min(streak,7)`, NUNCA fechas; copy "current
+  streak"; mientras `null` no pintar nada como hecho.
+- **Romper Full** → gate `CHESSCITO_LITE_MODE` en el mount; test que verifica
+  no-render en Full.
+- **UTC vs local** (medianoche) → heredado del store; aceptable, documentar.
+- **localStorage wipe / por-dispositivo** → sin DB no hay backup ni
+  cross-device; copy no promete permanencia ni "tu cuenta".
+- **VR drift** → refrescar baseline del hub Lite en el mismo PR.
+- **Scope creep** → prohibido `completedDates[]`, multi-fuente, WP, recompensas.
+
+---
+
+## 7. Tests / smoke requeridos
+
+- **Unit (helper, TDD primero):** `derivePassportView` para streak
+  `0,1,3,7,10` → slots `0,1,3,7,7`; `todayDone` por `lastCompletedDate`; tier.
+- **Unit (componente):** render por estado §5; estado `isLoading` no muestra
+  días llenos; copy **no** contiene `verified|on-chain|NFT|mint|cure|brain
+  health` (test de regresión-ceiling, estilo anti-AI-prose).
+- **Lite gate:** Passport no se renderiza con `CHESSCITO_LITE_MODE=false`.
+- **Smoke lite-preview:** Hub muestra Passport; resolver daily → slot de hoy se
+  llena + streak +1; reload → persiste; Full preview → sin Passport, sin
+  regresión.
+- **VR:** baseline hub Lite (empty + streak>0).
+
+---
+
+## 8. Recomendación final
+
+**IMPLEMENTAR como P1 pequeño.** Es ensamblaje sobre datos y patrones
+existentes: 1 helper puro + 1 componente presentacional + wiring de hidratación
++ CSS de superficie + tests. Sin backend, sin schema nuevo, sin riesgo para
+Full (gate de build). El único elemento que quedaría fuera (mini-calendar de
+fechas exactas) ya está correctamente diferido a P1.5 por falta de
+`completedDates[]`.
+
+**Tamaño estimado:** 1 sesión acotada (≤ ~8 archivos, mayoría nuevos/pequeños).
+**Pre-requisito:** ninguno — listo para ejecutar si se aprueba.
+
+### Copy seguro (referencia, no decir "verified"/"on-chain")
+
+- ✅ "N day streak", "Current streak", "Start your streak", "Keep going",
+  "7-day focus", "Come back tomorrow", "Fresh start".
+- ❌ Evitar: "verified", "on-chain", "NFT", "mint", "proof", y cualquier claim
+  médico ("brain training", "improves focus/memory", "cognitive health").

--- a/docs/specs/2026-06-20-focus-passport-p1.md
+++ b/docs/specs/2026-06-20-focus-passport-p1.md
@@ -1,0 +1,187 @@
+# Spec — Focus Passport (Chesscito Lite P1)
+
+**Date:** 2026-06-20
+**Status:** SPEC ONLY — no implementation
+**Predecessor:** Lite P0 closed (smoke 17/17) — `docs/handoffs/2026-06-20-lite-p0-closure-handoff.md`
+**Decision this spec enables:** ¿Focus Passport es un P1 pequeño (reusa datos) o
+requiere preparar datos primero?
+
+> **TL;DR decisión:** Un Passport **basado en streak** (hero card + 7 slots que
+> se llenan según el streak actual) es **P1 pequeño** y honesto — reusa
+> `chesscito:daily-progress` casi tal cual. Un **mini-calendar real** (qué días
+> exactos se completaron) **NO es posible hoy** sin agregar un historial de
+> fechas → eso es data-prep primero (P1.5). Recomendación: shippear el P1
+> streak-based y dejar el calendar exacto para P2.
+
+---
+
+## 1. Tesis de producto
+
+Chesscito Lite ya tiene el loop (Daily Focus jugable + overlay celebratorio).
+Falta el **refuerzo de hábito**: una superficie persistente que haga visible la
+consistencia y dé una razón para volver mañana. Focus Passport convierte el
+streak (que ya existe en datos pero casi no se ve) en el ancla de retorno
+diario: "tu constancia de foco, visible". Sin castigo, sin claims médicos —
+solo progreso visible.
+
+---
+
+## 2. User flow
+
+1. Abrir MiniPay → Hub Lite → ver **Passport** (hero card con streak + 7 slots).
+2. Tap Daily Focus → resolver el reto.
+3. Overlay celebratorio (ya existe) → **slot de hoy se marca** + streak sube.
+4. Volver mañana: el siguiente slot se llena; si pasó >1 día, el streak
+   reinicia (mensaje neutro, no punitivo).
+5. Al completar 7 días seguidos → milestone visible (badge/sello) + (futuro)
+   gancho con Welcome Package.
+
+---
+
+## 3. Qué cuenta como "focus day" (DECISIÓN)
+
+**P1 = 1 Daily Focus resuelto.** Es lo único que hoy escribe a
+`recordDailyCompletion()` → es la fuente de verdad existente, sin instrumentar
+nada nuevo.
+
+- ❌ N ejercicios → **no se trackea hoy** (exercises usan `PieceProgress`
+  id-keyed, sin marca temporal por-día) → requiere data nueva → P2.
+- ❌ 1 laberinto → **no se trackea hoy** como evento diario → P2.
+
+> Mantener P1 = daily-only evita inventar reglas ("¿cuántos ejercicios = un
+> día?") y evita instrumentación nueva. Multi-fuente es una expansión P2 con su
+> propia decisión.
+
+---
+
+## 4. UI propuesta
+
+**Passport hero card** (clonar patrón `vitrine-hero-band` / cream-amber):
+
+- Streak grande ("🔥 N day streak" / "Start your streak").
+- **7 slots** en fila (día 1–7). Slot lleno = sello/llama; vacío = outline.
+- Subline honesto: "Current streak" (no "estos 7 días exactos" — ver §11).
+- Estado vacío: "Solve today's focus to begin." (sin Arena, sin web3 jargon).
+
+Slots se derivan de `min(streak, 7)` llenos + el de hoy resaltado si
+`lastCompletedDate === todayUtc()`. **No** mini-calendar real en P1 (no hay
+fechas por-día).
+
+---
+
+## 5. Estados
+
+- **Empty** (streak 0, nunca jugó): 7 slots vacíos + CTA.
+- **In-progress hoy pendiente** (streak>0, hoy no resuelto): N slots llenos,
+  slot de hoy "pendiente/pulsante", CTA "Keep your streak".
+- **Hoy resuelto**: slot de hoy lleno, celebración en overlay.
+- **Streak roto** (gap >1 día): vuelve a 1 al próximo solve; copy neutro
+  ("Fresh start" — no "perdiste").
+- **Milestone 7/7**: estado de logro (sello). Luego se repite (semana 2).
+- **Hydration**: SSR/primer render = empty default (igual que slot actual) para
+  no parpadear estado falso.
+
+---
+
+## 6. Persistencia recomendada (DECISIÓN)
+
+**Local (localStorage), extendiendo `chesscito:daily-progress`.**
+
+- Cumple restricciones: sin DB, sin contratos, sin pagos, sin env, sin on-chain.
+- Reusa `DailyProgress { streak, lastCompletedDate, totalCompleted }` tal cual
+  para el P1 streak-based — **cero campos nuevos** para la versión mínima.
+- Para mini-calendar real (P2): agregar `completedDates: string[]` (cap ~30) al
+  mismo objeto, con migración tolerante (ya hay parser defensivo).
+- **No on-chain**: no hay txHash → no se promete on-chain (constraint honrada).
+- Limitación conocida: es **por-dispositivo, no por-usuario** (no cross-device).
+  Documentarlo; no presentarlo como cuenta global.
+
+---
+
+## 7. Relación con Progress/Trophies
+
+- Passport vive primero en **Hub Lite** (ancla de retorno) y se **refleja** en
+  Trophies/Progress (hero band ya muestra YOUR PROGRESS / SESSIONS).
+- El milestone 7/7 puede convertirse en el **primer achievement Lite real**
+  (hoy `emptyHintLite` promete "complete focus challenges to unlock
+  achievements" pero no existe ninguno — Passport lo cumple).
+- Resuelve parcialmente el riesgo abierto "0 SESSIONS": `totalCompleted` ya es
+  un contador de sesiones de foco real reutilizable.
+
+---
+
+## 8. Relación futura con Welcome Package
+
+- Passport **emite un evento** en milestones (ya existe `emitDailyStreakUpdated`;
+  añadir `passport.milestone_reached` análogo).
+- Welcome Package (NO implementar aquí) podría **suscribirse** a ese evento para
+  otorgar recompensa al primer 7/7. Mantener Passport desacoplado: emite, no
+  conoce a WP.
+
+---
+
+## 9. Riesgos
+
+- **Estado falso (P0 de honestidad):** mostrar 7 slots como "días exactos" sin
+  tener fechas por-día = mentira visual. Mitigación: en P1 los slots
+  representan el **streak count**, copy "current streak", no fechas exactas.
+- **UTC vs local timezone:** el módulo usa UTC; un usuario cerca de medianoche
+  puede ver el "día" cambiar raro. Aceptable P1; documentar.
+- **Pérdida de datos:** localStorage se borra al limpiar el WebView → streak se
+  pierde. Sin DB no hay backup. Comunicar suave; no prometer permanencia.
+- **Reloj manipulable:** fechas locales se pueden adelantar. Bajo impacto (sin
+  recompensa monetaria en Lite). No gamificar con dinero hasta tener servidor.
+- **Multi-dispositivo:** no sincroniza. No llamarlo "tu cuenta".
+- **Scope creep:** no meter multi-fuente, calendar real, WP, ni recompensas en
+  P1.
+
+---
+
+## 10. P0/P1/P2 de implementación futura
+
+- **P1 (pequeño, recomendado ahora):** hero card + 7 slots streak-based en Hub
+  Lite; reusa `chesscito:daily-progress`; slot de hoy resaltado; estados §5;
+  copy neutro; reflejo en Trophies. Sin campos nuevos. **Implementable como P1
+  pequeño.**
+- **P1.5 (data-prep, si se quiere calendar real):** agregar `completedDates[]`
+  con migración + escribir en `recordDailyCompletion`; entonces mini-calendar
+  con fechas exactas.
+- **P2:** focus days multi-fuente (exercises/labyrinths) con su propia regla +
+  instrumentación; grace day opcional; achievement Lite "7-day focus"; gancho
+  Welcome Package.
+
+---
+
+## Respuestas directas a las preguntas del spec
+
+- **¿Qué cuenta como focus day?** P1: 1 Daily Focus resuelto (único trackeado
+  hoy). N ejercicios / 1 laberinto → P2 (no hay data).
+- **¿Cómo se ven los 7 días?** P1: hero card + 7 slots llenados por streak
+  count. Mini-calendar real (fechas) → necesita `completedDates[]` (P1.5).
+- **¿Dónde vive?** Principal en Hub; reflejo en Trophies/Progress; refuerzo en
+  el Daily solved overlay (ya existe).
+- **¿Si falla un día?** No castigo: streak vuelve a 1 al próximo solve (lógica
+  actual), copy neutro. Grace day = decisión P2.
+- **¿Local/off-chain/on-chain?** **Local** (localStorage), extiende módulo
+  existente. No on-chain (sin txHash).
+- **¿Qué datos existen hoy?** `DailyProgress { streak, lastCompletedDate,
+  totalCompleted }` + eventos de streak + overlay celebratorio.
+- **¿Qué falta?** Historial por-día (`completedDates[]`) para calendar exacto;
+  marca temporal en exercises/labyrinths para multi-fuente.
+- **¿Cómo evitar estado falso?** Slots = streak count (no fechas) en P1; copy
+  "current streak"; SSR default-empty; nunca pintar día como hecho sin dato.
+- **¿Conexión con Welcome Package?** Passport emite evento de milestone; WP
+  (futuro) se suscribe. Desacoplado.
+- **¿Grant narrative MiniPay/Celo?** Razón diaria para abrir MiniPay no-
+  financiera; retención medible (streak, totalCompleted); hábito visible sin
+  pay-to-play ni NFT-first.
+
+---
+
+## Recomendación de cierre
+
+**Focus Passport SÍ puede ser un P1 pequeño** en su forma streak-based
+(reutiliza datos existentes, cero backend). El único elemento que exige
+data-prep previa es el **mini-calendar de fechas exactas** → posponer a P1.5/P2.
+Siguiente paso tras aprobar: escribir el plan de implementación del P1 pequeño
+(no implementar aún).


### PR DESCRIPTION
Spec + implementation plan for Chesscito Lite **Focus Passport P1**.

- streak-based, **local** (`chesscito:daily-progress`), **Lite-only**.
- No `completedDates[]`, no backend, no contracts, no payments, no on-chain.
- Copy avoids `verified`/`on-chain`/`txHash`/`proof` for the local P1.
- **Docs only — no code, no CSS, no env, no architecture changes.**

Next: implement the small P1 if approved.

Wolfcito 🐾 @akawolfcito