### PR TITLE
feat(arena): account pill matches LEARN + sheet below dock (aux rule)

### DIFF
--- a/apps/web/src/app/[locale]/arena/page.tsx
+++ b/apps/web/src/app/[locale]/arena/page.tsx
@@ -9,6 +9,7 @@ import {
   useDisconnect,
 } from "wagmi";
 import { AccountSheet } from "@/components/account/account-sheet";
+import { daysRemaining } from "@/lib/pro/days-remaining";
 import { useCoachCredits } from "@/lib/coach/use-coach-credits";
 import { formatWalletShort } from "@/lib/wallet/format";
 import { useConnectWallet } from "@/lib/wallet/use-connect-wallet";
@@ -1101,6 +1102,10 @@ function ArenaPageInner() {
                 isConnected
                   ? {
                     isPro: proActiveCached,
+                    daysRemaining: daysRemaining(
+                      proStatusFromHook?.expiresAt ?? null,
+                      Date.now(),
+                    ),
                     onTap: () => {
                       track("arena_account_tap", {
                         pro_active: proActiveCached,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -9450,7 +9450,9 @@ button.hud-resource-chip:active:not(:disabled) {
 .arena-scaffold-account {
   position: absolute;
   right: 10px;
-  top: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  margin: 0;
   /* Above the ContextualHeader (z-10) — otherwise the header subtree
      intercepts the tap and the account sheet never opens. */
   z-index: 20;

--- a/apps/web/src/components/account/account-sheet.tsx
+++ b/apps/web/src/components/account/account-sheet.tsx
@@ -96,13 +96,10 @@ export function AccountSheet({
         hideClose
         title={t("title")}
         description={t("description")}
-        // z-[70] on both scrim + content so the sheet renders ABOVE the
-        // persistent dock (z-60). Without this the full-screen sheet sits at
-        // the default z-50, behind the dock — invisible on surfaces that mount
-        // the dock (arena/play). Full-screen opaque `sheet-bg-hub` then covers
-        // the dock, so no dock-overlay sentinel is needed.
-        overlayClassName="z-[70]"
-        className="z-[70] sheet-bg-hub rounded-none border-0 h-[100dvh] flex flex-col focus:outline-none focus-visible:outline-none"
+        // Default z-50: the sheet sits BELOW the persistent dock (z-60) so the
+        // dock stays reachable on top — the canonical "aux/destination panel"
+        // rule (badge/shop/trophies/account). Full-screen sheet, dock overlaid.
+        className="sheet-bg-hub rounded-none border-0 h-[100dvh] flex flex-col focus:outline-none focus-visible:outline-none"
       >
         <div className="-mx-6 -mt-6 shrink-0 border-b border-[rgba(110,65,15,0.30)]">
           <ContextualHeader

--- a/apps/web/src/components/arena/__tests__/arena-select-scaffold.test.tsx
+++ b/apps/web/src/components/arena/__tests__/arena-select-scaffold.test.tsx
@@ -123,18 +123,31 @@ describe("ArenaSelectScaffold", () => {
     expect(screen.queryByText(/PRO/)).not.toBeInTheDocument();
   });
 
-  it("renders the account entry when account prop is provided and fires onTap", async () => {
+  it("renders the account pill (avatar + label) and fires onTap", async () => {
     const onTap = vi.fn();
-    render(<ArenaSelectScaffold {...baseProps} account={{ isPro: false, onTap }} />);
-    await userEvent.click(screen.getByTestId("arena-account-chip"));
+    render(
+      <ArenaSelectScaffold
+        {...baseProps}
+        account={{ isPro: false, daysRemaining: null, onTap }}
+      />,
+    );
+    const chip = screen.getByTestId("arena-account-chip");
+    expect(chip.className).toContain("candy-tray-pill");
+    await userEvent.click(chip);
     expect(onTap).toHaveBeenCalledOnce();
   });
 
-  it("adds the PRO ring modifier when account.isPro is true", () => {
-    render(<ArenaSelectScaffold {...baseProps} account={{ isPro: true, onTap: vi.fn() }} />);
-    expect(screen.getByTestId("arena-account-chip").className).toContain(
-      "hub-account-circle--pro",
+  it("adds the PRO text modifier + days suffix when account.isPro is true", () => {
+    render(
+      <ArenaSelectScaffold
+        {...baseProps}
+        account={{ isPro: true, daysRemaining: 200, onTap: vi.fn() }}
+      />,
     );
+    expect(screen.getByTestId("arena-account-chip").className).toContain(
+      "hub-hud-pill--pro-text",
+    );
+    expect(screen.getByText(/PRO · 200d/)).toBeInTheDocument();
   });
 
   it("omits the account entry when the account prop is absent", () => {

--- a/apps/web/src/components/arena/arena-select-scaffold.tsx
+++ b/apps/web/src/components/arena/arena-select-scaffold.tsx
@@ -47,12 +47,14 @@ type SoftGate = {
   onDismiss: () => void
 }
 
-/** Account entry (top-right of the HUD). Mirrors the LITE hub
- *  `hub-account-circle`: a compact avatar chip routing into the account
- *  surface. Caller only passes this when a wallet is connected — the
- *  scaffold renders nothing otherwise. */
+/** Account entry (top-right of the HUD). Mirrors the LEARN /exercises header
+ *  account pill (`candy-tray-pill hub-hud-pill` — avatar + "Account" label +
+ *  PRO days) for one unified visual language. Caller only passes this when a
+ *  wallet is connected — the scaffold renders nothing otherwise. */
 type ArenaAccountEntry = {
   isPro: boolean
+  /** Days left on the active PRO pass; `null` hides the "PRO · Nd" suffix. */
+  daysRemaining: number | null
   onTap: () => void
 }
 
@@ -140,12 +142,12 @@ export function ArenaSelectScaffold({
                 : tStatus('accountLabel')
             }
             data-testid="arena-account-chip"
-            className={`hub-account-circle arena-scaffold-account${
-              account.isPro ? ' hub-account-circle--pro' : ''
+            className={`candy-tray-pill hub-hud-pill arena-scaffold-account${
+              account.isPro ? ' hub-hud-pill--pro-text' : ''
             }`}
           >
             {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
-            <picture className="hub-account-circle-avatar">
+            <picture className="candy-tray-pill-icon candy-tray-pill-icon--floating">
               <source srcSet="/art/avatar-small-account.avif" type="image/avif" />
               <source srcSet="/art/avatar-small-account.webp" type="image/webp" />
               <img
@@ -155,6 +157,12 @@ export function ArenaSelectScaffold({
                 draggable={false}
               />
             </picture>
+            <span>{tStatus('accountChipLabel')}</span>
+            {account.isPro && account.daysRemaining != null ? (
+              <span className="hub-hud-pill-pro-days">
+                PRO · {account.daysRemaining}d
+              </span>
+            ) : null}
           </button>
         ) : null}
       </header>


### PR DESCRIPTION
Founder polish on the now-working /arena account entry:

1. **Pill style** — the account entry now uses the SAME pill as the LEARN /exercises header (`candy-tray-pill hub-hud-pill`: avatar + "Account" label + "PRO · Nd") instead of a bare circle. Unified visual language. `ArenaAccountEntry` gains `daysRemaining`.
2. **Sheet below dock** — revert AccountSheet to default `z-50` (was `z-[70]` in #174, a mis-diagnosis; the real blocker was the button z-index in #175). Aux/destination panels open BELOW the dock (`z-60`) so the dock stays reachable on top.

Verified via injected-wallet connected drive: pill renders in the arena header; tap opens the sheet at `z-50` with the dock overlaid on top. Typecheck clean; 225 tests green; build EXIT=0.

Wolfcito 🐾 @akawolfcito