### PR TITLE
fix(hub): PLAY mascot exact LEARN parity + smaller CHESS TOOLS icons

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -8770,8 +8770,10 @@ button.hud-resource-chip:active:not(:disabled) {
 }
 .play-hub-tools-grid .reward-tile .reward-tile-piece {
   position: static;
-  width: 44px;
-  height: 44px;
+  /* Match the LEARN training-path piece-icon footprint — smaller than the
+     tile so the cream frame reads around each icon (founder 2026-07-07). */
+  width: 34px;
+  height: 34px;
   transform: none;
   filter: drop-shadow(0 3px 3px rgba(110, 65, 15, 0.28));
 }

--- a/apps/web/src/components/hub/__tests__/play-hub-scaffold.test.tsx
+++ b/apps/web/src/components/hub/__tests__/play-hub-scaffold.test.tsx
@@ -3,9 +3,6 @@ import { renderWithIntl as render } from "@/test-utils/render-with-intl";
 import { screen } from "@testing-library/react";
 import { PlayHubScaffold } from "../play-hub-scaffold";
 
-vi.mock("@/components/kingdom/kingdom-anchor", () => ({
-  KingdomAnchor: () => <div data-testid="pro-portal" />,
-}));
 vi.mock("@/components/kingdom/kingdom-card", () => ({
   KingdomCard: ({ pro }: { pro: { active: boolean } }) => (
     <div data-testid="kingdom-card" data-pro={pro.active} />
@@ -49,24 +46,32 @@ const props = {
 };
 
 describe("PlayHubScaffold", () => {
-  it("renders the unified surfaces: portal, Kingdom panel, Play Chess CTA", () => {
+  it("renders the unified surfaces: LEARN mascot, Kingdom panel, Play Chess CTA", () => {
     render(<PlayHubScaffold {...props} />);
 
     expect(screen.getByLabelText("Minted victories: 0")).toHaveTextContent("0");
-    expect(screen.getByTestId("pro-portal")).toBeInTheDocument();
+    // Title + avatar reuse the exact LEARN/LITE mascot markup.
+    expect(screen.getByAltText("Chesscito")).toBeInTheDocument();
     expect(screen.getByTestId("kingdom-card")).toBeInTheDocument();
     expect(screen.getByText("PLAY CHESS")).toBeInTheDocument();
   });
 
-  it("orders portal → switch → Kingdom panel → CTA → CHESS TOOLS", () => {
+  it("orders mascot → switch → Kingdom panel → CTA → CHESS TOOLS", () => {
     render(<PlayHubScaffold {...props} />);
-    const portal = screen.getByTestId("pro-portal");
+    const mascot = screen.getByAltText("Chesscito");
     const modeSwitch = screen.getByTestId("mode-switch");
     const panel = screen.getByTestId("kingdom-card");
     const tools = screen.getByText("CHESS TOOLS");
-    expect(portal.compareDocumentPosition(modeSwitch) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(mascot.compareDocumentPosition(modeSwitch) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(modeSwitch.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(panel.compareDocumentPosition(tools) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("swaps to the PRO avatar when pro is active", () => {
+    render(<PlayHubScaffold {...props} pro={{ active: true, daysRemaining: 200 }} />);
+    expect(screen.getByAltText("Chesscito")).toBeInTheDocument();
+    const avatar = document.querySelector(".hub-lite-avatar img") as HTMLImageElement;
+    expect(avatar.getAttribute("src")).toContain("avatar-pro");
   });
 
   it("has one primary Play Chess CTA and no Learn/Training content", () => {

--- a/apps/web/src/components/hub/play-hub-scaffold.tsx
+++ b/apps/web/src/components/hub/play-hub-scaffold.tsx
@@ -5,7 +5,6 @@ import { AppModeSwitch } from "@/components/hub/app-mode-switch";
 import { HubActionTile } from "@/components/hub/hub-action-tile";
 import { HubProBadge } from "@/components/hub/hub-pro-badge";
 import { LanguageChip } from "@/components/hub/language-chip";
-import { KingdomAnchor } from "@/components/kingdom/kingdom-anchor";
 import { KingdomCard } from "@/components/kingdom/kingdom-card";
 import { PrimaryPlayCta } from "@/components/kingdom/primary-play-cta";
 import { CandyIcon } from "@/components/redesign/candy-icon";
@@ -92,8 +91,59 @@ export function PlayHubScaffold({
       </header>
 
       <section className="play-hub-body">
-        <div className="play-hub-portal">
-          <KingdomAnchor variant="playhub" showTagline={false} />
+        {/* Title + avatar reuse the EXACT LEARN/LITE mascot (wordmark banner +
+            circular gold-ring wizard) so the two hubs share one identity.
+            Avatar flips to the PRO variant in lockstep with `pro.active`. */}
+        <div className="hub-lite-mascot play-hub-mascot">
+          {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
+          <picture className="hub-lite-title">
+            <source
+              srcSet="/art/title-chesscito-288w.avif 288w, /art/title-chesscito-384w.avif 384w, /art/title-chesscito.avif 512w"
+              sizes="(max-width: 352px) 141px, (max-width: 417px) 40vw, 167px"
+              type="image/avif"
+            />
+            <source
+              srcSet="/art/title-chesscito-288w.webp 288w, /art/title-chesscito-384w.webp 384w, /art/title-chesscito.webp 512w"
+              sizes="(max-width: 352px) 141px, (max-width: 417px) 40vw, 167px"
+              type="image/webp"
+            />
+            <img
+              src="/art/title-chesscito.png"
+              alt="Chesscito"
+              width={512}
+              height={249}
+              draggable={false}
+            />
+          </picture>
+          {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
+          <picture className="hub-lite-avatar">
+            <source
+              srcSet={
+                pro.active
+                  ? "/art/avatar-pro-224w.avif 224w, /art/avatar-pro-340w.avif 340w, /art/avatar-pro.avif 499w"
+                  : "/art/avatar-lite-hub-224w.avif 224w, /art/avatar-lite-hub-340w.avif 340w, /art/avatar-lite-hub.avif 499w"
+              }
+              sizes="(max-width: 337px) 101px, (max-width: 377px) 30vw, 113px"
+              type="image/avif"
+            />
+            <source
+              srcSet={
+                pro.active
+                  ? "/art/avatar-pro-224w.webp 224w, /art/avatar-pro-340w.webp 340w, /art/avatar-pro.webp 499w"
+                  : "/art/avatar-lite-hub-224w.webp 224w, /art/avatar-lite-hub-340w.webp 340w, /art/avatar-lite-hub.webp 499w"
+              }
+              sizes="(max-width: 337px) 101px, (max-width: 377px) 30vw, 113px"
+              type="image/webp"
+            />
+            <img
+              src={pro.active ? "/art/avatar-pro.png" : "/art/avatar-lite-hub.png"}
+              alt=""
+              aria-hidden="true"
+              width={499}
+              height={560}
+              draggable={false}
+            />
+          </picture>
           <AppModeSwitch activeMode="play" />
         </div>
 


### PR DESCRIPTION
Founder feedback on the live Play Kingdom hub:

- **Title + avatar** now reuse the EXACT LEARN/LITE mascot markup (`hub-lite-title` wordmark banner + `hub-lite-avatar` circular gold-ring wizard, PRO variant flips with `pro.active`). Replaces the KingdomAnchor rectangular portal — PLAY and LEARN now share one identity.
- **CHESS TOOLS icons** shrunk (`reward-tile-piece` 44px → 34px) to match the LEARN training-path piece-icon footprint (were too large).

Drove `/hub` in play mode at 390px — title+avatar match the LEARN hub; icons sit smaller in-frame. Typecheck clean; play-hub-scaffold tests updated; 175 hub tests green.

Note: HUD status pills (trophy/language/PRO) kept as-is (play-appropriate). Full Peones/Account header parity with LEARN left as an optional follow-up.

Wolfcito 🐾 @akawolfcito