### PR TITLE
feat(pro): wire /hub ProSheet to the no-approve stablecoin rail

### DIFF
--- a/apps/web/src/lib/payments/__tests__/transfer-builder.test.ts
+++ b/apps/web/src/lib/payments/__tests__/transfer-builder.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { decodeFunctionData } from "viem";
 import { erc20Abi } from "@/lib/contracts/tokens";
-import { PEONES_PACKS, type PeonesPackSku } from "@/lib/payments/rail-config";
-import { buildPeonesPackTransfer } from "@/lib/payments/transfer-builder";
+import { PEONES_PACKS, PRO_PACKS, type PeonesPackSku, type ProPackSku } from "@/lib/payments/rail-config";
+import { buildPeonesPackTransfer, buildProPackTransfer } from "@/lib/payments/transfer-builder";
 
 const TREASURY = "0x1234567890abcdef1234567890abcdef12345678";
 const USDC = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
@@ -104,6 +104,88 @@ describe("buildPeonesPackTransfer — purity", () => {
     buildPeonesPackTransfer({ sku: "peones_pack_50", treasury: TREASURY });
     const after = JSON.stringify(
       PEONES_PACKS.peones_pack_50,
+      (_k, v) => (typeof v === "bigint" ? v.toString() : v),
+    );
+    expect(after).toBe(before);
+  });
+});
+
+describe("buildProPackTransfer — happy path (USDC default)", () => {
+  const tx = buildProPackTransfer({ sku: "chesscito_pro_30", treasury: TREASURY });
+
+  it("targets the USDC token contract with value 0n", () => {
+    expect(tx.to).toBe(USDC);
+    expect(tx.value).toBe(0n);
+    expect(tx.token.symbol).toBe("USDC");
+    expect(tx.token.decimals).toBe(6);
+  });
+
+  it("normalizes $1.99 to 1_990_000 (USDC 6 decimals)", () => {
+    expect(tx.priceUsd6).toBe(1_990_000n);
+    expect(tx.expectedAmount).toBe(1_990_000n);
+    expect(tx.sku).toBe("chesscito_pro_30");
+    expect(tx.source).toBe("pro_purchase");
+    expect(tx.treasury).toBe(TREASURY);
+  });
+
+  it("encodes transfer(treasury, 1_990_000) calldata", () => {
+    expect(tx.data.startsWith("0xa9059cbb")).toBe(true); // transfer selector
+    const decoded = decodeFunctionData({ abi: erc20Abi, data: tx.data });
+    expect(decoded.functionName).toBe("transfer");
+    expect(String(decoded.args?.[0]).toLowerCase()).toBe(TREASURY);
+    expect(decoded.args?.[1]).toBe(1_990_000n);
+  });
+});
+
+describe("buildProPackTransfer — other accepted stablecoins", () => {
+  it("cUSD (18 decimals) → 1_990_000 * 10^12", () => {
+    const tx = buildProPackTransfer({
+      sku: "chesscito_pro_30",
+      treasury: TREASURY,
+      tokenSymbol: "cUSD",
+    });
+    expect(tx.to).toBe(CUSD);
+    expect(tx.token.decimals).toBe(18);
+    expect(tx.expectedAmount).toBe(1_990_000n * 10n ** 12n);
+  });
+});
+
+describe("buildProPackTransfer — validation", () => {
+  it("rejects an invalid treasury address", () => {
+    expect(() =>
+      buildProPackTransfer({ sku: "chesscito_pro_30", treasury: "not-an-address" }),
+    ).toThrow(/Invalid treasury/);
+  });
+
+  it("rejects an unknown pack SKU", () => {
+    expect(() =>
+      buildProPackTransfer({
+        sku: "chesscito_pro_999" as ProPackSku,
+        treasury: TREASURY,
+      }),
+    ).toThrow(/Unknown PRO pack SKU/);
+  });
+
+  it("rejects a non-allowlisted token", () => {
+    expect(() =>
+      buildProPackTransfer({
+        sku: "chesscito_pro_30",
+        treasury: TREASURY,
+        tokenSymbol: "DAI",
+      }),
+    ).toThrow(/not-allowlisted/);
+  });
+});
+
+describe("buildProPackTransfer — purity", () => {
+  it("does not mutate the pack config", () => {
+    const before = JSON.stringify(
+      PRO_PACKS.chesscito_pro_30,
+      (_k, v) => (typeof v === "bigint" ? v.toString() : v),
+    );
+    buildProPackTransfer({ sku: "chesscito_pro_30", treasury: TREASURY });
+    const after = JSON.stringify(
+      PRO_PACKS.chesscito_pro_30,
       (_k, v) => (typeof v === "bigint" ? v.toString() : v),
     );
     expect(after).toBe(before);

--- a/apps/web/src/lib/payments/transfer-builder.ts
+++ b/apps/web/src/lib/payments/transfer-builder.ts
@@ -19,10 +19,13 @@ import {
   isValidAddress,
   PACK_PURCHASE_SOURCE,
   PEONES_PACKS,
+  PRO_PACKS,
+  PRO_PURCHASE_SOURCE,
   RAIL_ACCEPTED_STABLECOINS,
   SEASON_PASSES,
   SEASON_PASS_SOURCE,
   type PeonesPackSku,
+  type ProPackSku,
   type SeasonPassSku,
 } from "@/lib/payments/rail-config";
 
@@ -142,5 +145,57 @@ export function buildSeasonPassTransfer(args: {
     priceUsd6: pass.priceUsd6,
     sku: pass.sku,
     source: pass.source,
+  };
+}
+
+export type ProPackTransferTx = {
+  to: `0x${string}`;
+  data: `0x${string}`;
+  value: bigint;
+  token: { symbol: string; address: `0x${string}`; decimals: number };
+  treasury: `0x${string}`;
+  expectedAmount: bigint;
+  priceUsd6: bigint;
+  sku: ProPackSku;
+  source: typeof PRO_PURCHASE_SOURCE;
+};
+
+/**
+ * Build the direct-transfer payload for a Chesscito PRO purchase via the
+ * no-approve rail. Same shape as `buildSeasonPassTransfer` — the Shop's
+ * approve+`buyItem` PRO path (itemId 6) is untouched and stays a separate
+ * way to buy the identical entitlement.
+ *
+ * @throws on an invalid treasury, an unknown SKU, or a non-allowlisted token.
+ */
+export function buildProPackTransfer(args: {
+  sku: ProPackSku;
+  treasury: string;
+  tokenSymbol?: string;
+}): ProPackTransferTx {
+  if (!isValidAddress(args.treasury)) {
+    throw new Error(`Invalid treasury address: ${String(args.treasury)}`);
+  }
+  const pack = PRO_PACKS[args.sku];
+  if (!pack) {
+    throw new Error(`Unknown PRO pack SKU: ${String(args.sku)}`);
+  }
+  const token = resolveToken(args.tokenSymbol);
+  const expectedAmount = normalizePrice(pack.priceUsd6, token.decimals);
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "transfer",
+    args: [args.treasury, expectedAmount],
+  });
+  return {
+    to: token.address,
+    data,
+    value: 0n,
+    token: { symbol: token.symbol, address: token.address, decimals: token.decimals },
+    treasury: args.treasury,
+    expectedAmount,
+    priceUsd6: pack.priceUsd6,
+    sku: pack.sku,
+    source: pack.source,
   };
 }

--- a/apps/web/src/lib/pro/__tests__/pro-rail-error.test.ts
+++ b/apps/web/src/lib/pro/__tests__/pro-rail-error.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { classifyProRailError } from "../pro-rail-error";
+
+describe("classifyProRailError", () => {
+  it("no reason, or a user cancellation → silent (no banner, no telemetry)", () => {
+    expect(classifyProRailError(null, false)).toBe("silent");
+    expect(classifyProRailError(undefined, false)).toBe("silent");
+    expect(classifyProRailError("user_rejected", false)).toBe("silent");
+    expect(classifyProRailError("user_rejected", true)).toBe("silent");
+  });
+
+  it("a tx hash already exists → verifyFailed, regardless of the reason string", () => {
+    expect(classifyProRailError("amount_too_low", true)).toBe("verifyFailed");
+    expect(classifyProRailError("ledger_write_failed", true)).toBe("verifyFailed");
+    expect(classifyProRailError("some raw viem revert message", true)).toBe("verifyFailed");
+  });
+
+  it("no tx hash + rail unavailable → notConfigured", () => {
+    expect(classifyProRailError("unavailable", false)).toBe("notConfigured");
+  });
+
+  it("no tx hash + anything else → generic", () => {
+    expect(classifyProRailError("tx_failed", false)).toBe("generic");
+    expect(classifyProRailError("not_connected", false)).toBe("generic");
+  });
+});

--- a/apps/web/src/lib/pro/__tests__/use-pro-rail.test.ts
+++ b/apps/web/src/lib/pro/__tests__/use-pro-rail.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const useAccountMock = vi.hoisted(() => vi.fn());
+const useChainIdMock = vi.hoisted(() => vi.fn());
+const writeMock = vi.hoisted(() => vi.fn());
+const waitReceiptMock = vi.hoisted(() => vi.fn());
+vi.mock("wagmi", () => ({
+  useAccount: useAccountMock,
+  useChainId: useChainIdMock,
+  usePublicClient: () => ({ waitForTransactionReceipt: waitReceiptMock }),
+  useWriteContract: () => ({ writeContractAsync: writeMock }),
+}));
+vi.mock("@/lib/errors", () => ({
+  isUserCancellation: (e: unknown) => Boolean((e as { cancelled?: boolean })?.cancelled),
+}));
+
+import { act, renderHook } from "@testing-library/react";
+import { useProRail } from "@/lib/pro/use-pro-rail";
+
+const WALLET = "0xaaaabbbbccccddddeeeeffff0000111122223333";
+const USDC = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
+const HASH = `0x${"a".repeat(64)}` as const;
+
+function mockFetch(body: Record<string, unknown>) {
+  return vi.fn().mockResolvedValue({ json: () => Promise.resolve(body) });
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_CHESSCITO_TREASURY_ADDRESS =
+    "0x1234567890abcdef1234567890abcdef12345678";
+  useAccountMock.mockReturnValue({ address: WALLET });
+  useChainIdMock.mockReturnValue(42220);
+  writeMock.mockReset();
+  writeMock.mockResolvedValue(HASH);
+  waitReceiptMock.mockReset();
+  waitReceiptMock.mockResolvedValue({ status: "success" });
+  vi.stubGlobal(
+    "fetch",
+    mockFetch({
+      ok: true,
+      expiresAt: 1_800_000_000_000,
+      duplicate: false,
+      overpaid: false,
+      token: USDC,
+      amountPaid: "1990000",
+    }),
+  );
+});
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_CHESSCITO_TREASURY_ADDRESS;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const args = { sku: "chesscito_pro_30" as const, tokenSymbol: "USDC" };
+
+describe("useProRail — availability (fail-closed)", () => {
+  it("no treasury → unavailable, pay() never sends", async () => {
+    delete process.env.NEXT_PUBLIC_CHESSCITO_TREASURY_ADDRESS;
+    const { result } = renderHook(() => useProRail(args));
+    expect(result.current.available).toBe(false);
+    await act(async () => {
+      await result.current.pay();
+    });
+    expect(writeMock).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("error");
+    expect(result.current.errorReason).toBe("unavailable");
+  });
+
+  it("wrong chain → unavailable", async () => {
+    useChainIdMock.mockReturnValue(1);
+    const { result } = renderHook(() => useProRail(args));
+    expect(result.current.available).toBe(false);
+    await act(async () => {
+      await result.current.pay();
+    });
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  it("unsupported token → unavailable", async () => {
+    const { result } = renderHook(() => useProRail({ ...args, tokenSymbol: "DAI" }));
+    expect(result.current.available).toBe(false);
+    await act(async () => {
+      await result.current.pay();
+    });
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useProRail — happy path", () => {
+  it("builds, writes, waits, verifies → success + expiresAt", async () => {
+    const { result } = renderHook(() => useProRail(args));
+    await act(async () => {
+      await result.current.pay();
+    });
+
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    const call = writeMock.mock.calls[0][0];
+    expect(call.functionName).toBe("transfer");
+    expect(call.address).toBe(USDC);
+    expect(waitReceiptMock).toHaveBeenCalledWith({ hash: HASH });
+
+    expect(result.current.phase).toBe("success");
+    expect(result.current.result?.expiresAt).toBe(1_800_000_000_000);
+    expect(result.current.result?.duplicate).toBe(false);
+    expect(result.current.txHash).toBe(HASH);
+    expect(fetch).toHaveBeenCalledWith("/api/verify-payment", expect.any(Object));
+  });
+
+  it("never calls approve — direct transfer only", async () => {
+    const { result } = renderHook(() => useProRail(args));
+    await act(async () => {
+      await result.current.pay();
+    });
+    for (const c of writeMock.mock.calls) {
+      expect(c[0].functionName).not.toBe("approve");
+      expect(c[0].address).toBe(USDC);
+    }
+  });
+});
+
+describe("useProRail — errors", () => {
+  it("verify error (amount_too_low) → error, keeps txHash for re-verify via verifyAgain", async () => {
+    vi.stubGlobal("fetch", mockFetch({ ok: false, error: "amount_too_low" }));
+    const { result } = renderHook(() => useProRail(args));
+    await act(async () => {
+      await result.current.pay();
+    });
+    expect(result.current.phase).toBe("error");
+    expect(result.current.errorReason).toBe("amount_too_low");
+    expect(result.current.txHash).toBe(HASH);
+
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({ ok: true, duplicate: true, expiresAt: 1_800_000_000_000, token: USDC, amountPaid: "1990000" }),
+    );
+    await act(async () => {
+      await result.current.verifyAgain();
+    });
+    expect(result.current.phase).toBe("success");
+    expect(result.current.result?.duplicate).toBe(true);
+  });
+
+  it("retriable verify error (ledger_write_failed) → auto-retries → success", async () => {
+    const okBody = {
+      ok: true,
+      expiresAt: 1_800_000_000_000,
+      duplicate: true,
+      token: USDC,
+      amountPaid: "1990000",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ ok: false, error: "ledger_write_failed" }) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(okBody) });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useProRail({ ...args, retryDelaysMs: [0] }));
+    await act(async () => {
+      await result.current.pay();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.phase).toBe("success");
+  });
+
+  it("write rejected by user → error, no double-write", async () => {
+    writeMock.mockReset();
+    writeMock.mockRejectedValue({ cancelled: true });
+    const { result } = renderHook(() => useProRail(args));
+    await act(async () => {
+      await result.current.pay();
+    });
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(result.current.phase).toBe("error");
+    expect(result.current.errorReason).toBe("user_rejected");
+  });
+});

--- a/apps/web/src/lib/pro/__tests__/use-pro-sheet-state.test.tsx
+++ b/apps/web/src/lib/pro/__tests__/use-pro-sheet-state.test.tsx
@@ -5,18 +5,24 @@ import type { ReactNode } from "react";
 import enMessages from "@/lib/content/messages/en";
 
 const TEST_WALLET = "0x000000000000000000000000000000000000abcd";
-const SHOP_ADDRESS = "0x0000000000000000000000000000000000005a4e";
+const TREASURY = "0x1234567890abcdef1234567890abcdef12345678";
+const USDC = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
+const HASH = `0x${"a".repeat(64)}` as const;
 
 const useAccountMock = vi.hoisted(() =>
   vi.fn(() => ({ address: TEST_WALLET, isConnected: true })),
 );
 const useChainIdMock = vi.hoisted(() => vi.fn(() => 42220));
-const usePublicClientMock = vi.hoisted(() => vi.fn(() => ({}) as object));
+const waitReceiptMock = vi.hoisted(() => vi.fn());
+const usePublicClientMock = vi.hoisted(() =>
+  vi.fn(() => ({ waitForTransactionReceipt: waitReceiptMock })),
+);
 const useReadContractsMock = vi.hoisted(() =>
   vi.fn(() => ({
     data: undefined as
       | undefined
       | { result?: bigint; status?: string }[],
+    isLoading: false,
   })),
 );
 const writeContractAsyncMock = vi.hoisted(() => vi.fn());
@@ -38,7 +44,6 @@ const useProStatusMock = vi.hoisted(() =>
 );
 const trackMock = vi.hoisted(() => vi.fn());
 const hapticSuccessMock = vi.hoisted(() => vi.fn());
-const executeProPurchaseMock = vi.hoisted(() => vi.fn());
 
 vi.mock("wagmi", () => ({
   useAccount: () => useAccountMock(),
@@ -57,13 +62,10 @@ vi.mock("@/lib/pro/use-pro-status", () => ({
   useProStatus: () => useProStatusMock(),
 }));
 
-vi.mock("@/lib/pro/purchase", () => ({
-  executeProPurchase: (...args: unknown[]) => executeProPurchaseMock(...args),
-}));
-
 vi.mock("@/lib/contracts/chains", () => ({
   getConfiguredChainId: () => 42220,
-  getShopAddress: () => SHOP_ADDRESS,
+  getShopAddress: () => "0x0000000000000000000000000000000000005a4e",
+  getMiniPayFeeCurrency: () => undefined,
 }));
 
 vi.mock("@/lib/telemetry", () => ({
@@ -76,9 +78,6 @@ vi.mock("@/lib/haptics", () => ({
 
 import { useProSheetState } from "../use-pro-sheet-state";
 
-/** Wraps `renderHook` with the next-intl provider so the hook's
- *  internal `useTranslations("PRO_COPY")` call resolves successfully.
- *  EN bundle is sufficient — these tests assert behavior, not copy. */
 const IntlWrapper = ({ children }: { children: ReactNode }) => (
   <NextIntlClientProvider
     locale="en"
@@ -93,27 +92,27 @@ const IntlWrapper = ({ children }: { children: ReactNode }) => (
 );
 IntlWrapper.displayName = "IntlWrapper";
 
-function renderProSheetHook() {
-  return renderHook(() => useProSheetState(), { wrapper: IntlWrapper });
+function renderProSheetHook(options?: Parameters<typeof useProSheetState>[0]) {
+  return renderHook(() => useProSheetState(options), { wrapper: IntlWrapper });
 }
 
-/** Token balances large enough to clear the cheapest stablecoin tier so
- *  `selectPaymentToken(PRO_PRICE_USD6)` resolves to a non-null token in
- *  the success / verify-failed tests. */
 function withSufficientBalances() {
   useReadContractsMock.mockReturnValue({
     data: [
-      // ACCEPTED_TOKENS entries — assume 6 decimals, balance 1_000 USD6
       { result: 1_000_000_000n, status: "success" },
       { result: 1_000_000_000n, status: "success" },
       { result: 1_000_000_000n, status: "success" },
-      // CELO sibling — never used by PRO but read in the same batch
-      { result: 0n, status: "success" },
     ],
+    isLoading: false,
   });
 }
 
+function mockFetchOk(body: Record<string, unknown>) {
+  return vi.fn().mockResolvedValue({ json: () => Promise.resolve(body) });
+}
+
 beforeEach(() => {
+  process.env.NEXT_PUBLIC_CHESSCITO_TREASURY_ADDRESS = TREASURY;
   useAccountMock.mockReset();
   useChainIdMock.mockReset();
   usePublicClientMock.mockReset();
@@ -127,26 +126,27 @@ beforeEach(() => {
   useProStatusMock.mockReset();
   trackMock.mockReset();
   hapticSuccessMock.mockReset();
-  executeProPurchaseMock.mockReset();
+  waitReceiptMock.mockReset();
 
   useAccountMock.mockReturnValue({ address: TEST_WALLET, isConnected: true });
   useChainIdMock.mockReturnValue(42220);
-  usePublicClientMock.mockReturnValue({} as object);
-  useReadContractsMock.mockReturnValue({ data: undefined });
-  useWriteContractMock.mockReturnValue({
-    writeContractAsync: writeContractAsyncMock,
-  });
+  usePublicClientMock.mockReturnValue({ waitForTransactionReceipt: waitReceiptMock });
+  useReadContractsMock.mockReturnValue({ data: undefined, isLoading: false });
+  useWriteContractMock.mockReturnValue({ writeContractAsync: writeContractAsyncMock });
   useSwitchChainMock.mockReturnValue({ switchChain: switchChainMock });
   useProStatusMock.mockReturnValue({
     status: null,
     isLoading: false,
     refetch: refetchProStatusMock,
   });
+  writeContractAsyncMock.mockResolvedValue(HASH);
+  waitReceiptMock.mockResolvedValue({ status: "success" });
 
-  vi.stubGlobal("fetch", vi.fn());
+  vi.stubGlobal("fetch", mockFetchOk({ ok: true, expiresAt: Date.now() + 30 * 86_400_000, token: USDC, amountPaid: "1990000", duplicate: false, overpaid: false }));
 });
 
 afterEach(() => {
+  delete process.env.NEXT_PUBLIC_CHESSCITO_TREASURY_ADDRESS;
   vi.unstubAllGlobals();
 });
 
@@ -166,10 +166,7 @@ describe("useProSheetState — open/close lifecycle", () => {
 
   it("closeSheet while idle clears the sheet + resets error/verify state", async () => {
     withSufficientBalances();
-    executeProPurchaseMock.mockResolvedValueOnce({
-      kind: "verify-failed",
-      txHash: "0xfeedface",
-    });
+    vi.stubGlobal("fetch", mockFetchOk({ ok: false, error: "amount_too_low" }));
 
     const { result } = renderProSheetHook();
 
@@ -180,7 +177,7 @@ describe("useProSheetState — open/close lifecycle", () => {
       await result.current.sheetProps.onPurchase();
     });
 
-    expect(result.current.sheetProps.verifyFailedTxHash).toBe("0xfeedface");
+    expect(result.current.sheetProps.verifyFailedTxHash).toBe(HASH);
     expect(result.current.sheetProps.errorMessage).not.toBeNull();
 
     act(() => {
@@ -194,73 +191,25 @@ describe("useProSheetState — open/close lifecycle", () => {
 });
 
 describe("useProSheetState — handlePurchase", () => {
-  it("returns early without firing pro_purchase_started when balances are insufficient (no-token)", async () => {
-    // tokenBalances=undefined → selectPaymentToken returns null → no-token.
+  it("returns early without calling the rail when balances are insufficient (no-token)", async () => {
     const { result } = renderProSheetHook();
 
     await act(async () => {
       await result.current.sheetProps.onPurchase();
     });
 
-    expect(trackMock).toHaveBeenCalledWith("pro_purchase_failed", {
-      kind: "no-token",
-    });
-    // pro_purchase_started must NOT fire for the no-token preview branch —
-    // the lookahead exists precisely to keep the funnel clean.
+    expect(trackMock).toHaveBeenCalledWith("pro_purchase_failed", { kind: "no-token" });
     expect(
       trackMock.mock.calls.find((c) => c[0] === "pro_purchase_started"),
     ).toBeUndefined();
     expect(result.current.sheetProps.errorMessage).toBe(
       "Insufficient stablecoin balance.",
     );
-    expect(executeProPurchaseMock).not.toHaveBeenCalled();
+    expect(writeContractAsyncMock).not.toHaveBeenCalled();
   });
 
-  it("P1-6 invariant: never settles in CELO even when CELO is the only token with balance", async () => {
-    // CELO at the tail of the read; ACCEPTED_TOKENS (USDC/USDT/USDM) all
-    // empty. If `selectPaymentToken` accidentally widened to include
-    // CELO (e.g. by dropping the `slice(0, ACCEPTED_TOKENS.length)`
-    // or by swapping `ACCEPTED_TOKENS` → `BALANCE_READ_TOKENS` in the
-    // call), this test would surface a successful selection of CELO
-    // and fail. Today the slice keeps CELO out → no-token fires.
-    //
-    // Closes P1-6 (CELO oculto en runtime MiniPay). MiniPay never
-    // surfaces CELO; we make PRO equally strict regardless of runtime
-    // so a user with only CELO outside MiniPay also can't accidentally
-    // settle PRO in CELO at distorted USD value.
-    useReadContractsMock.mockReturnValue({
-      data: [
-        // USDC / USDT / USDM all empty
-        { result: 0n, status: "success" },
-        { result: 0n, status: "success" },
-        { result: 0n, status: "success" },
-        // CELO at the tail — huge balance (1000 CELO at 18 decimals)
-        { result: 1_000_000_000_000_000_000_000n, status: "success" },
-      ],
-    });
-    const { result } = renderProSheetHook();
-
-    await act(async () => {
-      await result.current.sheetProps.onPurchase();
-    });
-
-    expect(trackMock).toHaveBeenCalledWith("pro_purchase_failed", {
-      kind: "no-token",
-    });
-    expect(
-      trackMock.mock.calls.find((c) => c[0] === "pro_purchase_started"),
-    ).toBeUndefined();
-    expect(executeProPurchaseMock).not.toHaveBeenCalled();
-  });
-
-  it("on success: closes sheet, refetches PRO status, fires haptic + confirmed event", async () => {
+  it("on success: sends a direct transfer (no approve), closes sheet, refetches PRO status, fires haptic + confirmed event", async () => {
     withSufficientBalances();
-    executeProPurchaseMock.mockResolvedValueOnce({
-      kind: "success",
-      txHash: "0xabcdef0123456789",
-      expiresAt: Date.now() + 30 * 86_400_000,
-    });
-
     const { result } = renderProSheetHook();
 
     act(() => {
@@ -270,21 +219,22 @@ describe("useProSheetState — handlePurchase", () => {
       await result.current.sheetProps.onPurchase();
     });
 
+    for (const c of writeContractAsyncMock.mock.calls) {
+      expect(c[0].functionName).not.toBe("approve");
+    }
+    expect(writeContractAsyncMock).toHaveBeenCalledTimes(1);
     expect(result.current.open).toBe(false);
     expect(refetchProStatusMock).toHaveBeenCalledTimes(1);
     expect(hapticSuccessMock).toHaveBeenCalledTimes(1);
     expect(trackMock).toHaveBeenCalledWith(
       "pro_purchase_confirmed",
-      expect.objectContaining({ tx_hash_prefix: "0xabcdef01" }),
+      expect.objectContaining({ days_granted: 30, tx_hash_prefix: HASH.slice(0, 10) }),
     );
   });
 
   it("on verify-failed: keeps sheet open, sets verifyFailedTxHash + errorMessage, surfaces retry CTA", async () => {
     withSufficientBalances();
-    executeProPurchaseMock.mockResolvedValueOnce({
-      kind: "verify-failed",
-      txHash: "0xverifyhash",
-    });
+    vi.stubGlobal("fetch", mockFetchOk({ ok: false, error: "amount_too_low" }));
 
     const { result } = renderProSheetHook();
 
@@ -296,27 +246,17 @@ describe("useProSheetState — handlePurchase", () => {
     });
 
     expect(result.current.open).toBe(true);
-    expect(result.current.sheetProps.verifyFailedTxHash).toBe("0xverifyhash");
+    expect(result.current.sheetProps.verifyFailedTxHash).toBe(HASH);
     expect(result.current.sheetProps.errorMessage).not.toBeNull();
     expect(trackMock).toHaveBeenCalledWith(
       "pro_purchase_failed",
       expect.objectContaining({ kind: "verify-failed" }),
     );
   });
-});
 
-describe("useProSheetState — handleRetryVerify", () => {
-  it("on /api/verify-pro 200 + active=true: closes sheet, clears state, refetches", async () => {
+  it("on user cancellation: stays silent — no errorMessage, no pro_purchase_failed", async () => {
     withSufficientBalances();
-    executeProPurchaseMock.mockResolvedValueOnce({
-      kind: "verify-failed",
-      txHash: "0xretryhash",
-    });
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ active: true }),
-    });
+    writeContractAsyncMock.mockRejectedValueOnce(new Error("User rejected the request"));
 
     const { result } = renderProSheetHook();
 
@@ -326,7 +266,31 @@ describe("useProSheetState — handleRetryVerify", () => {
     await act(async () => {
       await result.current.sheetProps.onPurchase();
     });
-    expect(result.current.sheetProps.verifyFailedTxHash).toBe("0xretryhash");
+
+    expect(result.current.open).toBe(true);
+    expect(result.current.sheetProps.errorMessage).toBeNull();
+    expect(
+      trackMock.mock.calls.find((c) => c[0] === "pro_purchase_failed"),
+    ).toBeUndefined();
+  });
+});
+
+describe("useProSheetState — handleRetryVerify", () => {
+  it("on retry success: closes sheet, clears state, refetches", async () => {
+    withSufficientBalances();
+    vi.stubGlobal("fetch", mockFetchOk({ ok: false, error: "amount_too_low" }));
+
+    const { result } = renderProSheetHook();
+
+    act(() => {
+      result.current.openSheet();
+    });
+    await act(async () => {
+      await result.current.sheetProps.onPurchase();
+    });
+    expect(result.current.sheetProps.verifyFailedTxHash).toBe(HASH);
+
+    vi.stubGlobal("fetch", mockFetchOk({ ok: true, duplicate: true, expiresAt: Date.now() + 30 * 86_400_000, token: USDC, amountPaid: "1990000" }));
 
     await act(async () => {
       result.current.sheetProps.onRetryVerify?.();
@@ -340,17 +304,9 @@ describe("useProSheetState — handleRetryVerify", () => {
     expect(refetchProStatusMock).toHaveBeenCalled();
   });
 
-  it("on /api/verify-pro non-active response: keeps state intact + fires retry-failed telemetry", async () => {
+  it("on retry still failing: keeps state intact + fires retry-failed telemetry", async () => {
     withSufficientBalances();
-    executeProPurchaseMock.mockResolvedValueOnce({
-      kind: "verify-failed",
-      txHash: "0xretryhash2",
-    });
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ active: false }),
-    });
+    vi.stubGlobal("fetch", mockFetchOk({ ok: false, error: "amount_too_low" }));
 
     const { result } = renderProSheetHook();
 
@@ -368,14 +324,11 @@ describe("useProSheetState — handleRetryVerify", () => {
     await waitFor(() => {
       expect(result.current.sheetProps.isRetryingVerify).toBe(false);
     });
-    expect(result.current.sheetProps.verifyFailedTxHash).toBe("0xretryhash2");
+    expect(result.current.sheetProps.verifyFailedTxHash).toBe(HASH);
     expect(result.current.sheetProps.errorMessage).not.toBeNull();
     expect(trackMock).toHaveBeenCalledWith(
       "pro_verify_retry_failed",
-      expect.objectContaining({
-        tx_hash_prefix: "0xretryhas",
-        status: 200,
-      }),
+      expect.objectContaining({ tx_hash_prefix: HASH.slice(0, 10) }),
     );
   });
 });

--- a/apps/web/src/lib/pro/pro-rail-error.ts
+++ b/apps/web/src/lib/pro/pro-rail-error.ts
@@ -1,0 +1,23 @@
+/**
+ * Classifies a `useProRail` error into the buckets `<ProSheet>` already has
+ * copy for (PRO_COPY.errors.*) — no new i18n keys needed. Pure so the
+ * mapping is unit-testable without next-intl in scope.
+ */
+export type ProRailErrorKind = "silent" | "notConfigured" | "verifyFailed" | "generic";
+
+export function classifyProRailError(
+  errorReason: string | null | undefined,
+  hasTxHash: boolean,
+): ProRailErrorKind {
+  if (!errorReason || errorReason === "user_rejected" || errorReason === "tx_rejected") {
+    return "silent";
+  }
+  // A txHash only exists once the transfer has been sent — the payment
+  // already landed on-chain, so any failure past this point is a
+  // verification hiccup, not a lost purchase.
+  if (hasTxHash) return "verifyFailed";
+  if (errorReason === "unavailable" || errorReason === "rail_not_configured" || errorReason === "no_treasury") {
+    return "notConfigured";
+  }
+  return "generic";
+}

--- a/apps/web/src/lib/pro/use-pro-rail.ts
+++ b/apps/web/src/lib/pro/use-pro-rail.ts
@@ -1,0 +1,234 @@
+"use client";
+
+/**
+ * useProRail — client hook for buying Chesscito PRO via the no-approve
+ * stablecoin direct-transfer rail (`ERC20.transfer(treasury, amount)`).
+ * Mirrors `useSeasonPassRail` exactly (same phase machine, same verify
+ * auto-retry with backoff) — different SKU family, different result shape.
+ *
+ * The Shop's approve + `buyItem(PRO_ITEM_ID, ...)` path (itemId 6) is a
+ * separate, untouched way to buy the same entitlement — see
+ * `lib/shop/use-shop-sheet-state.ts`.
+ */
+
+import { useCallback, useState } from "react";
+import { useAccount, useChainId, usePublicClient, useWriteContract } from "wagmi";
+
+import { erc20Abi } from "@/lib/contracts/tokens";
+import { getMiniPayFeeCurrency } from "@/lib/contracts/chains";
+import { isUserCancellation } from "@/lib/errors";
+import {
+  getTreasuryAddressClient,
+  RAIL_ACCEPTED_STABLECOINS,
+  type ProPackSku,
+} from "@/lib/payments/rail-config";
+import { buildProPackTransfer } from "@/lib/payments/transfer-builder";
+
+const CELO_MAINNET_CHAIN_ID = 42220;
+const DEFAULT_VERIFY_RETRY_DELAYS_MS = [1000, 3000, 8000];
+const RETRIABLE_VERIFY_ERRORS = new Set([
+  "rate_limited",
+  "ledger_unavailable",
+  "ledger_write_failed",
+  "receipt_not_found",
+]);
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export type ProRailPhase =
+  | "idle"
+  | "preparing"
+  | "awaiting_signature"
+  | "pending_tx"
+  | "verifying"
+  | "success"
+  | "error";
+
+export type ProRailResult = {
+  txHash: string;
+  duplicate: boolean;
+  expiresAt: number;
+  token: string;
+  amountPaid: string;
+  overpaid: boolean;
+};
+
+export type UseProRailArgs = {
+  sku: ProPackSku;
+  tokenSymbol: string;
+  onVerified?: (result: ProRailResult) => void;
+  retryDelaysMs?: number[];
+};
+
+export function useProRail({
+  sku,
+  tokenSymbol,
+  onVerified,
+  retryDelaysMs = DEFAULT_VERIFY_RETRY_DELAYS_MS,
+}: UseProRailArgs) {
+  const { address } = useAccount();
+  const chainId = useChainId();
+  const publicClient = usePublicClient({ chainId });
+  const { writeContractAsync } = useWriteContract();
+
+  const [phase, setPhase] = useState<ProRailPhase>("idle");
+  const [txHash, setTxHash] = useState<`0x${string}` | null>(null);
+  const [result, setResult] = useState<ProRailResult | null>(null);
+  const [errorReason, setErrorReason] = useState<string | null>(null);
+
+  const treasury = getTreasuryAddressClient();
+  const tokenEntry = RAIL_ACCEPTED_STABLECOINS.find((t) => t.symbol === tokenSymbol) ?? null;
+
+  const available =
+    Boolean(treasury) && chainId === CELO_MAINNET_CHAIN_ID && Boolean(tokenEntry);
+
+  const reset = useCallback(() => {
+    setPhase("idle");
+    setTxHash(null);
+    setResult(null);
+    setErrorReason(null);
+  }, []);
+
+  const verify = useCallback(
+    async (hash: `0x${string}`) => {
+      if (!tokenEntry) return;
+      setPhase("verifying");
+      for (let attempt = 0; ; attempt++) {
+        try {
+          const res = await fetch("/api/verify-payment", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              chainId: CELO_MAINNET_CHAIN_ID,
+              txHash: hash,
+              wallet: address,
+              token: tokenEntry.address,
+              sku,
+            }),
+          });
+          const json = (await res.json()) as {
+            ok?: boolean;
+            error?: string;
+            duplicate?: boolean;
+            expiresAt?: number;
+            token?: string;
+            amountPaid?: string;
+            overpaid?: boolean;
+          };
+          if (json.ok) {
+            const railResult: ProRailResult = {
+              txHash: hash,
+              duplicate: Boolean(json.duplicate),
+              expiresAt: Number(json.expiresAt ?? 0),
+              token: json.token ?? tokenEntry.address,
+              amountPaid: json.amountPaid ?? "",
+              overpaid: Boolean(json.overpaid),
+            };
+            setResult(railResult);
+            setPhase("success");
+            onVerified?.(railResult);
+            return;
+          }
+          if (RETRIABLE_VERIFY_ERRORS.has(json.error ?? "") && attempt < retryDelaysMs.length) {
+            await sleep(retryDelaysMs[attempt]);
+            continue;
+          }
+          setErrorReason(json.error ?? "verify_failed");
+          setPhase("error");
+          return;
+        } catch (e) {
+          if (attempt < retryDelaysMs.length) {
+            await sleep(retryDelaysMs[attempt]);
+            continue;
+          }
+          setErrorReason((e as Error)?.message ?? "network_error");
+          setPhase("error");
+          return;
+        }
+      }
+    },
+    [address, sku, tokenEntry, onVerified, retryDelaysMs],
+  );
+
+  const pay = useCallback(async () => {
+    if (!available || !treasury || !tokenEntry) {
+      setErrorReason("unavailable");
+      setPhase("error");
+      return;
+    }
+    if (!address) {
+      setErrorReason("not_connected");
+      setPhase("error");
+      return;
+    }
+    setErrorReason(null);
+    setResult(null);
+    setTxHash(null);
+    setPhase("preparing");
+
+    const tx = buildProPackTransfer({ sku, treasury, tokenSymbol });
+    const feeCurrency = getMiniPayFeeCurrency(chainId);
+    const base = {
+      address: tx.token.address,
+      abi: erc20Abi,
+      functionName: "transfer" as const,
+      args: [treasury, tx.expectedAmount] as const,
+      chainId: CELO_MAINNET_CHAIN_ID,
+      account: address,
+    };
+
+    try {
+      setPhase("awaiting_signature");
+      let hash: `0x${string}`;
+      try {
+        hash = await writeContractAsync(
+          (feeCurrency ? { ...base, feeCurrency } : base) as Parameters<
+            typeof writeContractAsync
+          >[0],
+        );
+      } catch (e) {
+        if (isUserCancellation(e) || !feeCurrency) throw e;
+        hash = await writeContractAsync(base as Parameters<typeof writeContractAsync>[0]);
+      }
+      setTxHash(hash);
+      setPhase("pending_tx");
+      await publicClient?.waitForTransactionReceipt({ hash });
+      await verify(hash);
+    } catch (e) {
+      setErrorReason(
+        isUserCancellation(e)
+          ? "user_rejected"
+          : e instanceof Error
+            ? e.message
+            : "tx_failed",
+      );
+      setPhase("error");
+    }
+  }, [
+    available,
+    treasury,
+    tokenEntry,
+    address,
+    sku,
+    tokenSymbol,
+    chainId,
+    publicClient,
+    writeContractAsync,
+    verify,
+  ]);
+
+  const verifyAgain = useCallback(async () => {
+    if (txHash) await verify(txHash);
+  }, [txHash, verify]);
+
+  return {
+    phase,
+    txHash,
+    result,
+    errorReason,
+    available,
+    pay,
+    verifyAgain,
+    reset,
+  };
+}

--- a/apps/web/src/lib/pro/use-pro-sheet-state.ts
+++ b/apps/web/src/lib/pro/use-pro-sheet-state.ts
@@ -1,33 +1,22 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  useAccount,
-  useChainId,
-  usePublicClient,
-  useReadContracts,
-  useSwitchChain,
-  useWriteContract,
-} from "wagmi";
+import { useAccount, useChainId, useSwitchChain } from "wagmi";
 import { useConnectWallet } from "@/lib/wallet/use-connect-wallet";
 import { useTranslations } from "next-intl";
-import {
-  getConfiguredChainId,
-  getShopAddress,
-} from "@/lib/contracts/chains";
-import { PRO_PRICE_USD6 } from "@/lib/contracts/shop-catalog";
-import {
-  ACCEPTED_TOKENS,
-  CELO_TOKEN,
-  erc20Abi,
-} from "@/lib/contracts/tokens";
-import { selectMaxBalanceToken } from "@/lib/contracts/select-payment-token";
+import { getConfiguredChainId } from "@/lib/contracts/chains";
+import { getProPack } from "@/lib/payments/rail-config";
+import { useStablecoinTokenSelection } from "@/lib/payments/use-get-peones-token-selection";
 import { hapticSuccess } from "@/lib/haptics";
-import { executeProPurchase } from "@/lib/pro/purchase";
+import { classifyProRailError } from "@/lib/pro/pro-rail-error";
+import { useProRail, type ProRailResult } from "@/lib/pro/use-pro-rail";
 import { useProStatus, type ProStatus } from "@/lib/pro/use-pro-status";
 import { track } from "@/lib/telemetry";
 
 import type { ProSheetProps } from "@/components/pro/pro-sheet";
+
+const PRO_RAIL_SKU = "chesscito_pro_30" as const;
+const FALLBACK_TOKEN_SYMBOL = "USDC";
 
 type SheetProps = Omit<ProSheetProps, "open" | "onOpenChange"> & {
   open: boolean;
@@ -48,10 +37,11 @@ export type ProPurchaseReceipt = {
 };
 
 export type UseProSheetStateOptions = {
-  /** Fires AFTER the wagmi receipt confirms — NOT on user-initiated close.
-   *  Deferred via `requestAnimationFrame` so the dispatch lands after the
-   *  sheet's exit transition starts (design-lock §6.4 race 1). The host
-   *  can synchronously trigger atmosphere shift / shields refresh / etc. */
+  /** Fires AFTER the on-chain payment verifies — NOT on user-initiated
+   *  close. Deferred via `requestAnimationFrame` so the dispatch lands
+   *  after the sheet's exit transition starts (design-lock §6.4 race 1).
+   *  The host can synchronously trigger atmosphere shift / shields
+   *  refresh / etc. */
   onPurchaseSuccess?: (receipt: ProPurchaseReceipt) => void;
 };
 
@@ -78,6 +68,11 @@ export type UseProSheetStateReturn = {
  *  the B2 "Play in Arena" race (audit 2026-05-07) and what hid the bottom
  *  CTA behind the legacy persistent dock.
  *
+ *  Buys via the no-approve stablecoin direct-transfer rail (`useProRail`,
+ *  same rail as Season Pass / Get Peones) — single tx, no approve. The
+ *  Shop's approve + `buyItem` PRO path (itemId 6) is a separate, untouched
+ *  way to buy the identical entitlement (see `use-shop-sheet-state.ts`).
+ *
  *  Self-contained — pulls every wagmi/RainbowKit dependency it needs.
  *  Returns `sheetProps` already shaped for `<ProSheet>` so the host
  *  component is just `<ProSheet {...proSheet.sheetProps} />`. */
@@ -87,79 +82,141 @@ export function useProSheetState(
   const t = useTranslations("PRO_COPY");
   const { address, isConnected } = useAccount();
   const chainId = useChainId();
-  const publicClient = usePublicClient({ chainId });
   const { switchChain } = useSwitchChain();
   const { connectWallet } = useConnectWallet();
 
   const configuredChainId = useMemo(() => getConfiguredChainId(), []);
   const isCorrectChain =
     configuredChainId != null && chainId === configuredChainId;
-  const shopAddress = useMemo(() => getShopAddress(chainId), [chainId]);
 
-  const { writeContractAsync: writeShopAsync } = useWriteContract();
   const { status: proStatus, refetch: refetchProStatus } = useProStatus(address);
+  const pack = useMemo(() => getProPack(PRO_RAIL_SKU), []);
 
-  // Capture the success callback in a ref so handlePurchase's deps array
-  // stays stable across host renders (the host doesn't have to memoize
-  // the callback). The ref is refreshed on every render synchronously
-  // via the layout-style effect below.
+  // Capture the success callback in a ref so onVerified's identity stays
+  // stable across host renders (the host doesn't have to memoize it). The
+  // ref is refreshed on every render synchronously via a layout-style effect.
   const onPurchaseSuccessRef = useRef(options?.onPurchaseSuccess);
   useEffect(() => {
     onPurchaseSuccessRef.current = options?.onPurchaseSuccess;
   });
 
-  const fireOnPurchaseSuccess = useCallback((txHash: string) => {
-    const cb = onPurchaseSuccessRef.current;
-    if (!cb) return;
-    const buyer = address;
-    if (!buyer) return;
-    // rAF defer — landing the dispatch after the sheet's exit transition
-    // starts so atmosphere shift / shields refresh feels sequenced rather
-    // than racing with the close animation (design-lock §6.4 race 1).
-    requestAnimationFrame(() => {
-      cb({
-        txHash: txHash as `0x${string}`,
-        daysGranted: 30,
-        buyer: buyer as `0x${string}`,
+  const fireOnPurchaseSuccess = useCallback(
+    (txHash: string) => {
+      const cb = onPurchaseSuccessRef.current;
+      if (!cb) return;
+      const buyer = address;
+      if (!buyer) return;
+      // rAF defer — landing the dispatch after the sheet's exit transition
+      // starts so atmosphere shift / shields refresh feels sequenced rather
+      // than racing with the close animation (design-lock §6.4 race 1).
+      requestAnimationFrame(() => {
+        cb({
+          txHash: txHash as `0x${string}`,
+          daysGranted: pack.durationDays,
+          buyer: buyer as `0x${string}`,
+        });
       });
-    });
-  }, [address]);
+    },
+    [address, pack],
+  );
 
   const [open, setOpen] = useState(false);
-  const [purchaseState, setPurchaseState] = useState<
-    "idle" | "purchasing" | "verifying"
-  >("idle");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [verifyFailedTxHash, setVerifyFailedTxHash] = useState<string | null>(
-    null,
-  );
+  const [previewErrorMessage, setPreviewErrorMessage] = useState<string | null>(null);
   const [isRetryingVerify, setIsRetryingVerify] = useState(false);
+  // Read synchronously inside the rail's error effect so a manual retry's
+  // failure is attributed correctly regardless of render timing (same
+  // pattern as onPurchaseSuccessRef above).
+  const retryInFlightRef = useRef(false);
+  // Bumped at the START of every pay()/verifyAgain() call. A retry that
+  // fails with the exact same errorReason/txHash as the attempt before it
+  // would otherwise leave the error-effect's dependency array unchanged
+  // between commits (mocked I/O resolves fully within one microtask
+  // flush, so React batches the whole retry into one render) — the effect
+  // would then never re-fire and `isRetryingVerify` would stick forever.
+  // Including this token in the deps guarantees a fresh value every
+  // attempt regardless of what the outcome looks like.
+  const [attemptToken, setAttemptToken] = useState(0);
 
-  // Token balances drive `selectPaymentToken` — same shape ExercisesScreen
-  // uses. CELO sits at the tail purely to share the read; PRO never
-  // settles in CELO, only stablecoins.
-  const BALANCE_READ_TOKENS = useMemo(() => [...ACCEPTED_TOKENS, CELO_TOKEN], []);
-  const { data: tokenBalances } = useReadContracts({
-    contracts: BALANCE_READ_TOKENS.map((t) => ({
-      address: t.address,
-      abi: erc20Abi,
-      functionName: "balanceOf" as const,
-      args: address ? ([address] as const) : undefined,
-      chainId,
-    })),
-    allowFailure: true,
-    query: { enabled: Boolean(address), staleTime: 15_000 },
-  });
+  const selection = useStablecoinTokenSelection(pack.priceUsd6);
+  const tokenSymbol = selection.selectedSymbol ?? FALLBACK_TOKEN_SYMBOL;
 
-  const selectPaymentToken = useCallback(
-    (priceUsd6: bigint) =>
-      selectMaxBalanceToken(
-        ACCEPTED_TOKENS,
-        tokenBalances?.slice(0, ACCEPTED_TOKENS.length),
-        priceUsd6,
-      ),
-    [tokenBalances],
+  const handleVerified = useCallback(
+    (result: ProRailResult) => {
+      track("pro_purchase_confirmed", {
+        item_id: 6,
+        price_usd6: Number(pack.priceUsd6),
+        days_granted: pack.durationDays,
+        tx_hash_prefix: result.txHash.slice(0, 10),
+      });
+      refetchProStatus();
+      hapticSuccess();
+      retryInFlightRef.current = false;
+      setIsRetryingVerify(false);
+      setOpen(false);
+      fireOnPurchaseSuccess(result.txHash);
+    },
+    [pack, refetchProStatus, fireOnPurchaseSuccess],
   );
+
+  const rail = useProRail({ sku: PRO_RAIL_SKU, tokenSymbol, onVerified: handleVerified });
+
+  const errorKind = useMemo(
+    () =>
+      rail.phase === "error"
+        ? classifyProRailError(rail.errorReason, Boolean(rail.txHash))
+        : null,
+    [rail.phase, rail.errorReason, rail.txHash],
+  );
+
+  // Fires telemetry exactly once per attempt that ends in "error" —
+  // `attemptToken` in the deps guarantees this runs even when a retry's
+  // outcome is byte-identical to the attempt before it.
+  useEffect(() => {
+    if (rail.phase !== "error" || errorKind === null) return;
+    if (errorKind === "silent") {
+      retryInFlightRef.current = false;
+      setIsRetryingVerify(false);
+      return;
+    }
+    if (retryInFlightRef.current) {
+      track("pro_verify_retry_failed", {
+        tx_hash_prefix: rail.txHash ? rail.txHash.slice(0, 10) : null,
+        reason: rail.errorReason,
+      });
+    } else {
+      track("pro_purchase_failed", {
+        kind:
+          errorKind === "verifyFailed"
+            ? "verify-failed"
+            : errorKind === "notConfigured"
+              ? "unavailable"
+              : "error",
+      });
+    }
+    retryInFlightRef.current = false;
+    setIsRetryingVerify(false);
+  }, [rail.phase, rail.errorReason, rail.txHash, errorKind, attemptToken]);
+
+  const purchaseState: "idle" | "purchasing" | "verifying" =
+    rail.phase === "preparing" ||
+    rail.phase === "awaiting_signature" ||
+    rail.phase === "pending_tx"
+      ? "purchasing"
+      : rail.phase === "verifying" && !isRetryingVerify
+        ? "verifying"
+        : "idle";
+
+  const railErrorMessage =
+    errorKind === null || errorKind === "silent"
+      ? null
+      : errorKind === "notConfigured"
+        ? t("errors.notConfigured")
+        : errorKind === "verifyFailed"
+          ? t("errors.verifyFailedTitle")
+          : t("errors.purchaseFailed");
+
+  const errorMessage = previewErrorMessage ?? railErrorMessage;
+  const verifyFailedTxHash = errorKind === "verifyFailed" ? rail.txHash : null;
 
   const openSheet = useCallback(() => {
     setOpen(true);
@@ -168,132 +225,37 @@ export function useProSheetState(
   const closeSheet = useCallback(() => {
     if (purchaseState !== "idle" || isRetryingVerify) return;
     setOpen(false);
-    setErrorMessage(null);
-    setVerifyFailedTxHash(null);
-  }, [purchaseState, isRetryingVerify]);
+    setPreviewErrorMessage(null);
+    rail.reset();
+  }, [purchaseState, isRetryingVerify, rail]);
 
+  // Async (not `void`-wrapped) so a caller holding a direct reference —
+  // notably this file's own tests — can `await` full settlement. Still
+  // assignable to `ProSheetProps.onPurchase: () => void` (TS treats a
+  // `Promise<void>`-returning function as compatible with a `void`-typed
+  // callback).
   const handlePurchase = useCallback(async () => {
-    if (!address || !shopAddress || !publicClient || !isCorrectChain) return;
-    setErrorMessage(null);
-    setVerifyFailedTxHash(null);
-
-    const previewToken = selectPaymentToken(PRO_PRICE_USD6);
-    if (!previewToken) {
+    setPreviewErrorMessage(null);
+    if (!selection.selected) {
       track("pro_purchase_failed", { kind: "no-token" });
-      setErrorMessage(t("insufficientBalance"));
+      setPreviewErrorMessage(t("insufficientBalance"));
       return;
     }
-
     track("pro_purchase_started", {
       item_id: 6,
-      price_usd6: 1_990_000,
+      price_usd6: Number(pack.priceUsd6),
     });
+    setAttemptToken((n) => n + 1);
+    await rail.pay();
+  }, [selection, pack, rail, t]);
 
-    const result = await executeProPurchase({
-      address,
-      shopAddress,
-      publicClient,
-      chainId,
-      writeContractAsync: writeShopAsync,
-      selectPaymentToken: (price) => selectPaymentToken(price),
-      onPhaseChange: (phase) => setPurchaseState(phase),
-    });
-    setPurchaseState("idle");
-
-    if (result.kind === "success") {
-      track("pro_purchase_confirmed", {
-        item_id: 6,
-        price_usd6: 1_990_000,
-        days_granted: 30,
-        tx_hash_prefix: result.txHash.slice(0, 10),
-      });
-      refetchProStatus();
-      hapticSuccess();
-      setOpen(false);
-      fireOnPurchaseSuccess(result.txHash);
-      return;
-    }
-    if (result.kind === "cancelled") return;
-    if (result.kind === "verify-failed") {
-      track("pro_purchase_failed", {
-        kind: "verify-failed",
-        tx_hash_prefix: result.txHash ? result.txHash.slice(0, 10) : null,
-      });
-      setVerifyFailedTxHash(result.txHash ?? null);
-    } else {
-      track("pro_purchase_failed", { kind: result.kind });
-    }
-    setErrorMessage(
-      result.kind === "no-token"
-        ? t("insufficientBalance")
-        : result.kind === "timeout"
-          ? t("txTimeout")
-          : result.kind === "verify-failed"
-            ? t("errors.verifyFailedTitle")
-            : t("errors.purchaseFailed"),
-    );
-  }, [
-    address,
-    shopAddress,
-    publicClient,
-    isCorrectChain,
-    chainId,
-    writeShopAsync,
-    selectPaymentToken,
-    refetchProStatus,
-    fireOnPurchaseSuccess,
-    t,
-  ]);
-
-  const handleRetryVerify = useCallback(async () => {
-    if (!verifyFailedTxHash || !address || isRetryingVerify) return;
+  const handleRetryVerify = useCallback(() => {
+    if (!rail.txHash || isRetryingVerify) return;
+    retryInFlightRef.current = true;
     setIsRetryingVerify(true);
-    try {
-      const res = await fetch("/api/verify-pro", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          txHash: verifyFailedTxHash,
-          walletAddress: address,
-        }),
-      });
-      const json = (await res.json().catch(() => null)) as
-        | { active?: boolean }
-        | null;
-      if (res.ok && json?.active) {
-        track("pro_purchase_confirmed", {
-          item_id: 6,
-          price_usd6: 1_990_000,
-          days_granted: 30,
-          tx_hash_prefix: verifyFailedTxHash.slice(0, 10),
-        });
-        setErrorMessage(null);
-        setVerifyFailedTxHash(null);
-        refetchProStatus();
-        hapticSuccess();
-        setOpen(false);
-        fireOnPurchaseSuccess(verifyFailedTxHash);
-        return;
-      }
-      track("pro_verify_retry_failed", {
-        tx_hash_prefix: verifyFailedTxHash.slice(0, 10),
-        status: res.status,
-      });
-    } catch {
-      track("pro_verify_retry_failed", {
-        tx_hash_prefix: verifyFailedTxHash.slice(0, 10),
-        status: 0,
-      });
-    } finally {
-      setIsRetryingVerify(false);
-    }
-  }, [
-    verifyFailedTxHash,
-    address,
-    isRetryingVerify,
-    refetchProStatus,
-    fireOnPurchaseSuccess,
-  ]);
+    setAttemptToken((n) => n + 1);
+    void rail.verifyAgain();
+  }, [rail, isRetryingVerify]);
 
   const sheetProps: SheetProps = {
     open,
@@ -309,11 +271,11 @@ export function useProSheetState(
     errorMessage,
     verifyFailedTxHash,
     isRetryingVerify,
-    onRetryVerify: () => void handleRetryVerify(),
+    onRetryVerify: handleRetryVerify,
     onConnectWallet: () => connectWallet(),
     onSwitchNetwork: () =>
       configuredChainId != null && switchChain({ chainId: configuredChainId }),
-    onPurchase: () => void handlePurchase(),
+    onPurchase: handlePurchase,
   };
 
   return { open, openSheet, closeSheet, sheetProps, proStatus };

--- a/docs/handoffs/2026-07-01-treasury-canary-and-pro-rail-handoff.md
+++ b/docs/handoffs/2026-07-01-treasury-canary-and-pro-rail-handoff.md
@@ -22,18 +22,26 @@
    plan already decided "TX only for on-chain persistence, everything
    consumable via Peones" — it was only half-shipped (Coach analysis got the
    Peones-spend path, the old Shop-TX credit-pack path was never retired).
-5. **Phase 1 of the consolidation, PRO piece — done.** Chesscito PRO can now
-   be bought via the no-approve treasury rail (same mechanism as Season
-   Pass / Get Peones), in parallel with the existing Shop.buyItem path.
-   Backend only — UI still wired to the old path. See below.
+5. **Phase 1 of the consolidation, PRO piece — backend done.** Chesscito PRO
+   can now be bought via the no-approve treasury rail (same mechanism as
+   Season Pass / Get Peones), in parallel with the existing Shop.buyItem
+   path. Backend only at the time this doc was first written.
+6. **Task 4 (UI wiring) — done in a follow-up pass, same day.** `/hub`'s
+   `<ProSheet>` now uses the rail. Uncommitted — see the Task 4 section
+   below for full detail, including a scope correction (a third,
+   still-untouched PRO purchase path was found) and a real batching bug
+   caught by TDD.
 
-## Current state — safe to leave as-is
+## Current state — NOT all committed
 
-- Everything is committed and pushed to `main`. Nothing half-broken. The old
+- The canary + treasury repointing work (items 1–4 above) is committed and
+  pushed to `main` (`652d2965`). Nothing half-broken there. The old
   approve+`buyItem` PRO path (Shop itemId 6) still works unchanged — the new
   rail is additive, not a replacement yet.
-- Full test suite: 4597/4597 passing, tsc clean, as of the last commit
-  (`652d2965`).
+- **Task 4 (PRO UI → rail) is done but sitting uncommitted in the working
+  tree** as of this update — see below for the file list.
+- Full test suite: 4617/4617 passing, tsc clean (includes Task 4's new
+  tests; was 4597/4597 at the `652d2965` commit).
 - The new `pro_subscriptions` + `consume_pro_treasury_payment` migration
   (`apps/web/supabase/migrations/20260701140000_pro_treasury_payment.sql`)
   is committed but **not yet applied to hosted Supabase** — it applies via
@@ -41,36 +49,60 @@
 - Local Supabase is stopped. Docker is running (was started this session to
   validate the migration; leave running or stop it, either is fine).
 
-## Next task — Phase 1, Task 4: wire the PRO purchase UI
+## Phase 1, Task 4: wire the PRO purchase UI — DONE (uncommitted)
 
-**Not started.** This is the next concrete piece of Phase 1
-(`docs/product/chesscito-monetization-consolidation-audit-2026-07-01.md`,
-"Decision: two phases" section).
+Implemented via SDD → TDD → EDD in the same session this doc was written.
+Not yet committed/pushed — sitting as working-tree changes.
 
-What needs to happen:
+**Scope correction found during implementation:** there are actually
+*three* PRO purchase paths, not two. `<ProSheet>` at `/hub`
+(`useProSheetState`) is now on the new rail. `useShopSheetState`'s
+`PRO_ITEM_ID` branch (the `/exercises` Shop sheet, itemId 6, approve +
+`buyItem`) is untouched, as planned. But `<ExercisesScreen>` **also**
+renders its own separate `<ProSheet>` instance with a local
+`handleProPurchase()` still calling `executeProPurchase` (same old
+approve + `buyItem` + `/api/verify-pro` flow, `lib/pro/purchase.ts`) —
+this was NOT in scope for today and was left untouched. So
+`lib/pro/purchase.ts`/`executeProPurchase` is still live, not dead code.
 
-1. Find the `<ProSheet>` component (per `shop-catalog.ts`'s comment, it's
-   "the hero discoverability surface" at `/hub`) and the `PRO_ITEM_ID`
-   branch inside `useShopSheetState` (parallel to the `SHIELD_ITEM_ID`
-   branch — grep both for context).
-2. Switch that flow from approve + `Shop.buyItem` + `POST /api/verify-pro`
-   to the same `usePaymentRail`-style single-tx flow already used by
-   `GetPeonesSheet` / `SeasonPassSheet`, with `sku: "chesscito_pro_30"`.
-   The backend piece for this (`/api/verify-payment` PRO branch) is done
-   and tested — this task is UI-only.
-3. Keep the Shop `buyItem` PRO path (itemId 6) working in parallel — do not
-   remove it in this task. Both paths already compose correctly (shared
-   Redis extend logic, see `lib/coach/pro-extend.ts`).
-4. Per project convention for UI changes: start the dev server and
-   exercise the real purchase flow in a browser (or MiniPay) before calling
-   this done — don't just rely on the test suite for a user-facing flow
-   change.
-5. Once this ships and is proven (mirroring today's real-purchase
-   verification pattern for the canary/Season Pass), the natural follow-ups
-   are: retire the Shop-TX Coach-pack path (itemId 3/4, no new backend
-   needed, Peones already covers it), and build the Shield Peones-spend
-   backend (doesn't exist yet — see the audit doc's grant-mechanism risk
-   map) before retiring Shield's Shop-TX path. Founder stays parked.
+**New files:**
+- `lib/payments/transfer-builder.ts` — added `buildProPackTransfer`
+  (mirrors `buildSeasonPassTransfer`).
+- `lib/pro/use-pro-rail.ts` — `useProRail`, mirrors `useSeasonPassRail`
+  exactly (same phase machine/retry backoff), posts to
+  `/api/verify-payment` (already shipped, unchanged).
+- `lib/pro/pro-rail-error.ts` — pure `classifyProRailError` mapping rail
+  errors to `<ProSheet>`'s *existing* `PRO_COPY.errors.*` strings (no new
+  i18n keys).
+
+**Changed:** `lib/pro/use-pro-sheet-state.ts` rewritten to use
+`useStablecoinTokenSelection` + `useProRail` instead of the Shop
+approve+`buyItem` flow. `ProSheetProps`/`<ProSheet>` itself: **zero
+changes** — external contract identical, so `/arena` and
+`/profile`'s `useProSheetState()` consumers are unaffected.
+
+**Non-obvious bug found + fixed during TDD:** a manual "retry
+verification" that fails with the *same* error reason/txHash as the
+original failure can get silently swallowed by React 18's batching —
+the effect meant to fire on error-transition never re-runs because its
+dependency array looks unchanged between commits. Fixed with an
+explicit `attemptToken` counter bumped on every `pay()`/`verifyAgain()`
+call, included in the effect's deps. Caught by the "retry still
+failing" test, not by inspection.
+
+**Verified:** 4617/4617 tests green, `tsc --noEmit` clean. Browser pass
+(Playwright, dev server, Full mode) confirmed `<ProSheet>` renders
+correctly at `/hub` and `/exercises`, wallet-connect gate unregressed,
+close/reopen has no state leak, zero console errors. **Not verified:**
+the actual on-chain leg (direct transfer vs. approve+buyItem,
+`/api/verify-payment` vs `/api/verify-pro` on the wire) — no funded
+wallet reachable in the coding sandbox. Needs a real MiniPay/wallet
+pass before this is "proven" the way the canary/Season Pass were.
+
+**Not done yet (next task):** commit + push + PR. Then, per the
+original plan: retire the Shop-TX Coach-pack path (itemId 3/4, no new
+backend needed), and build the Shield Peones-spend backend (doesn't
+exist yet) before retiring Shield's Shop-TX path. Founder stays parked.
 
 ## Open decisions, not yet made (not blocking Task 4)
 


### PR DESCRIPTION
## Summary
- `/hub`'s `<ProSheet>` (`useProSheetState`) now buys Chesscito PRO via the direct stablecoin transfer rail (same mechanism as Season Pass / Get Peones) instead of approve + `Shop.buyItem` + `/api/verify-pro`.
- New: `buildProPackTransfer`, `useProRail` (mirrors `useSeasonPassRail`), `classifyProRailError` (pure, reuses existing `PRO_COPY.errors.*` — no new i18n keys).
- `<ProSheet>`'s props contract is unchanged. Two other PRO purchase paths (Shop `buyItem` itemId 6 via `useShopSheetState`, and `ExercisesScreen`'s own inline `<ProSheet>`/`executeProPurchase`) are intentionally untouched — out of scope for this task.

## Test plan
- [x] 4617/4617 tests passing (`pnpm exec vitest run`)
- [x] `tsc --noEmit` clean
- [x] Browser-verified via Playwright + dev server: `<ProSheet>` renders correctly at `/hub` and `/exercises`, wallet-connect gate unregressed, close/reopen has no state leak, zero console errors
- [ ] Real on-chain leg (direct transfer + `/api/verify-payment`) — not verifiable in this sandbox (no funded wallet); needs a real MiniPay/wallet pass before Prod rollout

Wolfcito 🐾 @akawolfcito