### PR TITLE
feat(play-hub): LEARN distribution parity + Peones modal layering fix

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,40 +1,41 @@
-# Session Handoff — 2026-07-04
+# Session Handoff — 2026-07-07
 
-Full detail: spec `docs/specs/landing-onboarding-slides.md` (status: implemented).
+## Completed (all merged to main)
+- [ PR #168 ] Landing onboarding real ES copy.
+- [ PR #169 ] Play Kingdom hub unification (Phase 1) — `KingdomCard` panel, CHESS TOOLS grid, "Arena"→"Play Kingdom" rename.
+- [ PR #170 ] Arena account entry (Phase 2, initial).
+- [ PR #171 ] PLAY mascot exact LEARN parity + smaller CHESS TOOLS icons.
+- [ PR #172 ] PLAY header LEARN grammar (Peones + Account; account later removed in #173).
+- [ PR #173 ] Extract `AccountSheet` → `components/account/account-sheet.tsx`; wire inline in /arena; hide account circle in PLAY hub; hide WarmUp modal on /arena.
+- [ PR #174 ] AccountSheet z-[70] (later reverted — mis-diagnosis).
+- [ PR #175 ] **Real fix**: account chip `z-index:20` above the ContextualHeader (was intercepting the tap → sheet never opened).
+- [ PR #176 ] Account entry = LEARN pill style (avatar + "Account" + "PRO · Nd"); AccountSheet back to z-50 (aux panels sit below the dock, dock reachable on top).
+- **Play Kingdom hub unification cluster CLOSED** (thread 3 of MiniPay listing feedback). Founder confirmed the /arena account sheet works on-device.
 
-## Completed
-- **Landing onboarding feature (MiniPay listing feedback item 1/3)** — `apps/landing` (`www.chesscito.com`) now serves a real onboarding at `/`:
-  - First-time visitor: 4-slide carousel (client state, no history per slide), progress counter pinned to the top edge, legal footer pinned to the bottom edge.
-  - Returning visitor: cookie-decided (`GET /api/enter?mode=` route handler sets `chesscito_onboarded`/`chesscito_preferred_mode`, 302s to destination) — single Welcome + START screen, no carousel, no flash (server-side decision).
-  - `/classic` = the old 957-line hero, moved unchanged, outside locale routing.
-  - `next-intl` scaffold (`en`/`es`, `es` is a typed placeholder mirror of `en` — no real ES copy yet).
-  - Pills + CTA buttons now reuse the Hub's exact CSS (`.candy-tray-pill`/`.hub-hud-pill`, `.primary-play-cta`/`.hub-scaffold-practice-cta`/`.hub-scaffold-arena-cta`, ported verbatim from `apps/web/globals.css`).
-  - Slide 4: "Learn Pieces" / "Play" (renamed from "Start Learning"/"Enter Arena") now render as small inline pills next to their matching price row (Season Pass / PRO), not as big buttons below the frame.
-- Real founder assets iterated 3x (`design/landing-slides/bg-slides.png`: 1018×1768 → 1070×1264 → 980×1398, each re-optimized to png+webp+avif and the code's hardcoded aspect ratio updated to match).
-- **Real mobile-viewport scroll bug found + fixed**: frame sizing by width alone produced a too-tall card on real phone viewports (browser chrome eats into `dvh`) — fixed with an explicit `min(100%, height-budget-derived-width)` CSS formula. Verified at 375×667 (smallest tested), 390×844, 390×700 (simulated chrome-eaten), and 1440×900 desktop — no scroll at any size.
-- 2 new memory lessons saved: [[feedback_gitignore_design_dirname_collision]] (bare `design/` gitignore rule swallows any `public/design/` dir anywhere in the repo — land assets under `public/art/**` instead) and [[feedback_negative_zindex_bg_color_gotcha]] (`-z-10` paints BEHIND its own parent's `background-color` in real Chromium, contra naive recall — fix by making the foreground sibling `relative` too, not by going more negative).
-- 27 commits, all local on `main`, **nothing pushed to origin yet**.
+### Continuation — PLAY hub LEARN parity + Peones layering (2026-07-07)
+- **PLAY hub adopts the LEARN distribution**: removed the `.play-hub-body` centered wrapper so mascot · panel · CTA · tools are direct siblings of `<main>` (flat stack). `.play-hub-scaffold` now `flex-start` + `gap:6px` + 14px gutter; header aligned to the gutter; CTA breathing `24/16`; CHESS TOOLS pinned to the floor (`margin-top:auto`) like the Training Path. Base `.hub-scaffold` (legacy FULL hub) untouched.
+- **Tactics/Coach/Shop tiles → LEARN gold piece-tiles**: 78px cream retired; now the gold `.reward-tile.is-compact` look (48px, gold gradient, piece 28×30, label 0.55rem). Overrides HubActionTile's `is-locked` gray back to active gold.
+- **PLAY CHESS CTA → blue clone of Start Focus**: new `.play-chess-cta` duplicates `.hub-lite-start-focus` geometry 1:1 (60px, 0 46px, radius 20px, 1.35rem, stacked bevel) in canonical blue, keeps the crossed-swords icon + haptic. Replaced `PrimaryPlayCta`. Duplicated, NOT shared — keep in sync by hand (documented in CSS).
+- **Fix: Get Peones modal layering in /arena Account sheet**. The Radix `<Sheet>` slide-in `transform` trapped the modal's `position:fixed` inside the sheet (read as an "interior screen", z stuck under the dock). `VictoryPopupShell` got opt-in `portal` + `scrimZClassName` props; `GetPeonesSheet` passes `portal` + `z-[55]` → portals to `<body>`, covers the whole Account sheet (z-50), stays UNDER the dock (z-60). Arena/exercises popups unchanged (`z-[70]`, no portal).
 
 ## Current State
-- **Branch**: `main`, 27 commits ahead of `origin/main`, working tree clean.
-- **Build**: `apps/landing` 21/21 tests passing, `tsc --noEmit` clean, `next build` clean.
-- Founder made several direct manual edits/commits mid-session (spacing, icon sizes, copy) — all incorporated, nothing reverted.
-- `next lint` was never configured for `apps/landing` (pre-existing gap, untouched this session — out of scope, not blocking).
+- **Branch**: `feat/play-hub-learn-parity-and-peones-layering` (off main @ PR #176)
+- **Build**: `tsc --noEmit` clean; targeted unit tests green (play-hub 11/11, shell/sheet/card 23/23). Full-suite pass count in commit footers.
+- **Uncommitted work**: this session's 2 commits (play-hub parity, peones layering fix) + this handoff.
 
 ## Next Tasks
-1. **Push these 27 commits to origin** (never asked to push this session — confirm with founder before doing it, per repo's push-confirmation norm).
-2. **Real ES copy** for the 4 slides — `es.ts` is currently a byte-identical mirror of `en.ts` (tracked as a watch item in the spec so it doesn't rot into permanent fake-i18n).
-3. Remaining MiniPay listing feedback backlog (items 2–3, not started this session):
-   - Validate save-score-onchain is gas-only.
-   - "Full → play" simplification in `apps/web`: hide/retire Train Pieces (Lite) from the primary entry, rename Lite→"Train Pieces", Play→"Play Chess + Coach".
-4. Desktop composition for the 4 web reference mockups (`chesscito-slide-web-{1..4}.png`) was never pixel-matched — current desktop uses a straightforward centered scale-up of the same mobile card; acceptable per spec, revisit only if founder flags a specific desktop issue.
-5. Optional polish backlog: MiniPay "unknown transaction/dev mode" listing item (separate, from the earlier Victory NFT cluster) still open.
+1. **save-score-onchain gas-only validation** — thread 2 of MiniPay listing feedback, **NOT STARTED** (needs a spec first). Only remaining cluster thread.
+2. (Perf) `/api/founder-status` was ~55s on the tunnel — the AccountSheet's Founder row triggers it. Consider deferring/lazy the founder read. See [[founder-status-mitigated-2026-06-03]].
+3. (Coverage) No VR fixture covers `/hub` play mode or the arena account sheet — all PLAY visual QA was manual. Consider adding fixtures.
 
 ## Blockers
-None.
+- None.
 
 ## Notes
-- Command hygiene: `git -C`/`pnpm -C`, never `cd`; one cmd per call; Write tool for files.
-- **`next build`/`next start` gotcha this session**: piping `next build`'s output through `| tail -N` in this sandboxed shell silently truncated the build before it wrote `BUILD_ID`, then `next start` failed claiming "no production build" even though the route table had printed. Fix: run `next build` plain (no pipe to `tail`) or redirect to a file instead. Also hit real stale-server issues (`lsof -ti:4173 | xargs kill` + fresh `rm -rf .next` before every rebuild-and-screenshot cycle) — always fully clear `.next` and kill any lingering `next-server`/`next start` process before trusting a fresh screenshot.
-- Manual QA this session was all via headless Playwright screenshots at fixed viewports (375×667, 390×844, 390×700, 1440×900) — no real device testing.
-- Key files: `apps/landing/src/components/onboarding/{slide-shell,slide-bodies,onboarding-carousel,welcome-back,pill,legal-footer}.tsx`, `apps/landing/src/app/globals.css` (ported Hub CSS lives at the bottom), `apps/landing/src/lib/onboarding/{slides,types,resolve-state}.ts`, `apps/landing/src/app/api/enter/route.ts`.
+- **`AccountSheet` is reusable** at `components/account/account-sheet.tsx` (13 props). Mounted in exercises (unchanged) + arena. Same sheet everywhere — no learn/play-specific content.
+- **z-index rules** (learned this session, see [[feedback_zindex_sheet_and_trigger_layering]]): a sheet trigger must beat `ContextualHeader` (z-10); aux/destination sheets open at z-50 BELOW the dock (z-60) so the dock stays on top; only ProSheet-type uses `z-[70]`.
+- **Debugging connected flows**: injected an EIP-1193 provider from `ONLY_TEST_NO_FUNDS_PK` (`.env.local`, gitignored) via Playwright — key stays in Node, only the address is injected. This is how the tap-interception bug was found.
+- `.next` stale cache can mask merged changes in local dev (`rm -rf apps/web/.next`) — a red herring, not a code bug.
+- "PRO not updating on MiniPay" was env (ngrok origin not allowlisted) — resolved by setting `NEXT_PUBLIC_APP_URL`/`PREVIEW_URL` to the tunnel; `enforceOrigin` untouched.
+- Local drive: `/hub` = FULL hub unless `NEXT_PUBLIC_CHESSCITO_MODE=play`; LEARN needs `=learn` + `NEXT_PUBLIC_CHESSCITO_LITE_MODE=true`. Playwright scripts run from `apps/web`.
+- Specs: `docs/specs/play-kingdom-hub-unification{,-redteam}.md`. Memory: `project_play_kingdom_hub_2026_07.md` + `feedback_zindex_sheet_and_trigger_layering.md` + MEMORY.md index.

--- a/apps/web/src/app/[locale]/arena/__tests__/arena-handle-back-no-flash.test.tsx
+++ b/apps/web/src/app/[locale]/arena/__tests__/arena-handle-back-no-flash.test.tsx
@@ -83,6 +83,7 @@ vi.mock("@/lib/game/use-chess-game", () => ({
 // ---------------------------------------------------------------------------
 vi.mock("wagmi", () => ({
   useAccount: () => ({ address: undefined, isConnected: false }),
+  useDisconnect: () => ({ disconnect: vi.fn() }),
   useChainId: () => 42220,
   useReadContract: () => ({ data: undefined, isLoading: false }),
   useReadContracts: () => ({ data: [], isLoading: false }),

--- a/apps/web/src/app/[locale]/arena/__tests__/arena-play-mode-dock-destinations.test.tsx
+++ b/apps/web/src/app/[locale]/arena/__tests__/arena-play-mode-dock-destinations.test.tsx
@@ -65,6 +65,7 @@ vi.mock("@/lib/game/use-chess-game", () => ({
 
 vi.mock("wagmi", () => ({
   useAccount: () => ({ address: undefined, isConnected: false }),
+  useDisconnect: () => ({ disconnect: vi.fn() }),
   useChainId: () => 42220,
   useReadContract: () => ({ data: undefined, isLoading: false }),
   useReadContracts: () => ({ data: [], isLoading: false }),

--- a/apps/web/src/app/[locale]/arena/__tests__/arena-play-timer-resilience.test.tsx
+++ b/apps/web/src/app/[locale]/arena/__tests__/arena-play-timer-resilience.test.tsx
@@ -73,6 +73,7 @@ vi.mock("@/lib/game/use-chess-game", () => ({
 // ---------------------------------------------------------------------------
 vi.mock("wagmi", () => ({
   useAccount: () => ({ address: undefined, isConnected: false }),
+  useDisconnect: () => ({ disconnect: vi.fn() }),
   useChainId: () => 42220,
   useReadContract: () => ({ data: undefined, isLoading: false }),
   useReadContracts: () => ({ data: [], isLoading: false }),

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -8483,19 +8483,41 @@ button.hud-resource-chip:active:not(:disabled) {
 
 /* Play deployment Hub: competitive-only composition. Training rails, Daily,
    Tactics and mastery progression are intentionally absent from this tree. */
+/* Flat vertical stack — adopts the LEARN/LITE hub's single distribution
+   (`.hub-lite-scaffold`): direct children flow top→down with one rhythm
+   instead of the old two-tier `space-between` + centered `.play-hub-body`
+   wrapper (which read as a detached, "patched" block). The base
+   `.hub-scaffold` keeps the forest background; only distribution changes. */
 .play-hub-scaffold {
-  justify-content: space-between;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 6px;
+  /* Base `.hub-scaffold` ships 0 horizontal padding — restore the 14px
+     inset LEARN uses so every zone shares one gutter. */
+  padding-left: 14px;
+  padding-right: 14px;
 }
 
-.play-hub-body {
-  display: flex;
-  flex: 1 1 auto;
-  min-height: 0;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 14px;
-  padding: 0 20px;
+/* Header sits flush to the scaffold's 14px gutter (LEARN grammar). The
+   shared `.hub-scaffold-hud-top` adds its own asymmetric 20/8px inset for
+   the legacy FULL hub; zero it out here so PLAY aligns to the body. */
+.play-hub-scaffold .hub-scaffold-hud-top {
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+}
+
+/* CTA breathing room — mirrors LEARN's `.hub-lite-start-focus-wrap`
+   (24px above / 16px below) so the dominant Play CTA is not cramped
+   against the Kingdom panel now that the flex gap is a tight 6px. */
+.play-hub-cta-row {
+  margin: 24px 0 16px;
+}
+
+/* Shortcuts pinned to the floor — same mechanism as LEARN's Training Path
+   (`margin-top: auto` absorbs the leftover column height). */
+.play-hub-tools {
+  margin-top: auto;
 }
 
 .play-hub-portal {
@@ -8740,50 +8762,122 @@ button.hud-resource-chip:active:not(:disabled) {
 }
 .play-hub-tools-grid {
   display: grid;
-  grid-template-columns: repeat(3, 78px);
+  grid-template-columns: repeat(3, 48px);
   gap: 14px;
   justify-content: center;
 }
-.play-hub-tools-grid .reward-tile {
+/* Tactics/Coach/Shop adopt the LEARN Training-Path piece tile verbatim: the
+   gold candy tile at the compact 48px footprint (mirrors `.reward-tile.is-compact`
+   + base gold gradient). HubActionTile ships `.reward-tile.is-locked` (gray) —
+   override the locked treatment back to the active gold gradient so the three
+   tools read as gold piece-tiles, same size + style as the LEARN chess-piece
+   shortcuts. (Founder 2026-07-07 cream look retired in favor of LEARN parity.) */
+.play-hub-tools-grid .reward-tile,
+.play-hub-tools-grid .reward-tile.is-locked {
   position: relative;
   display: flex;
-  width: 78px;
-  min-width: 78px;
-  min-height: 78px;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  width: 48px;
+  min-width: 48px;
+  height: 48px;
+  min-height: 48px;
   margin: 0;
-  padding: 8px 5px 6px;
-  flex-direction: column-reverse;
-  gap: 3px;
-  color: rgba(63, 34, 8, 0.95);
-  text-shadow: 0 1px 0 rgba(255, 245, 215, 0.7);
-  background: linear-gradient(180deg,
-      rgba(255, 248, 222, 0.96) 0%,
-      rgba(247, 226, 175, 0.96) 100%);
-  border: 1px solid rgba(180, 120, 35, 0.45);
-  border-radius: 18px;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -1px 0 rgba(150, 90, 20, 0.18),
-    0 1px 2px rgba(110, 65, 15, 0.18);
+  padding: 4px 4px 5px;
+  gap: 0;
+  border: 0;
+  border-radius: 13px;
+  background: linear-gradient(180deg, #ffe26d 0%, #f9ce89 60%, #ffb555 100%);
+  box-shadow: none;
+  color: rgba(50, 25, 5, 0.95);
+  text-shadow: none;
+  font-size: 0.55rem;
   filter: none;
   overflow: visible;
 }
 .play-hub-tools-grid .reward-tile .reward-tile-piece {
-  position: static;
-  /* Match the LEARN training-path piece-icon footprint — smaller than the
-     tile so the cream frame reads around each icon (founder 2026-07-07). */
-  width: 34px;
-  height: 34px;
+  order: 1;
+  position: relative;
+  width: 28px;
+  height: 30px;
+  margin: -3px auto 1px;
   transform: none;
-  filter: drop-shadow(0 3px 3px rgba(110, 65, 15, 0.28));
+  filter: drop-shadow(0 4px 2px rgba(61, 37, 7, 0.35));
 }
 .play-hub-tools-grid .reward-tile .reward-tile-label {
+  order: 2;
   position: static;
-  width: auto;
-  color: rgba(63, 34, 8, 0.95);
-  text-shadow: 0 1px 0 rgba(255, 245, 215, 0.7);
-  font-size: 0.62rem;
+  width: 100%;
+  min-height: auto;
+  letter-spacing: 0;
+  color: rgba(50, 25, 5, 0.95);
+  text-shadow: none;
+  font-size: 0.55rem;
   font-weight: 800;
+}
+
+/* ── PLAY CHESS dominant CTA — a 1:1 blue clone of the LEARN Start Focus
+   button (`.hub-lite-start-focus`): identical geometry (60px min-height,
+   0 46px padding, 20px radius, 1.35rem label, the glossy inset + stacked
+   bevel), with the gold ramp swapped for the canonical blue and the
+   crossed-swords icon retained on the left. Duplicated (not shared) so the
+   LEARN button stays untouched; keep the two in sync by hand. ── */
+.play-chess-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: auto;
+  min-height: 60px;
+  padding: 0 46px;
+  border: none;
+  border-radius: 20px;
+  background:
+    radial-gradient(circle at 30% 20%, rgba(150, 225, 255, 0.85), transparent 28%),
+    radial-gradient(circle at 75% 75%, rgba(10, 70, 130, 0.4), transparent 35%),
+    linear-gradient(145deg, #4fc8f5 0%, #1f9fe0 28%, #0f78c0 55%, #0a568f 100%);
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.45),
+    inset 0 -5px 0 rgba(8, 50, 90, 0.35),
+    0 6px 0 #0a568f,
+    0 0 0 2px rgba(120, 210, 255, 0.7),
+    0 6px 0 2px rgba(120, 210, 255, 0.7),
+    0 0 6px 2px rgba(70, 180, 255, 0.7),
+    0 8px 6px 2px rgba(70, 180, 255, 0.55),
+    0 12px 20px rgba(0, 0, 0, 0.35);
+  color: #fff;
+  font-size: 1.35rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-shadow:
+    -1px -1px 0 #063a63,
+    1px -1px 0 #063a63,
+    -1px 1px 0 #063a63,
+    1px 1px 0 #063a63,
+    0 2px 2px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+}
+.play-chess-cta:active {
+  transform: translateY(3px);
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.35),
+    inset 0 -3px 0 rgba(8, 50, 90, 0.4),
+    0 3px 0 #0a568f,
+    0 5px 10px rgba(0, 0, 0, 0.3);
+}
+.play-chess-cta-icon {
+  display: block;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.35));
+}
+.play-chess-cta-icon img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .hub-scaffold-guide {

--- a/apps/web/src/components/arena/victory-popup-shell.tsx
+++ b/apps/web/src/components/arena/victory-popup-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 type Props = {
   /** Optional close handler. When provided, X tap calls this to dismiss
@@ -23,6 +24,18 @@ type Props = {
   ariaLive?: "polite" | "assertive";
   /** Aria label for the close button (e.g. "Close victory dialog"). */
   closeLabel?: string;
+  /** When true, render the scrim into `document.body` via a portal so it
+   *  escapes any transformed ancestor. A Radix Sheet's slide-in applies a
+   *  `transform` to its content, which turns `position: fixed` into
+   *  sheet-relative and traps this modal INSIDE the sheet (it then reads as
+   *  an "interior screen" and its z-index is scoped under the dock). Aux
+   *  modals opened from a sheet (Get Peones from the Account sheet) set this.
+   *  Default false — arena/exercises popups already mount at the app root. */
+  portal?: boolean;
+  /** Tailwind z-index utility for the scrim. Default `z-[70]` sits ABOVE the
+   *  PersistentDock (z-60). Aux-family modals pass `z-[55]` to cover the
+   *  z-50 aux sheet while staying UNDER the dock. */
+  scrimZClassName?: string;
   children: ReactNode;
 };
 
@@ -44,17 +57,21 @@ export function VictoryPopupShell({
   role = "dialog",
   ariaLive,
   closeLabel = "Close",
+  portal = false,
+  scrimZClassName = "z-[70]",
   children,
 }: Props) {
   const handleBackdropClick = disableBackdropClose ? undefined : () => onClose?.();
-  return (
+  const scrim = (
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
     <div
-      // z-[70] sits above the PersistentDock (z-60 in globals.css) so the
-      // scrim dims the dock and the modal panel is the only interactive
+      // Default z-[70] sits above the PersistentDock (z-60 in globals.css) so
+      // the scrim dims the dock and the modal panel is the only interactive
       // surface. Earlier z-50 left the dock visually on top of the modal
       // in exercises popups (piece-complete / labyrinth-solved / score-saved).
-      className="candy-modal-scrim pointer-events-auto fixed inset-0 z-[70] flex items-center justify-center animate-in fade-in duration-300"
+      // Aux-family callers pass a lower `scrimZClassName` (e.g. z-[55]) to
+      // stay UNDER the dock while covering their z-50 sheet.
+      className={`candy-modal-scrim pointer-events-auto fixed inset-0 ${scrimZClassName} flex items-center justify-center animate-in fade-in duration-300`}
       role={role}
       aria-modal="true"
       aria-label={ariaLabel}
@@ -99,4 +116,9 @@ export function VictoryPopupShell({
       </div>
     </div>
   );
+
+  if (portal && typeof document !== "undefined") {
+    return createPortal(scrim, document.body);
+  }
+  return scrim;
 }

--- a/apps/web/src/components/hub/__tests__/play-hub-scaffold.test.tsx
+++ b/apps/web/src/components/hub/__tests__/play-hub-scaffold.test.tsx
@@ -30,12 +30,6 @@ vi.mock("@/components/hub/hub-action-tile", () => ({
     <button aria-label={ariaLabel} className={className}>{label}</button>
   ),
 }));
-vi.mock("@/components/kingdom/primary-play-cta", () => ({
-  PrimaryPlayCta: ({ label, ariaLabel, className }: { label: string; ariaLabel: string; className?: string }) => (
-    <button aria-label={ariaLabel} className={className}>{label}</button>
-  ),
-}));
-
 const props = {
   mintedVictoryCount: 0,
   isWalletConnected: true,
@@ -95,7 +89,7 @@ describe("PlayHubScaffold", () => {
       screen.getAllByRole("button", { name: "Play Chess: full chess vs AI" }),
     ).toHaveLength(1);
     expect(
-      container.querySelector(".hub-scaffold-cta-row > .hub-scaffold-arena-cta"),
+      container.querySelector(".hub-scaffold-cta-row > .play-chess-cta"),
     ).not.toBeNull();
     expect(screen.queryByText(/Training Path/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Daily Focus/i)).not.toBeInTheDocument();

--- a/apps/web/src/components/hub/play-hub-scaffold.tsx
+++ b/apps/web/src/components/hub/play-hub-scaffold.tsx
@@ -6,10 +6,10 @@ import { HubActionTile } from "@/components/hub/hub-action-tile";
 import { HubProBadge } from "@/components/hub/hub-pro-badge";
 import { LanguageChip } from "@/components/hub/language-chip";
 import { KingdomCard } from "@/components/kingdom/kingdom-card";
-import { PrimaryPlayCta } from "@/components/kingdom/primary-play-cta";
 import { PeonesBalanceChip } from "@/components/peones/peones-balance-chip";
 import { CandyIcon } from "@/components/redesign/candy-icon";
 import { PlayTacticsTile } from "@/components/tactics/play-tactics-tile";
+import { hapticTap } from "@/lib/haptics";
 
 type PlayHubScaffoldProps = {
   mintedVictoryCount: number;
@@ -99,101 +99,116 @@ export function PlayHubScaffold({
         </div>
       </header>
 
-      <section className="play-hub-body">
-        {/* Title + avatar reuse the EXACT LEARN/LITE mascot (wordmark banner +
-            circular gold-ring wizard) so the two hubs share one identity.
-            Avatar flips to the PRO variant in lockstep with `pro.active`. */}
-        <div className="hub-lite-mascot play-hub-mascot">
-          {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
-          <picture className="hub-lite-title">
-            <source
-              srcSet="/art/title-chesscito-288w.avif 288w, /art/title-chesscito-384w.avif 384w, /art/title-chesscito.avif 512w"
-              sizes="(max-width: 352px) 141px, (max-width: 417px) 40vw, 167px"
-              type="image/avif"
-            />
-            <source
-              srcSet="/art/title-chesscito-288w.webp 288w, /art/title-chesscito-384w.webp 384w, /art/title-chesscito.webp 512w"
-              sizes="(max-width: 352px) 141px, (max-width: 417px) 40vw, 167px"
-              type="image/webp"
-            />
-            <img
-              src="/art/title-chesscito.png"
-              alt="Chesscito"
-              width={512}
-              height={249}
-              draggable={false}
-            />
-          </picture>
-          {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
-          <picture className="hub-lite-avatar">
-            <source
-              srcSet={
-                pro.active
-                  ? "/art/avatar-pro-224w.avif 224w, /art/avatar-pro-340w.avif 340w, /art/avatar-pro.avif 499w"
-                  : "/art/avatar-lite-hub-224w.avif 224w, /art/avatar-lite-hub-340w.avif 340w, /art/avatar-lite-hub.avif 499w"
-              }
-              sizes="(max-width: 337px) 101px, (max-width: 377px) 30vw, 113px"
-              type="image/avif"
-            />
-            <source
-              srcSet={
-                pro.active
-                  ? "/art/avatar-pro-224w.webp 224w, /art/avatar-pro-340w.webp 340w, /art/avatar-pro.webp 499w"
-                  : "/art/avatar-lite-hub-224w.webp 224w, /art/avatar-lite-hub-340w.webp 340w, /art/avatar-lite-hub.webp 499w"
-              }
-              sizes="(max-width: 337px) 101px, (max-width: 377px) 30vw, 113px"
-              type="image/webp"
-            />
-            <img
-              src={pro.active ? "/art/avatar-pro.png" : "/art/avatar-lite-hub.png"}
-              alt=""
-              aria-hidden="true"
-              width={499}
-              height={560}
-              draggable={false}
-            />
-          </picture>
-          <AppModeSwitch activeMode="play" />
-        </div>
+      {/* Flat sibling stack — mirrors the LEARN/LITE hub's DOM so both hubs
+          share ONE distribution: header · mascot · panel · CTA · shortcuts flow
+          as direct children of <main> (no intermediate centered body wrapper). */}
 
-        {/* Kingdom hero panel — one panel, PRO chip is the only per-state
-            difference. The non-PRO chip opens the PRO sheet (onProTap). */}
-        <KingdomCard pro={pro} onProDiscover={onProTap} />
+      {/* Title + avatar reuse the EXACT LEARN/LITE mascot (wordmark banner +
+          circular gold-ring wizard) so the two hubs share one identity.
+          Avatar flips to the PRO variant in lockstep with `pro.active`. */}
+      <div className="hub-lite-mascot play-hub-mascot">
+        {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
+        <picture className="hub-lite-title">
+          <source
+            srcSet="/art/title-chesscito-288w.avif 288w, /art/title-chesscito-384w.avif 384w, /art/title-chesscito.avif 512w"
+            sizes="(max-width: 352px) 141px, (max-width: 417px) 40vw, 167px"
+            type="image/avif"
+          />
+          <source
+            srcSet="/art/title-chesscito-288w.webp 288w, /art/title-chesscito-384w.webp 384w, /art/title-chesscito.webp 512w"
+            sizes="(max-width: 352px) 141px, (max-width: 417px) 40vw, 167px"
+            type="image/webp"
+          />
+          <img
+            src="/art/title-chesscito.png"
+            alt="Chesscito"
+            width={512}
+            height={249}
+            draggable={false}
+          />
+        </picture>
+        {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
+        <picture className="hub-lite-avatar">
+          <source
+            srcSet={
+              pro.active
+                ? "/art/avatar-pro-224w.avif 224w, /art/avatar-pro-340w.avif 340w, /art/avatar-pro.avif 499w"
+                : "/art/avatar-lite-hub-224w.avif 224w, /art/avatar-lite-hub-340w.avif 340w, /art/avatar-lite-hub.avif 499w"
+            }
+            sizes="(max-width: 337px) 101px, (max-width: 377px) 30vw, 113px"
+            type="image/avif"
+          />
+          <source
+            srcSet={
+              pro.active
+                ? "/art/avatar-pro-224w.webp 224w, /art/avatar-pro-340w.webp 340w, /art/avatar-pro.webp 499w"
+                : "/art/avatar-lite-hub-224w.webp 224w, /art/avatar-lite-hub-340w.webp 340w, /art/avatar-lite-hub.webp 499w"
+            }
+            sizes="(max-width: 337px) 101px, (max-width: 377px) 30vw, 113px"
+            type="image/webp"
+          />
+          <img
+            src={pro.active ? "/art/avatar-pro.png" : "/art/avatar-lite-hub.png"}
+            alt=""
+            aria-hidden="true"
+            width={499}
+            height={560}
+            draggable={false}
+          />
+        </picture>
+        <AppModeSwitch activeMode="play" />
+      </div>
 
-        {/* Dominant CTA — occupies the Start Focus slot of the LEARN/LITE hub. */}
-        <div className="hub-scaffold-cta-row play-hub-cta-row">
-          <PrimaryPlayCta
-            surface="playhub"
-            label={tPlay("arenaLabel")}
-            ariaLabel={tPlay("arenaAriaLabel")}
-            onPress={onArenaPress}
-            className="hub-scaffold-arena-cta play-hub-arena-cta"
-            pieceIconSrc="/art/hub/enter-arena.png"
+      {/* Kingdom hero panel — one panel, PRO chip is the only per-state
+          difference. The non-PRO chip opens the PRO sheet (onProTap). */}
+      <KingdomCard pro={pro} onProDiscover={onProTap} />
+
+      {/* Dominant CTA — occupies the Start Focus slot of the LEARN/LITE hub.
+          A 1:1 blue clone of that button's geometry (`.play-chess-cta` mirrors
+          `.hub-lite-start-focus`), keeping the crossed-swords icon. */}
+      <div className="hub-scaffold-cta-row play-hub-cta-row">
+        <button
+          type="button"
+          className="play-chess-cta"
+          data-testid="play-chess-cta"
+          aria-label={tPlay("arenaAriaLabel")}
+          onClick={() => {
+            hapticTap();
+            onArenaPress();
+          }}
+        >
+          {/* eslint-disable-next-line jsx-a11y/aria-unsupported-elements */}
+          <picture className="play-chess-cta-icon" aria-hidden="true">
+            <source srcSet="/art/hub/enter-arena.avif" type="image/avif" />
+            <source srcSet="/art/hub/enter-arena.webp" type="image/webp" />
+            <img src="/art/hub/enter-arena.png" alt="" draggable={false} />
+          </picture>
+          <span>{tPlay("arenaLabel")}</span>
+        </button>
+      </div>
+
+      {/* CHESS TOOLS — reuses the LEARN training-path square-tile visual
+          (HubActionTile already mirrors .reward-tile). Tactics stays
+          self-contained; Coach/Shop are prop-driven. Pinned to the floor
+          (margin-top:auto) like the LEARN Training Path. */}
+      <section className="play-hub-tools" aria-label={tPlay("chessToolsLabel")}>
+        <h2 className="play-hub-tools-label">{tPlay("chessToolsLabel")}</h2>
+        <div className="play-hub-tools-grid" aria-label={tPlay("actionsAriaLabel")}>
+          <PlayTacticsTile className="" />
+          <HubActionTile
+            iconSrc="/art/redesign/icons/coach.png"
+            label={tPlay("coachLabel")}
+            ariaLabel={tHud("coachAriaLabel")}
+            onClick={onCoachTap}
+            badge={<span className="play-hub-action-badge">PRO</span>}
+          />
+          <HubActionTile
+            iconSrc="/art/redesign/icons/shop.png"
+            label={tPlay("shopLabel")}
+            ariaLabel={tPlay("shopAriaLabel")}
+            onClick={onShopTap}
           />
         </div>
-
-        {/* CHESS TOOLS — reuses the LEARN training-path square-tile visual
-            (HubActionTile already mirrors .reward-tile). Tactics stays
-            self-contained; Coach/Shop are prop-driven. */}
-        <section className="play-hub-tools" aria-label={tPlay("chessToolsLabel")}>
-          <h2 className="play-hub-tools-label">{tPlay("chessToolsLabel")}</h2>
-          <div className="play-hub-tools-grid" aria-label={tPlay("actionsAriaLabel")}>
-            <PlayTacticsTile className="" />
-            <HubActionTile
-              iconSrc="/art/redesign/icons/coach.png"
-              label={tPlay("coachLabel")}
-              ariaLabel={tHud("coachAriaLabel")}
-              onClick={onCoachTap}
-              badge={<span className="play-hub-action-badge">PRO</span>}
-            />
-            <HubActionTile
-              iconSrc="/art/redesign/icons/shop.png"
-              label={tPlay("shopLabel")}
-              ariaLabel={tPlay("shopAriaLabel")}
-              onClick={onShopTap}
-            />
-          </div>
-        </section>
       </section>
     </main>
   );

--- a/apps/web/src/components/payments/get-peones-sheet.tsx
+++ b/apps/web/src/components/payments/get-peones-sheet.tsx
@@ -122,6 +122,12 @@ export function GetPeonesSheet({ open, onOpenChange, onSuccess }: GetPeonesSheet
       disableBackdropClose={busy}
       ariaLabel={t("title")}
       closeLabel={t("close")}
+      // Opened from inside the Account aux sheet (Chesito Card → Top up), whose
+      // Radix slide-in transform would otherwise trap this `fixed` modal inside
+      // the sheet. Portal to <body> so it covers the whole sheet, and drop to
+      // z-[55] so it sits ABOVE the z-50 sheet but UNDER the z-60 dock.
+      portal
+      scrimZClassName="z-[55]"
     >
       <div
         className="flex flex-col items-center gap-4 text-center"


### PR DESCRIPTION
## What

Two founder-requested PLAY hub polish items + one layering fix, plus a pre-existing red-suite repair.

### PLAY hub → LEARN parity
- **Distribution**: removed the centered `.play-hub-body` wrapper — mascot · Kingdom panel · CTA · CHESS TOOLS are now direct siblings of `<main>` (flat stack, `flex-start` + `gap:6px`), matching the LEARN/LITE hub. Shortcuts pinned to the floor via `margin-top:auto`. Base `.hub-scaffold` (legacy FULL hub) untouched.
- **Tiles**: Tactics/Coach/Shop adopt the LEARN gold piece-tile (48px compact, gold gradient) — retires the cream look.
- **PLAY CHESS CTA**: 1:1 blue clone of the Start Focus button geometry (`.play-chess-cta`), keeps the crossed-swords icon.

### Fix — Get Peones modal layering (/arena)
The Radix `<Sheet>` slide-in `transform` trapped the modal's `position:fixed` inside the Account sheet (read as an "interior screen", stuck under the dock). `VictoryPopupShell` gains opt-in `portal` + `scrimZClassName`; `GetPeonesSheet` portals to `<body>` at `z-[55]` → covers the Account sheet (z-50), stays under the dock (z-60). Arena/exercises popups unchanged.

### Test repair (pre-existing)
Added `useDisconnect` to the wagmi mock in 3 arena test files (red since PR #173 wired AccountSheet into /arena).

## Verification
- `tsc --noEmit` clean
- Full unit suite: **4681 passing** (was 5 failing — all pre-existing arena mock gaps, now fixed)
- Visual QA of the modal `transform` trap is Chromium/MiniPay-only (not repro in jsdom); founder to confirm on-device.

Wolfcito 🐾 @akawolfcito