### PR TITLE
fix(arena): account chip must sit above the ContextualHeader (z-index)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -9451,7 +9451,9 @@ button.hud-resource-chip:active:not(:disabled) {
   position: absolute;
   right: 10px;
   top: 4px;
-  z-index: 3;
+  /* Above the ContextualHeader (z-10) — otherwise the header subtree
+     intercepts the tap and the account sheet never opens. */
+  z-index: 20;
 }
 
 .arena-scaffold-hud-top {


### PR DESCRIPTION
**Real root cause** of "account sheet won't open in /arena" (LEARN /exercises worked, PLAY /arena didn't):

The account circle `.arena-scaffold-account` was `z-index:3`, BELOW the `ContextualHeader` (`z-10`) in the same HUD. The header subtree **intercepted the tap**, so the button never fired `setAccountSheetOpen`.

Fix: bump `.arena-scaffold-account` to `z-index:20` (above the header).

**Verified** by driving the real connected flow (injected no-funds test wallet → `/arena` → tap account chip): before = click intercepted by `<h1>Arena</h1>`; after = sheet opens (`hasSheetBg` + `Disconnect` present, real wallet address rendered).

Complements #174 (sheet renders above the dock at `z-[70]`) — both needed: one makes the button clickable, one makes the opened sheet visible.

Wolfcito 🐾 @akawolfcito