### PR TITLE
feat(hub): PLAY header adopts LEARN grammar (Peones + Account, no Daily)

### DIFF
--- a/apps/web/src/components/hub/__tests__/play-hub-scaffold.test.tsx
+++ b/apps/web/src/components/hub/__tests__/play-hub-scaffold.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderWithIntl as render } from "@/test-utils/render-with-intl";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { PlayHubScaffold } from "../play-hub-scaffold";
 
 vi.mock("@/components/kingdom/kingdom-card", () => ({
@@ -14,6 +15,9 @@ vi.mock("@/components/hub/app-mode-switch", () => ({
   ),
 }));
 vi.mock("@/components/hub/language-chip", () => ({ LanguageChip: () => null }));
+vi.mock("@/components/peones/peones-balance-chip", () => ({
+  PeonesBalanceChip: () => <div data-testid="peones-chip" />,
+}));
 vi.mock("@/components/hub/hub-pro-badge", () => ({
   HubProBadge: ({ ariaLabel }: { ariaLabel: string }) => <button aria-label={ariaLabel}>PRO</button>,
 }));
@@ -43,6 +47,7 @@ const props = {
   onCoachTap: vi.fn(),
   onShopTap: vi.fn(),
   onArenaPress: vi.fn(),
+  onAccountTap: vi.fn(),
 };
 
 describe("PlayHubScaffold", () => {
@@ -65,6 +70,27 @@ describe("PlayHubScaffold", () => {
     expect(mascot.compareDocumentPosition(modeSwitch) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(modeSwitch.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(panel.compareDocumentPosition(tools) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders the LEARN header grammar: Peones chip + Account entry when connected", async () => {
+    const onAccountTap = vi.fn();
+    render(<PlayHubScaffold {...props} onAccountTap={onAccountTap} />);
+    expect(screen.getByTestId("peones-chip")).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("play-hub-account-chip"));
+    expect(onAccountTap).toHaveBeenCalledOnce();
+  });
+
+  it("hides the Peones chip and Account entry for guests", () => {
+    render(<PlayHubScaffold {...props} isWalletConnected={false} />);
+    expect(screen.queryByTestId("peones-chip")).toBeNull();
+    expect(screen.queryByTestId("play-hub-account-chip")).toBeNull();
+  });
+
+  it("adds the PRO ring to the account chip when pro is active", () => {
+    render(<PlayHubScaffold {...props} pro={{ active: true, daysRemaining: 200 }} />);
+    expect(screen.getByTestId("play-hub-account-chip").className).toContain(
+      "hub-account-circle--pro",
+    );
   });
 
   it("swaps to the PRO avatar when pro is active", () => {

--- a/apps/web/src/components/hub/play-hub-client.tsx
+++ b/apps/web/src/components/hub/play-hub-client.tsx
@@ -105,6 +105,10 @@ export function PlayHubClient({
           shopSheet.openSheet();
         }}
         onArenaPress={handleArenaPress}
+        onAccountTap={() => {
+          track("play_hub_account_tap", { pro_active: pro.active });
+          router.push("/exercises?sheet=account");
+        }}
       />
       <ProSheet {...proSheet.sheetProps} />
       <ShopSheet {...shopSheet.sheetProps} />

--- a/apps/web/src/components/hub/play-hub-scaffold.tsx
+++ b/apps/web/src/components/hub/play-hub-scaffold.tsx
@@ -7,6 +7,7 @@ import { HubProBadge } from "@/components/hub/hub-pro-badge";
 import { LanguageChip } from "@/components/hub/language-chip";
 import { KingdomCard } from "@/components/kingdom/kingdom-card";
 import { PrimaryPlayCta } from "@/components/kingdom/primary-play-cta";
+import { PeonesBalanceChip } from "@/components/peones/peones-balance-chip";
 import { CandyIcon } from "@/components/redesign/candy-icon";
 import { PlayTacticsTile } from "@/components/tactics/play-tactics-tile";
 
@@ -20,6 +21,9 @@ type PlayHubScaffoldProps = {
   onCoachTap: () => void;
   onShopTap: () => void;
   onArenaPress: () => void;
+  /** Opens the account surface (same universal sheet as LEARN + arena —
+   *  `/exercises?sheet=account`). Only wired/rendered when connected. */
+  onAccountTap: () => void;
 };
 
 /** Play Kingdom home. Mirrors the LEARN/LITE hub's visual system (unified
@@ -36,10 +40,12 @@ export function PlayHubScaffold({
   onCoachTap,
   onShopTap,
   onArenaPress,
+  onAccountTap,
 }: PlayHubScaffoldProps) {
   const tHud = useTranslations("HUD_COPY");
   const tRail = useTranslations("HUB_ACTION_RAIL_COPY");
   const tPlay = useTranslations("PLAY_HUB_COPY");
+  const tStatus = useTranslations("GLOBAL_STATUS_BAR_COPY");
   const proAriaLabel = pro.active
     ? tHud("proAriaLabel", { days: pro.daysRemaining })
     : tHud("proInactiveAriaLabel");
@@ -60,9 +66,44 @@ export function PlayHubScaffold({
               <CandyIcon name="trophy" className="candy-tray-pill-icon candy-tray-pill-icon--floating" />
               <span>{mintedVictoryCount}</span>
             </button>
+            {/* Peones balance + recharge — same universal economy chip as the
+                LEARN header. Self-gates on useAccount (null for guests). */}
+            {isWalletConnected ? (
+              <PeonesBalanceChip surface="hub" showRecharge />
+            ) : null}
             <LanguageChip />
           </div>
           <div className="hub-scaffold-hud-right">
+            {/* Account entry — same circular avatar chip + universal account
+                sheet as the LEARN header (Daily gift is Lite-only, so PLAY's
+                top-right anchor stays the PRO badge below instead). */}
+            {isWalletConnected ? (
+              <button
+                type="button"
+                onClick={onAccountTap}
+                aria-label={
+                  pro.active
+                    ? tStatus("proManageLabel")
+                    : tStatus("accountLabel")
+                }
+                data-testid="play-hub-account-chip"
+                className={`hub-account-circle${
+                  pro.active ? " hub-account-circle--pro" : ""
+                }`}
+              >
+                {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
+                <picture className="hub-account-circle-avatar">
+                  <source srcSet="/art/avatar-small-account.avif" type="image/avif" />
+                  <source srcSet="/art/avatar-small-account.webp" type="image/webp" />
+                  <img
+                    src="/art/avatar-small-account.png"
+                    alt=""
+                    aria-hidden="true"
+                    draggable={false}
+                  />
+                </picture>
+              </button>
+            ) : null}
             {!isWalletConnected ? (
               <button
                 type="button"


### PR DESCRIPTION
Founder: PLAY header should match LEARN's, without leaking Lite-only things into play.

- **PeonesBalanceChip** (left) — universal economy chip, same as LEARN; self-gates on `useAccount`.
- **Account circle** (right) — same `.hub-account-circle` + universal account sheet (`/exercises?sheet=account`). New `onAccountTap` wired in `play-hub-client`.
- **No Daily gift** (Lite-only daily-focus ritual). PLAY's top-right anchor stays the PRO badge — "the daily icon for us IS the PRO badge". PRO flips the account ring via `pro.active`.

Header now reads `trophy · Peones · EN / Account · Connect · PRO` — structurally identical to LEARN minus the Lite-only Daily.

Typecheck clean; 3 new tests (Peones+Account render/onTap, guest hides both, PRO ring); 178 hub tests green; build EXIT=0. Connected-state visual not driven (needs injected wallet) — reuses primitives proven on LEARN.

Wolfcito 🐾 @akawolfcito