### PR TITLE
fix(scripts): reset-wallet --full deletes treasury FK children before peones_ledger

### DIFF
--- a/apps/web/scripts/reset-wallet.ts
+++ b/apps/web/scripts/reset-wallet.ts
@@ -111,7 +111,14 @@ async function main() {
     );
     redisPatterns.push(`coach:game:${lower}:*`, `coach:analysis:${lower}:*`);
     supaDeletes.push(
+      // FK children of peones_ledger + treasury_payment_intents (Get Peones
+      // treasury canary). MUST precede peones_ledger, else the delete violates
+      // treasury_payment_consumptions_ledger_id_fkey. consumptions →
+      // intents (intent_id FK) so consumptions is deleted first.
+      { table: "treasury_payment_consumptions", column: "wallet" },
+      { table: "treasury_payment_intents", column: "wallet" },
       { table: "peones_ledger", column: "wallet" },
+      { table: "pro_subscriptions", column: "wallet" },
       { table: "score_saves", column: "wallet" },
       { table: "scores", column: "player" },
       { table: "welcome_pack_claims", column: "wallet_address" },

--- a/docs/runbooks/2026-07-07-reset-wallet-for-testing.md
+++ b/docs/runbooks/2026-07-07-reset-wallet-for-testing.md
@@ -76,9 +76,15 @@ re-hidrata**. PLAY seguirá mostrando tus victorias on-chain.
   DEL coach:pro:<wallet>
   ```
 - **Peones** (`peones_ledger`, Supabase) — economía ganada en LEARN, gastada en
-  ambos. Borrar deja balance 0 (Welcome Pack re-reclamable):
+  ambos. Borrar deja balance 0 (Welcome Pack re-reclamable). **Ojo con la FK del
+  canary de Treasury**: hay que borrar los hijos ANTES de `peones_ledger`
+  (`treasury_payment_consumptions.ledger_id` → `peones_ledger`, y
+  `.intent_id` → `treasury_payment_intents`):
   ```sql
-  delete from public.peones_ledger where wallet = lower('<WALLET>');
+  delete from public.treasury_payment_consumptions where wallet = lower('<WALLET>');
+  delete from public.treasury_payment_intents      where wallet = lower('<WALLET>');
+  delete from public.peones_ledger                 where wallet = lower('<WALLET>');
+  delete from public.pro_subscriptions             where wallet = lower('<WALLET>');
   ```
 
 **Opcional (dedupe de tx):** solo si quisieras re-verificar la MISMA tx de compra


### PR DESCRIPTION
Fixes FK violation: `peones_ledger` delete hit `treasury_payment_consumptions_ledger_id_fkey` (Get Peones treasury canary). New delete order: treasury_payment_consumptions → treasury_payment_intents → peones_ledger (+ pro_subscriptions). Idempotent; safe to re-run.

Wolfcito 🐾 @akawolfcito