### PR TITLE
feat(arena): account entry on /arena select surface (Phase 2)

### DIFF
--- a/apps/web/src/app/[locale]/arena/page.tsx
+++ b/apps/web/src/app/[locale]/arena/page.tsx
@@ -1083,6 +1083,19 @@ function ArenaPageInner() {
                   }
                   : undefined
               }
+              account={
+                isConnected
+                  ? {
+                    isPro: proActiveCached,
+                    onTap: () => {
+                      track("arena_account_tap", {
+                        pro_active: proActiveCached,
+                      });
+                      router.push("/exercises?sheet=account");
+                    },
+                  }
+                  : undefined
+              }
               errorMessage={game.errorMessage}
             />
           )}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -9436,9 +9436,20 @@ button.hud-resource-chip:active:not(:disabled) {
 }
 
 .arena-scaffold-hud {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+/* Account entry — top-right of the arena HUD, mirroring the LITE hub
+   account circle. Absolutely anchored so it floats over the ContextualHeader
+   without shifting the title. */
+.arena-scaffold-account {
+  position: absolute;
+  right: 10px;
+  top: 4px;
+  z-index: 3;
 }
 
 .arena-scaffold-hud-top {

--- a/apps/web/src/components/arena/__tests__/arena-select-scaffold.test.tsx
+++ b/apps/web/src/components/arena/__tests__/arena-select-scaffold.test.tsx
@@ -123,6 +123,25 @@ describe("ArenaSelectScaffold", () => {
     expect(screen.queryByText(/PRO/)).not.toBeInTheDocument();
   });
 
+  it("renders the account entry when account prop is provided and fires onTap", async () => {
+    const onTap = vi.fn();
+    render(<ArenaSelectScaffold {...baseProps} account={{ isPro: false, onTap }} />);
+    await userEvent.click(screen.getByTestId("arena-account-chip"));
+    expect(onTap).toHaveBeenCalledOnce();
+  });
+
+  it("adds the PRO ring modifier when account.isPro is true", () => {
+    render(<ArenaSelectScaffold {...baseProps} account={{ isPro: true, onTap: vi.fn() }} />);
+    expect(screen.getByTestId("arena-account-chip").className).toContain(
+      "hub-account-circle--pro",
+    );
+  });
+
+  it("omits the account entry when the account prop is absent", () => {
+    render(<ArenaSelectScaffold {...baseProps} />);
+    expect(screen.queryByTestId("arena-account-chip")).toBeNull();
+  });
+
   it("renders an error message banner when errorMessage is provided", () => {
     render(<ArenaSelectScaffold {...baseProps} errorMessage="AI disconnected" />);
     expect(screen.getByText("AI disconnected")).toBeInTheDocument();

--- a/apps/web/src/components/arena/arena-select-scaffold.tsx
+++ b/apps/web/src/components/arena/arena-select-scaffold.tsx
@@ -47,6 +47,15 @@ type SoftGate = {
   onDismiss: () => void
 }
 
+/** Account entry (top-right of the HUD). Mirrors the LITE hub
+ *  `hub-account-circle`: a compact avatar chip routing into the account
+ *  surface. Caller only passes this when a wallet is connected — the
+ *  scaffold renders nothing otherwise. */
+type ArenaAccountEntry = {
+  isPro: boolean
+  onTap: () => void
+}
+
 type Props = {
   difficulty: ArenaDifficulty
   playerColor: PlayerColor
@@ -55,6 +64,7 @@ type Props = {
   onStart: () => void
   onBack?: () => void
   softGate?: SoftGate
+  account?: ArenaAccountEntry
   errorMessage?: string | null
   onError?: (
     context: import('@/components/error/primitive-boundary').PrimitiveBoundaryErrorContext,
@@ -75,10 +85,12 @@ export function ArenaSelectScaffold({
   onStart,
   onBack,
   softGate,
+  account,
   errorMessage,
   onError,
 }: Props) {
   const t = useTranslations('ARENA_COPY')
+  const tStatus = useTranslations('GLOBAL_STATUS_BAR_COPY')
   const arenaTitle = t('title')
   const colorLabels: Record<PlayerColor, string> = {
     w: t('playAsWhite'),
@@ -118,6 +130,33 @@ export function ArenaSelectScaffold({
         ) : (
           <ContextualHeader variant="title" title={arenaTitle} />
         )}
+        {account ? (
+          <button
+            type="button"
+            onClick={account.onTap}
+            aria-label={
+              account.isPro
+                ? tStatus('proManageLabel')
+                : tStatus('accountLabel')
+            }
+            data-testid="arena-account-chip"
+            className={`hub-account-circle arena-scaffold-account${
+              account.isPro ? ' hub-account-circle--pro' : ''
+            }`}
+          >
+            {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
+            <picture className="hub-account-circle-avatar">
+              <source srcSet="/art/avatar-small-account.avif" type="image/avif" />
+              <source srcSet="/art/avatar-small-account.webp" type="image/webp" />
+              <img
+                src="/art/avatar-small-account.png"
+                alt=""
+                aria-hidden="true"
+                draggable={false}
+              />
+            </picture>
+          </button>
+        ) : null}
       </header>
 
       <section className="arena-scaffold-body">


### PR DESCRIPTION
## What
Phase 2 of the Play Kingdom hub unification. Adds the LITE hub **account-circle** grammar to the `/arena` select HUD: a compact avatar chip anchored top-right → `/exercises?sheet=account`. Rendered only when a wallet is connected; PRO adds the gold-ring modifier.

## WARM UP modal PIECES removal — already done
Drove `/arena?fresh=1` live: the `SoftGateSheet` modal shows **only the ARENA CTA**, no PIECES. The `arena-select-scaffold` test already asserts `softGateLearn` is not rendered. Reference Image 3 was stale — no code change needed.

## Process (SDD → TDD → EDD)
- New `ArenaAccountEntry` contract on `ArenaSelectScaffold`.
- 3 new tests (render / onTap / PRO-ring); typecheck clean; 112 arena tests green; build EXIT=0.
- Connected-state visual reuses the proven `.hub-account-circle` primitive (unit-tested; not driven — needs an injected wallet).

Closes thread 3 of the MiniPay listing feedback cluster. Spec: `docs/specs/play-kingdom-hub-unification.md`.

Wolfcito 🐾 @akawolfcito