### PR TITLE
fix(account): render AccountSheet above the persistent dock (z-[70])

### DIFF
--- a/apps/web/src/components/account/account-sheet.tsx
+++ b/apps/web/src/components/account/account-sheet.tsx
@@ -96,7 +96,13 @@ export function AccountSheet({
         hideClose
         title={t("title")}
         description={t("description")}
-        className="sheet-bg-hub rounded-none border-0 h-[100dvh] flex flex-col focus:outline-none focus-visible:outline-none"
+        // z-[70] on both scrim + content so the sheet renders ABOVE the
+        // persistent dock (z-60). Without this the full-screen sheet sits at
+        // the default z-50, behind the dock — invisible on surfaces that mount
+        // the dock (arena/play). Full-screen opaque `sheet-bg-hub` then covers
+        // the dock, so no dock-overlay sentinel is needed.
+        overlayClassName="z-[70]"
+        className="z-[70] sheet-bg-hub rounded-none border-0 h-[100dvh] flex flex-col focus:outline-none focus-visible:outline-none"
       >
         <div className="-mx-6 -mt-6 shrink-0 border-b border-[rgba(110,65,15,0.30)]">
           <ContextualHeader


### PR DESCRIPTION
On `/arena` the account button opened the sheet (state flipped, content mounted — the founder-status/peones fetches in the log confirm it) but it was **invisible**: `SheetContent` defaults to `z-50`, BELOW the persistent dock (`z-60`). `exercises-screen` hides the dock via its overlay sentinel so `z-50` was fine there; arena has no sentinel, so the dock covered the sheet.

Fix: pass `z-[70]` to both the scrim (`overlayClassName`) and content — the documented pattern in `sheet.tsx` for sheets that must sit above the dock (same as ProSheet). The full-screen opaque sheet then covers the dock, no sentinel needed. Safe in exercises.

Typecheck clean; 225 arena/exercises tests green.

Wolfcito 🐾 @akawolfcito