### PR TITLE
feat(minipay): Lote 2 — off-chain save gratis + colapsar CTA verde

### DIFF
--- a/apps/web/src/app/api/scores/save/__tests__/route.test.ts
+++ b/apps/web/src/app/api/scores/save/__tests__/route.test.ts
@@ -175,36 +175,30 @@ describe("POST /api/scores/save", () => {
     expect(json.status).toBe("saved");
     expect(json.mode).toBe("free");
     expect(json.quota.freeUsed).toBe(1);
-    expect(json.quota.freeRemaining).toBe(2); // limit 3 - used 1
     expect(json.quota.requiresPeones).toBe(false);
+    expect(json.quota.costPeones).toBe(0);
   });
 
-  it("RPC saved/peones → 200 spent 1", async () => {
-    rpcOk({ status: "saved", mode: "peones", spent: 1, freeUsed: 6, balance: 4 });
+  // MiniPay Lote 2: off-chain save is ALWAYS FREE. Even far beyond the former
+  // 3-save threshold, the response stays free and never charges / never 409s.
+  it("save beyond the old free threshold → still 200 saved/free, never peones", async () => {
+    rpcOk({ status: "saved", mode: "free", freeUsed: 12 });
     const res = await POST(makeRequest(body()));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe("saved");
-    expect(json.mode).toBe("peones");
-    expect(json.spent).toBe(1);
-    expect(json.quota.requiresPeones).toBe(true);
+    expect(json.mode).toBe("free");
+    expect(json.quota.requiresPeones).toBe(false);
+    expect(json.quota.costPeones).toBe(0);
   });
 
   it("RPC duplicate → 200 duplicate", async () => {
     rpcOk({ status: "duplicate", mode: "free", freeUsed: 3 });
     const res = await POST(makeRequest(body()));
     expect(res.status).toBe(200);
-    expect((await res.json()).status).toBe("duplicate");
-  });
-
-  it("RPC insufficient_peones → 409 with required + balance", async () => {
-    rpcOk({ status: "insufficient_peones", required: 1, balance: 0, freeUsed: 6 });
-    const res = await POST(makeRequest(body()));
-    expect(res.status).toBe(409);
     const json = await res.json();
-    expect(json.status).toBe("insufficient_peones");
-    expect(json.required).toBe(1);
-    expect(json.balance).toBe(0);
+    expect(json.status).toBe("duplicate");
+    expect(json.quota.requiresPeones).toBe(false);
   });
 
   it("RPC error → 500 controlled error", async () => {
@@ -218,20 +212,15 @@ describe("POST /api/scores/save", () => {
   });
 
   // ── attestation + wallet + isolation ────────────────────────────
-  it("builds the save_game attestation and passes it to the RPC", async () => {
+  // MiniPay Lote 2: off-chain save is always free → NO save_game attestation is
+  // built (the sink never fires) and p_attestation_hash is passed null.
+  it("does NOT build a save_game attestation; passes p_attestation_hash null", async () => {
     rpcOk({ status: "saved", mode: "free", freeUsed: 1 });
     await POST(makeRequest(body()));
-    expect(buildAttestationHash).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event_type: "spend",
-        source: "save_game",
-        source_id: SAVE_ID,
-        idempotency_key: `spend:save_game:${SAVE_ID}`,
-      }),
-    );
+    expect(buildAttestationHash).not.toHaveBeenCalled();
     expect(supabaseMock.rpc).toHaveBeenCalledWith(
       "save_basic_score",
-      expect.objectContaining({ p_attestation_hash: "att-sentinel" }),
+      expect.objectContaining({ p_attestation_hash: null }),
     );
   });
 

--- a/apps/web/src/app/api/scores/save/route.ts
+++ b/apps/web/src/app/api/scores/save/route.ts
@@ -27,11 +27,9 @@
 import { NextResponse } from "next/server";
 
 import { normalizeWallet } from "@/lib/peones/ledger-service";
-import { buildAttestationHash } from "@/lib/peones/ledger-service-server";
 import {
   computeScoreSaveQuota,
   deriveScoreSaveId,
-  SCORE_SAVE_COST_PEONES,
   type BasicScoreSaveResult,
 } from "@/lib/scores/save-service";
 import {
@@ -48,10 +46,6 @@ const log = createLogger({ route: "/api/scores/save" });
 
 /** Window of the soft limiter; surfaced to the client as a retry hint. */
 const RATE_LIMIT_WINDOW_MS = 60_000;
-
-function todayUtcDate(): string {
-  return new Date().toISOString().slice(0, 10);
-}
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -152,22 +146,11 @@ export async function POST(req: Request) {
     return json({ status: "error", reason: "unavailable" }, 503);
   }
 
-  // 5. save_game attestation — deterministic SHA-256 over the canonical
-  //    economic payload, identical to what /api/peones/spend records for
-  //    a save_game debit. Used by the RPC only on the paid path; the free
-  //    path ignores it. NOT a placeholder.
-  const idempotencyKey = `spend:save_game:${saveId}`;
-  const attestationHash = buildAttestationHash({
-    wallet,
-    event_type: "spend",
-    amount: SCORE_SAVE_COST_PEONES,
-    source: "save_game",
-    source_id: saveId,
-    day_utc: todayUtcDate(),
-    idempotency_key: idempotencyKey,
-  });
-
-  // 6. Atomic RPC. Returns a single jsonb object (NOT a table).
+  // 5. Atomic RPC. Returns a single jsonb object (NOT a table). Off-chain
+  //    save is ALWAYS FREE (MiniPay Lote 2): the RPC never calls peones_spend,
+  //    so the `save_game` sink never fires and no attestation is built. The
+  //    `p_attestation_hash` param is kept for call-site compatibility only and
+  //    passed null.
   const { data, error } = await supabase.rpc("save_basic_score", {
     p_save_id: saveId,
     p_wallet: wallet,
@@ -175,7 +158,7 @@ export async function POST(req: Request) {
     p_score: score,
     p_time_ms: timeMs,
     p_game_id: gameId,
-    p_attestation_hash: attestationHash,
+    p_attestation_hash: null,
     p_metadata: null,
   });
 
@@ -184,34 +167,18 @@ export async function POST(req: Request) {
     return json({ status: "error", reason: "save_failed" }, 500);
   }
 
-  // 7. Map jsonb → BasicScoreSaveResult. The RPC returns
-  //    insufficient_peones as DATA (it catches P0001 internally), so no
-  //    error-code parsing is needed for it.
+  // 6. Map jsonb → BasicScoreSaveResult. Off-chain save is always free, so the
+  //    RPC only ever returns `saved` (mode free) or `duplicate` — there is no
+  //    paid path, no `insufficient_peones`, and no 409.
   const row = data as Record<string, unknown>;
   const freeUsed = Number(row.freeUsed ?? 0);
   const quota = computeScoreSaveQuota(wallet, freeUsed);
 
   switch (row.status) {
     case "saved":
-      if (row.mode === "peones") {
-        return json(
-          { status: "saved", mode: "peones", spent: Number(row.spent ?? SCORE_SAVE_COST_PEONES), quota },
-          200,
-        );
-      }
       return json({ status: "saved", mode: "free", quota }, 200);
     case "duplicate":
       return json({ status: "duplicate", quota }, 200);
-    case "insufficient_peones":
-      return json(
-        {
-          status: "insufficient_peones",
-          required: Number(row.required ?? SCORE_SAVE_COST_PEONES),
-          balance: Number(row.balance ?? 0),
-          quota,
-        },
-        409,
-      );
     default:
       log.error("rpc_unexpected_status", { wallet, status: String(row.status) });
       return json({ status: "error", reason: "save_failed" }, 500);

--- a/apps/web/src/app/dev/exercises-popups/fixture.tsx
+++ b/apps/web/src/app/dev/exercises-popups/fixture.tsx
@@ -110,15 +110,16 @@ export function ExercisesPopupsFixture({ variant }: { variant: Variant }) {
       )}
 
       {variant === "reward-dual" && (
+        /* MiniPay Lote 2 F1: the off-chain SAVE pin was removed — CLAIM is the
+           only reward pin now (off-chain save auto-runs). */
         <div className="flex min-h-[100dvh] items-center justify-center">
           <div className="flex items-center justify-center gap-3">
-            {(["submitScore", "claimBadge"] as const).map((a) => (
+            {(["claimBadge"] as const).map((a) => (
               <ContextualActionSlot
                 key={a}
                 action={a}
                 shieldsAvailable={0}
                 isBusy={false}
-                onSubmitScore={noop}
                 onUseShield={noop}
                 onClaimBadge={noop}
                 onRetry={noop}

--- a/apps/web/src/app/dev/exercises-popups/fixture.tsx
+++ b/apps/web/src/app/dev/exercises-popups/fixture.tsx
@@ -80,11 +80,11 @@ export function ExercisesPopupsFixture({ variant }: { variant: Variant }) {
       )}
 
       {variant === "score-saved-peones" && (
+        /* B2 (Lote 2): off-chain save is free — no Peones-spent pill. */
         <ResultOverlay
           variant="score"
           pieceType="bishop"
           totalStars={15}
-          spentPeones={1}
           onDismiss={noop}
         />
       )}

--- a/apps/web/src/components/exercises/__tests__/contextual-action-slot.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/contextual-action-slot.test.tsx
@@ -5,7 +5,6 @@ import { ContextualActionSlot } from "../contextual-action-slot";
 const noop = () => {};
 
 const baseHandlers = {
-  onSubmitScore: noop,
   onUseShield: noop,
   onClaimBadge: noop,
   onRetry: noop,
@@ -38,13 +37,12 @@ describe("ContextualActionSlot — compact label", () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
-  it("uses the compactLabel ('SAVE') for the submitScore action", () => {
-    // Post-SAVE-local-first (Cluster C) the long "Submit Score" copy was
-    // collapsed into the canonical "SAVE" label across all action-slot
-    // variants. This assertion locks the editorial alignment.
+  // MiniPay Lote 2 F1: the off-chain SAVE pin was removed from the action
+  // slot (off-chain save auto-runs). CLAIM is the compact reward pin now.
+  it("uses the compactLabel ('CLAIM') for the claimBadge action", () => {
     render(
       <ContextualActionSlot
-        action="submitScore"
+        action="claimBadge"
         shieldsAvailable={0}
         isBusy={false}
         compact
@@ -52,10 +50,9 @@ describe("ContextualActionSlot — compact label", () => {
       />,
     );
     const label = screen
-      .getAllByText("SAVE")
+      .getAllByText("CLAIM")
       .find((el) => el.tagName === "SPAN");
     expect(label).toBeDefined();
-    expect(label!.textContent).toBe("SAVE");
-    expect(screen.queryByText("Submit Score")).not.toBeInTheDocument();
+    expect(label!.textContent).toBe("CLAIM");
   });
 });

--- a/apps/web/src/components/exercises/__tests__/mission-detail-sheet.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/mission-detail-sheet.test.tsx
@@ -104,51 +104,69 @@ describe("<MissionDetailSheet> — guide-only surface (redistribution D1)", () =
   });
 });
 
-describe("<MissionDetailSheet> — save score affordance (D5)", () => {
-  it("renders the promise line + save button and fires the handler", async () => {
-    const onSaveScore = vi.fn();
-    const user = userEvent.setup();
-    renderSheet({ canSaveScore: true, onSaveScore, score: "120" });
+describe("<MissionDetailSheet> — off-chain save state (B2, Lote 2)", () => {
+  it("shows the informative 'Score saved' state, never a green Save CTA", () => {
+    renderSheet({ scoreSaved: true, score: "120" });
 
-    // Promise-first narrative (QA F5/G3): the off-chain save promises
-    // the leaderboard, never on-chain permanence.
-    expect(screen.getByText("Climb the leaderboard")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Save score" }));
-    expect(onSaveScore).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("score-saved-state")).toHaveTextContent(
+      "Score saved",
+    );
+    // The off-chain save is automatic + free: no green protagonist CTA.
+    expect(
+      screen.queryByRole("button", { name: "Save score" }),
+    ).not.toBeInTheDocument();
+    // And no leaderboard "value" promise on the off-chain save.
+    expect(screen.queryByText("Climb the leaderboard")).not.toBeInTheDocument();
   });
 
-  it("disables the save button while a save is in flight", () => {
+  it("surfaces a FREE manual retry only when the auto-save failed", async () => {
+    const onRetrySave = vi.fn();
+    const user = userEvent.setup();
+    renderSheet({ saveFailed: true, onRetrySave, score: "120" });
+
+    const retry = screen.getByRole("button", { name: "Retry save" });
+    await user.click(retry);
+    expect(onRetrySave).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the retry while a save is in flight", () => {
     renderSheet({
-      canSaveScore: true,
-      onSaveScore: vi.fn(),
+      saveFailed: true,
+      onRetrySave: vi.fn(),
       isSavingScore: true,
       score: "120",
     });
 
-    expect(screen.getByRole("button", { name: "Save score" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Retry save" })).toBeDisabled();
   });
 
-  it("renders no save button when saving is not available", () => {
-    renderSheet({ canSaveScore: false, onSaveScore: vi.fn() });
+  it("renders no save state when there is no pending/saved score", () => {
+    renderSheet({ canSaveScore: false });
 
     expect(
       screen.queryByRole("button", { name: "Save score" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry save" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("score-saved-state")).not.toBeInTheDocument();
   });
 
-  it("renders the on-chain save action when available and fires its handler", async () => {
+  it("keeps the on-chain proof as the only explicit save CTA", async () => {
     const onSaveOnChain = vi.fn();
     const user = userEvent.setup();
     renderSheet({
       canSaveScore: true,
-      onSaveScore: vi.fn(),
       canSaveOnChain: true,
       onSaveOnChain,
       score: "120",
     });
 
-    // Its own promise line, distinct from the leaderboard one.
     expect(screen.getByText("Save today’s training proof")).toBeInTheDocument();
+    // No competing green off-chain CTA next to the gold proof.
+    expect(
+      screen.queryByRole("button", { name: "Save score" }),
+    ).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Save proof" }));
     expect(onSaveOnChain).toHaveBeenCalledTimes(1);
   });
@@ -156,7 +174,6 @@ describe("<MissionDetailSheet> — save score affordance (D5)", () => {
   it("hides the on-chain action when unavailable (no dead buttons)", () => {
     renderSheet({
       canSaveScore: true,
-      onSaveScore: vi.fn(),
       canSaveOnChain: false,
       onSaveOnChain: vi.fn(),
     });
@@ -171,7 +188,6 @@ describe("<MissionDetailSheet> — score breakdown (transparency)", () => {
   it("shows stars × 100 breakdown when canSaveScore + totalStars provided", () => {
     renderSheet({
       canSaveScore: true,
-      onSaveScore: vi.fn(),
       score: "1200",
       totalStars: 12,
       maxPossibleStars: 30,
@@ -184,7 +200,6 @@ describe("<MissionDetailSheet> — score breakdown (transparency)", () => {
   it("shows Max indicator when totalStars equals maxPossibleStars", () => {
     renderSheet({
       canSaveScore: true,
-      onSaveScore: vi.fn(),
       score: "3000",
       totalStars: 30,
       maxPossibleStars: 30,
@@ -204,7 +219,6 @@ describe("<MissionDetailSheet> — score breakdown (transparency)", () => {
         isCapture={false}
         score="3000"
         canSaveScore
-        onSaveScore={vi.fn()}
         totalStars={30}
         maxPossibleStars={30}
         trigger={<button type="button">peek</button>}
@@ -220,7 +234,6 @@ describe("<MissionDetailSheet> — score breakdown (transparency)", () => {
   it("does NOT show breakdown when totalStars is absent", () => {
     renderSheet({
       canSaveScore: true,
-      onSaveScore: vi.fn(),
       score: "1200",
     });
 
@@ -230,7 +243,6 @@ describe("<MissionDetailSheet> — score breakdown (transparency)", () => {
   it("does NOT include labyrinths in the breakdown text", () => {
     renderSheet({
       canSaveScore: true,
-      onSaveScore: vi.fn(),
       score: "1200",
       totalStars: 12,
       maxPossibleStars: 30,

--- a/apps/web/src/components/exercises/__tests__/result-overlay.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/result-overlay.test.tsx
@@ -119,18 +119,18 @@ describe("ResultOverlay — SaveScore recovery + quota communication", () => {
     expect(screen.queryByText(/Try again/i)).not.toBeInTheDocument();
   });
 
-  it("free save: shows the remaining-free-saves quota pill", () => {
+  // MiniPay Lote 2 (B2): off-chain save is free → the score overlay shows NO
+  // Peones-spent or free-saves-left pill, only the stars earned.
+  it("score save: shows stars but no Peones/free-saves pill", () => {
     renderWithIntl(
       <ResultOverlay
         variant="score"
         pieceType="rook"
         totalStars={9}
-        freeSavesLeft={2}
         onDismiss={vi.fn()}
       />,
     );
-    expect(
-      screen.getByTestId("score-free-saves-left").textContent,
-    ).toContain("2");
+    expect(screen.queryByTestId("score-free-saves-left")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("score-peones-spent")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/exercises/contextual-action-slot.tsx
+++ b/apps/web/src/components/exercises/contextual-action-slot.tsx
@@ -9,7 +9,6 @@ type ContextualActionSlotProps = {
   action: ContextAction;
   shieldsAvailable: number;
   isBusy: boolean;
-  onSubmitScore: () => void;
   onUseShield: () => void;
   onClaimBadge: () => void;
   onRetry: () => void;
@@ -25,7 +24,6 @@ function getHandler(
   props: ContextualActionSlotProps
 ): () => void {
   switch (action) {
-    case "submitScore": return props.onSubmitScore;
     case "useShield": return props.onUseShield;
     case "claimBadge": return props.onClaimBadge;
     case "retry": return props.onRetry;
@@ -107,5 +105,5 @@ export function ContextualActionSlot(props: ContextualActionSlotProps) {
 }
 
 function hasLoading(action: Exclude<ContextAction, null>): boolean {
-  return action === "submitScore" || action === "useShield" || action === "claimBadge";
+  return action === "useShield" || action === "claimBadge";
 }

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -453,11 +453,6 @@ export function ExercisesScreen({
      *  insufficient-funds errors. Only the shop-buy caller sets this. */
     txErrorKind?: TxErrorKind | null;
     retryAction?: () => void;
-    /** SaveScore off-chain (Slice 5): Peones spent on a paid save. Passed
-     *  to the score overlay so the player sees the 1-Peón charge. */
-    spentPeones?: number;
-    /** SaveScore: free saves remaining after this save (free/duplicate). */
-    freeSavesLeft?: number;
     /** Recovery CTA (insufficient Peones → Get Peones). */
     recoveryCta?: { label: string; onPress: () => void };
   } | null>(null);
@@ -466,6 +461,11 @@ export function ExercisesScreen({
   // request. Replaces the wagmi `isScoreWriting`/`isSubmitConfirming` busy
   // signal for the base save path (now off-chain, no tx to confirm).
   const [isSavingScore, setIsSavingScore] = useState(false);
+  // MiniPay Lote 2 (B2): the off-chain save auto-runs on completion and is
+  // silent (no celebration overlay). If that auto-save fails, this flips true
+  // so the mission sheet surfaces a free manual "Retry save" fallback instead
+  // of leaving the player stuck. Reset when a fresh pending score appears.
+  const [autoSaveFailed, setAutoSaveFailed] = useState(false);
   // Get Peones recovery sheet — opened from the insufficient-save overlay.
   const [getPeonesOpen, setGetPeonesOpen] = useState(false);
 
@@ -752,6 +752,10 @@ export function ExercisesScreen({
    *  React could flip the disabled state. Cleared in the finally
    *  branch so retries after failure/timeout still work. */
   const submittingScoreRef = useRef(false);
+  /** MiniPay Lote 2 (B2): the local score the silent auto-save has already
+   *  attempted, so the auto-save effect fires exactly once per distinct score
+   *  (no loop on failure — the manual fallback handles retry). */
+  const autoSavedScoreRef = useRef<number | null>(null);
   /** Same concurrency guard as `submittingScoreRef`, for
    *  `handleUseShield`'s async server call — prevents a rapid
    *  double-tap on the ContextualActionSlot shield action from firing
@@ -1597,16 +1601,21 @@ export function ExercisesScreen({
     }
   }
 
-  async function handleSubmitScore() {
-    // SaveScore off-chain (Slice 5): the base save no longer signs
-    // (/api/sign-score), never broadcasts `submitScoreSigned`, never
-    // prompts approve/send, and never enters the signer 429 loop. It POSTs
-    // /api/scores/save (5 free saves per wallet, then 1 Peón) and renders
-    // exactly what the server returns. The retained on-chain path lives in
-    // @/lib/contracts/scoreboard for the future Leaderboard Proof lane.
+  async function handleSubmitScore(opts?: { silent?: boolean }) {
+    // SaveScore off-chain: the base save no longer signs (/api/sign-score),
+    // never broadcasts `submitScoreSigned`, never prompts approve/send, and
+    // never enters the signer 429 loop. It POSTs /api/scores/save (ALWAYS
+    // FREE — MiniPay Lote 2 B1) and renders exactly what the server returns.
+    // The retained on-chain path lives in @/lib/contracts/scoreboard for the
+    // Leaderboard Proof lane.
+    //
+    // `silent` (B2): the auto-save on completion persists in the background
+    // and never pops the celebration overlay — the inline "Score saved" state
+    // is the feedback. A manual retry (fallback) runs non-silent.
     //
     // `canSaveScore` (no badgeEarned requirement) gates the surface; the
     // scoreboard address is no longer a precondition.
+    const silent = opts?.silent ?? false;
     if (!canSaveScore || !address || isSubmitBusy) {
       return;
     }
@@ -1645,9 +1654,18 @@ export function ExercisesScreen({
         source: "exercises",
       });
 
+      // Silent auto-save (B2): never throw an error overlay at the player in
+      // the background. Any non-success flips the inline fallback so the
+      // mission sheet offers a free manual "Retry save".
+      if (silent && result.status !== "saved" && result.status !== "duplicate") {
+        setAutoSaveFailed(true);
+        return;
+      }
+
       switch (result.status) {
         case "saved":
         case "duplicate": {
+          setAutoSaveFailed(false);
           hapticSuccess();
           // Local-first save state. Empty txHash: off-chain saves have no
           // receipt, so `savedReceiptUrl` stays undefined (no CeloScan
@@ -1655,14 +1673,12 @@ export function ExercisesScreen({
           // to its saved-parity state, same as the on-chain path did.
           recordSaveFor(selectedPiece, scoreNum, "");
 
-          const paid = result.status === "saved" && result.mode === "peones";
-          const spentPeones = paid ? result.spent : undefined;
-          // Communicate the free-save quota progressively: on a free save
-          // (or idempotent duplicate) show how many free saves remain so
-          // the wall never arrives as a surprise.
-          const freeSavesLeft = paid ? undefined : result.quota.freeRemaining;
-
-          setResultOverlay({ variant: "score", spentPeones, freeSavesLeft });
+          // Off-chain save is always free (B1) and silent on auto-save (B2):
+          // the background auto-save persists without popping the celebration
+          // overlay. Only a manual (non-silent) save shows the score overlay.
+          if (!silent) {
+            setResultOverlay({ variant: "score" });
+          }
 
           // Optimistic leaderboard entry (same key the leaderboard sheet
           // reads on open). The combined view (Slice 4) already includes
@@ -1730,6 +1746,23 @@ export function ExercisesScreen({
       setIsSavingScore(false);
     }
   }
+
+  // MiniPay Lote 2 (B2): auto-save the off-chain score the moment a new score
+  // is pending. Off-chain persistence is normal app behaviour (always free),
+  // not a purchase — so it never waits for a CTA tap. Fires once per distinct
+  // score via `autoSavedScoreRef`; a failure flips `autoSaveFailed` (surfacing
+  // the free manual fallback) without looping. The on-chain proof stays the
+  // only explicit value action.
+  useEffect(() => {
+    if (!scorePendingNew || isSubmitBusy) return;
+    if (autoSavedScoreRef.current === localScoreNum) return;
+    autoSavedScoreRef.current = localScoreNum;
+    setAutoSaveFailed(false);
+    void handleSubmitScore({ silent: true });
+    // handleSubmitScore is a stable closure recreated each render; gating on
+    // the score value + the ref makes the effect idempotent without it in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scorePendingNew, isSubmitBusy, localScoreNum]);
 
   /** QA round 2 (2026-06-11): the ORIGINAL on-chain SAVE, revived as an
    *  explicit second action (gas-only, no Peones). Faithful to the
@@ -2265,8 +2298,13 @@ export function ExercisesScreen({
           maxPossibleStars={maxPossibleStars}
           trainingPath={trainingPath}
           canSaveScore={scorePendingNew}
-          onSaveScore={() => void handleSubmitScore()}
           isSavingScore={isSubmitBusy}
+          // B2: off-chain save auto-runs silently. The sheet shows an
+          // informative "Score saved" state (or a free manual retry on
+          // failure) instead of a competing green CTA.
+          scoreSaved={isSavedAtParity}
+          saveFailed={autoSaveFailed}
+          onRetrySave={() => void handleSubmitScore()}
           canSaveOnChain={scorePendingNew && scoreboardAddress != null}
           onSaveOnChain={() => void handleSaveScoreOnChain()}
           isSavingOnChain={isScoreWriting || isSubmitConfirming}
@@ -2693,8 +2731,6 @@ export function ExercisesScreen({
             errorKind={resultOverlay.errorKind}
             txErrorKind={resultOverlay.txErrorKind}
             totalStars={totalStars}
-            spentPeones={resultOverlay.spentPeones}
-            freeSavesLeft={resultOverlay.freeSavesLeft}
             recoveryCta={resultOverlay.recoveryCta}
             onDismiss={() => setResultOverlay(null)}
             onRetry={resultOverlay.retryAction}

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -2434,12 +2434,7 @@ export function ExercisesScreen({
                     key={a}
                     action={a}
                     shieldsAvailable={shieldCount}
-                    isBusy={
-                      a === "submitScore"
-                        ? isSavingScore
-                        : isBadgeWriting || isClaimConfirming
-                    }
-                    onSubmitScore={() => void handleSubmitScore()}
+                    isBusy={isBadgeWriting || isClaimConfirming}
                     onUseShield={handleUseShield}
                     onClaimBadge={() => void handleClaimBadge()}
                     onRetry={handleRetryApplied}
@@ -2472,8 +2467,7 @@ export function ExercisesScreen({
               <ContextualActionSlot
                 action={contextAction}
                 shieldsAvailable={shieldCount}
-                isBusy={isSavingScore || isBadgeWriting || isClaimConfirming}
-                onSubmitScore={() => void handleSubmitScore()}
+                isBusy={isBadgeWriting || isClaimConfirming}
                 onUseShield={handleUseShield}
                 onClaimBadge={() => void handleClaimBadge()}
                 // Sprint 5 commit G — route the legacy free Retry
@@ -2657,24 +2651,9 @@ export function ExercisesScreen({
               // on the badges sheet, which now owns the switch grid.
               setBadgeSheetOpen(true);
             }}
-            onSubmitScore={
-              canSaveScore
-                ? () => {
-                    setShowPieceComplete(false);
-                    // Submit-and-close used to drop the user back on
-                    // the final exercise of the just-completed piece
-                    // while the score POST flew off; align it with
-                    // the dismiss/next-piece path so the surface
-                    // advances even when the user picks the on-chain
-                    // save route.
-                    void handleSubmitScore();
-                    if (nextPiece) {
-                      setSelectedPiece(nextPiece);
-                      resetBoard();
-                    }
-                  }
-                : undefined
-            }
+            // MiniPay Lote 2 F1: no manual off-chain save CTA here — the score
+            // auto-saves on completion. The primary continuation CTAs
+            // (next piece / labyrinth / choose piece) advance the flow.
           />
         ) : null}
 
@@ -2710,12 +2689,10 @@ export function ExercisesScreen({
           <BadgeEarnedPrompt
             pieceType={selectedPiece}
             totalStars={totalStars}
-            onSubmitScore={() => {
-              autoReset.clear();
-              setShowBadgeEarned(false);
-              void handleSubmitScore();
-            }}
-            onLater={handleBadgeEarnedDismiss}
+            // MiniPay Lote 2 F1: no manual off-chain SAVE CTA — the score
+            // auto-saves. The badge celebration just continues to the piece
+            // complete flow.
+            onContinue={handleBadgeEarnedDismiss}
           />
         ) : null}
 

--- a/apps/web/src/components/exercises/mission-detail-sheet.tsx
+++ b/apps/web/src/components/exercises/mission-detail-sheet.tsx
@@ -32,11 +32,19 @@ type Props = {
    *  before reporting so the player lands straight on the board.
    *  Absent → the line renders nothing. */
   onLabyrinthSelect?: (labyrinthId: string) => void;
-  /** D5 — save-score affordance below the objective. Button renders
-   *  only when `canSaveScore` AND the handler are provided. */
+  /** MiniPay Lote 2 (B2): the off-chain save auto-runs on completion and is
+   *  free, so the sheet no longer renders a green "Save score" CTA. It shows
+   *  an informative saved state — or, only if the background auto-save failed,
+   *  a free manual retry.
+   *  `canSaveScore`: a new score is pending (auto-save in flight / just ran).
+   *  `scoreSaved`: the score is persisted → show "✓ Score saved".
+   *  `saveFailed`: the auto-save failed → show the free "Retry save" fallback.
+   */
   canSaveScore?: boolean;
-  onSaveScore?: () => void;
   isSavingScore?: boolean;
+  scoreSaved?: boolean;
+  saveFailed?: boolean;
+  onRetrySave?: () => void;
   /** Score transparency: total exercise stars for the selected piece.
    *  When provided alongside maxPossibleStars, renders the breakdown
    *  line "12★ × 100 pts" (or "Max" indicator when at cap).
@@ -68,8 +76,10 @@ export function MissionDetailSheet({
   trainingPath,
   onLabyrinthSelect,
   canSaveScore = false,
-  onSaveScore,
   isSavingScore = false,
+  scoreSaved = false,
+  saveFailed = false,
+  onRetrySave,
   canSaveOnChain = false,
   onSaveOnChain,
   isSavingOnChain = false,
@@ -120,7 +130,9 @@ export function MissionDetailSheet({
         .findIndex((node) => node.id === nextChallenge.id) + 1
     : 0;
   const showNowLine = Boolean(nextChallenge && onLabyrinthSelect);
-  const showSaveScore = Boolean(canSaveScore && onSaveScore);
+  // B2: the off-chain save is not a CTA. Surface its state (saved / retrying /
+  // just-saved) whenever there is a pending or persisted score to reflect.
+  const showSaveState = Boolean(canSaveScore || scoreSaved || saveFailed);
   const showSaveOnChain = Boolean(canSaveOnChain && onSaveOnChain);
   const pieceName = (() => {
     try {
@@ -262,7 +274,7 @@ export function MissionDetailSheet({
                   </div>
                 </div>
 
-                {(showNowLine || showSaveScore || showSaveOnChain) && (
+                {(showNowLine || showSaveState || showSaveOnChain) && (
                   <picture>
                     <source
                       srcSet="/art/screen-mission/adorno-icon.avif"
@@ -302,25 +314,16 @@ export function MissionDetailSheet({
                   </button>
                 ) : null}
 
-                {/* D5 + QA F5 — save score, below the objective block.
-                    Promise line leads with the reward; the button stays
-                    an explicit action. Same handler the contextual SAVE
-                    pin uses; the parent owns gating and busy state. */}
-                {showSaveScore ? (
-                  <p
-                    className="mt-3 text-center text-xs font-semibold"
-                    style={{
-                      color: "rgba(110, 65, 15, 0.78)",
-                      textShadow: "0 1px 0 rgba(255, 245, 215, 0.55)",
-                    }}
-                  >
-                    {tDetail("saveScorePromise")}
-                  </p>
-                ) : null}
-                {showSaveScore && totalStars !== undefined && maxPossibleStars !== undefined ? (
+                {/* B2 (Lote 2) — the off-chain score save is automatic and
+                    free, so there is NO green "Save score" CTA here. We only
+                    reflect its state: the stars breakdown, then an informative
+                    "Score saved" line (or a free manual retry if the silent
+                    auto-save failed). The on-chain proof below stays the only
+                    explicit value action. */}
+                {showSaveState && totalStars !== undefined && maxPossibleStars !== undefined ? (
                   <p
                     data-testid="score-breakdown"
-                    className="mt-1 text-center text-xs font-medium"
+                    className="mt-3 text-center text-xs font-medium"
                     style={{
                       color: "rgba(110, 65, 15, 0.55)",
                       textShadow: "0 1px 0 rgba(255, 245, 215, 0.4)",
@@ -334,14 +337,17 @@ export function MissionDetailSheet({
                       : tDetail("scoreBreakdown", { stars: totalStars })}
                   </p>
                 ) : null}
-                {showSaveScore ? (
+                {saveFailed && onRetrySave ? (
+                  /* Auto-save failed → free manual retry (never a paywall,
+                     never a competing protagonist CTA). */
                   <button
                     type="button"
-                    aria-label={tDetail("saveScoreCta")}
-                    onClick={onSaveScore}
+                    aria-label={tDetail("retrySaveCta")}
+                    onClick={onRetrySave}
                     disabled={isSavingScore}
                     aria-busy={isSavingScore}
-                    className="candy-tray-pill shop-item-tile-buy-pill shop-item-tile-buy-pill--green mt-1.5"
+                    data-testid="score-save-retry"
+                    className="candy-tray-pill mt-1.5"
                   >
                     {isSavingScore ? (
                       <>
@@ -352,9 +358,27 @@ export function MissionDetailSheet({
                         <span>{tDetail("saving")}</span>
                       </>
                     ) : (
-                      `${tDetail("saveScoreCta")} · ${score}`
+                      tDetail("retrySaveCta")
                     )}
                   </button>
+                ) : scoreSaved ? (
+                  <p
+                    data-testid="score-saved-state"
+                    className="mt-1.5 text-center text-sm font-semibold"
+                    style={{
+                      color: "rgba(21, 128, 61, 0.95)",
+                      textShadow: "0 1px 0 rgba(255, 245, 215, 0.5)",
+                    }}
+                  >
+                    ✓ {tDetail("scoreSaved")}
+                  </p>
+                ) : isSavingScore ? (
+                  <p
+                    data-testid="score-saving-state"
+                    className="mt-1.5 text-center text-xs font-medium opacity-70"
+                  >
+                    {tDetail("saving")}
+                  </p>
                 ) : null}
 
                 {/* QA round 2 — the revived on-chain SAVE: the original

--- a/apps/web/src/components/exercises/mission-panel-candy.tsx
+++ b/apps/web/src/components/exercises/mission-panel-candy.tsx
@@ -51,8 +51,13 @@ type MissionPanelProps = {
   /** D5 — save-score affordance inside the mission detail sheet.
    *  Forwarded untouched; the host owns gating and busy state. */
   canSaveScore?: boolean
-  onSaveScore?: () => void
   isSavingScore?: boolean
+  /** B2 (Lote 2): off-chain save auto-runs + is free. Forwarded to
+   *  MissionDetailSheet, which renders the informative saved state / free
+   *  manual retry instead of a green CTA. */
+  scoreSaved?: boolean
+  saveFailed?: boolean
+  onRetrySave?: () => void
   /** Score transparency breakdown. Forwarded to MissionDetailSheet. */
   totalStars?: number
   maxPossibleStars?: number
@@ -421,8 +426,10 @@ export function MissionPanelCandy({
   isCapture = false,
   trainingPath,
   canSaveScore,
-  onSaveScore,
   isSavingScore,
+  scoreSaved,
+  saveFailed,
+  onRetrySave,
   totalStars,
   maxPossibleStars,
   canSaveOnChain,
@@ -537,8 +544,10 @@ export function MissionPanelCandy({
               trainingPath={trainingPath}
               onLabyrinthSelect={onLabyrinthSelect}
               canSaveScore={canSaveScore}
-              onSaveScore={onSaveScore}
               isSavingScore={isSavingScore}
+              scoreSaved={scoreSaved}
+              saveFailed={saveFailed}
+              onRetrySave={onRetrySave}
               totalStars={totalStars}
               maxPossibleStars={maxPossibleStars}
               canSaveOnChain={canSaveOnChain}

--- a/apps/web/src/components/exercises/result-overlay.tsx
+++ b/apps/web/src/components/exercises/result-overlay.tsx
@@ -603,8 +603,10 @@ export function ResultOverlay({
 type BadgeEarnedPromptProps = {
   pieceType: PieceKey;
   totalStars: number;
-  onSubmitScore: () => void;
-  onLater: () => void;
+  /** MiniPay Lote 2 F1: the off-chain score auto-saves, so the badge prompt
+   *  is purely celebratory. Its single primary CTA continues the flow (X /
+   *  scrim / auto-dismiss all resolve to the same continuation). */
+  onContinue: () => void;
 };
 
 const BADGE_AUTO_DISMISS_MS = 15_000;
@@ -612,8 +614,7 @@ const BADGE_AUTO_DISMISS_MS = 15_000;
 export function BadgeEarnedPrompt({
   pieceType,
   totalStars,
-  onSubmitScore,
-  onLater,
+  onContinue,
 }: BadgeEarnedPromptProps) {
   const tBadge = useTranslations("BADGE_EARNED_COPY");
   const tPiece = useTranslations("PIECE_LABELS");
@@ -624,22 +625,22 @@ export function BadgeEarnedPrompt({
     track("modal_open", { id: "badge-earned", piece: pieceType, stars: totalStars });
   }, [pieceType, totalStars]);
 
-  function handleLater() {
+  function handleContinue() {
     setExiting(true);
-    setTimeout(onLater, 250);
+    setTimeout(onContinue, 250);
   }
 
   // Founder vocabulary pass 2026-06-11: migrated from CandyGlassShell
   // (plain green glass) to VictoryPopupShell so the prompt carries the
-  // panel-bg1 forest frame like every other app modal. CTAs follow the
-  // ceremonial vocabulary: SAVE = PrincipalButton, Later = secondary
-  // text action.
+  // panel-bg1 forest frame like every other app modal.
+  // MiniPay Lote 2 F1: the off-chain save auto-runs, so the former green
+  // SAVE CTA is gone — a single neutral "Continue" resolves the celebration.
   return (
     <div className={exiting ? "modal-exiting" : undefined}>
       <VictoryPopupShell
-        onClose={handleLater}
+        onClose={handleContinue}
         ariaLabel={tBadge("headerLabel")}
-        closeLabel={tBadge("later")}
+        closeLabel={tBadge("continue")}
       >
         {/* Auto-dismiss countdown bar — first element inside the panel
             so it reads as a "timer on the modal". */}
@@ -670,16 +671,9 @@ export function BadgeEarnedPrompt({
         </div>
 
         <div className="flex flex-col items-center gap-2">
-          <PrincipalButton size="medium" onClick={onSubmitScore}>
-            {tBadge("submitScore")}
+          <PrincipalButton size="medium" onClick={handleContinue}>
+            {tBadge("continue")}
           </PrincipalButton>
-          <button
-            type="button"
-            onClick={handleLater}
-            className="arena-result-secondary-action"
-          >
-            {tBadge("later")}
-          </button>
         </div>
 
         <div
@@ -710,10 +704,6 @@ type PieceCompletePromptProps = {
    *  source of truth (we never need labyrinthList.length passed
    *  separately). */
   onTryLabyrinth?: () => void;
-  /** Re-surfaces the Submit Score transactional moment that may have
-   *  been lost when the user dismissed BadgeEarnedPrompt with "Later".
-   *  Only wired when canSendOnChain && score is eligible. */
-  onSubmitScore?: () => void;
   /** Opens the PiecePickerSheet from the completion ceremony. Used as
    *  the primary CTA when there is no next piece in the linear order
    *  AND no labyrinth available for the current piece — without this
@@ -733,7 +723,6 @@ export function PieceCompletePrompt({
   onArena,
   onPracticeAgain,
   onTryLabyrinth,
-  onSubmitScore,
   onChoosePiece,
 }: PieceCompletePromptProps) {
   const tComplete = useTranslations("PIECE_COMPLETE_COPY");
@@ -876,16 +865,6 @@ export function PieceCompletePrompt({
               className="arena-result-secondary-action"
             >
               {tComplete("nextPiece", { piece: tPiece(nextPiece) })}
-            </button>
-          )}
-
-          {onSubmitScore && (
-            <button
-              type="button"
-              onClick={() => handleAction(onSubmitScore)}
-              className="arena-result-secondary-action"
-            >
-              {tComplete("submitScore")}
             </button>
           )}
 

--- a/apps/web/src/components/exercises/result-overlay.tsx
+++ b/apps/web/src/components/exercises/result-overlay.tsx
@@ -53,16 +53,6 @@ type ResultOverlayProps = {
   onDismiss: () => void;
   onRetry?: () => void;
   totalStars?: number;
-  /** SaveScore off-chain (Slice 5): Peones spent on this save (past the 5
-   *  free saves). When > 0 on the score variant, a small cost pill renders
-   *  beside the stars so the player sees the 1-Peón charge. Omitted/0 for
-   *  free saves. */
-  spentPeones?: number;
-  /** SaveScore off-chain: free saves remaining AFTER this save. When set on
-   *  the score variant, a quota pill renders so the player sees the free
-   *  allowance ("2 free saves left"). 0 communicates the next save costs a
-   *  Peón. Omitted for paid saves. */
-  freeSavesLeft?: number;
   /** Recovery CTA for an error variant (e.g. insufficient Peones → "Get
    *  Peones"). When set, it becomes the primary button + a "Not now"
    *  secondary, replacing the Try-again/Dismiss pair. */
@@ -259,8 +249,6 @@ export function ResultOverlay({
   onDismiss,
   onRetry,
   totalStars,
-  spentPeones,
-  freeSavesLeft,
   recoveryCta,
 }: ResultOverlayProps) {
   const tResult = useTranslations("RESULT_OVERLAY_COPY");
@@ -342,28 +330,16 @@ export function ResultOverlay({
               </div>
             </div>
 
-            {(starsLabel ||
-              (spentPeones != null && spentPeones > 0) ||
-              freeSavesLeft != null) && (
+            {/* B2 (Lote 2): off-chain save is free, so no Peones-spent or
+                free-saves-left pills — only the stars earned. */}
+            {starsLabel && (
               <div className="arena-result-stats-row arena-result-stats-row--missionpills">
-                {starsLabel && (
-                  <span className="candy-stat-pill">
-                    <span className="candy-stat-pill-icon">
-                      <CandyIcon name="star" className="h-4 w-4" />
-                    </span>
-                    {starsLabel}
+                <span className="candy-stat-pill">
+                  <span className="candy-stat-pill-icon">
+                    <CandyIcon name="star" className="h-4 w-4" />
                   </span>
-                )}
-                {spentPeones != null && spentPeones > 0 && (
-                  <span className="candy-stat-pill" data-testid="score-peones-spent">
-                    {spentPeones} {tResult("score.peonesSpentLabel")}
-                  </span>
-                )}
-                {freeSavesLeft != null && (
-                  <span className="candy-stat-pill" data-testid="score-free-saves-left">
-                    {freeSavesLeft} {tResult("score.freeSavesLeftLabel")}
-                  </span>
-                )}
+                  {starsLabel}
+                </span>
               </div>
             )}
 

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -337,6 +337,9 @@ export const BADGE_EARNED_COPY = {
   claimBadge: "CLAIM",
   submitScore: "SAVE",
   later: "Later",
+  /** MiniPay Lote 2 F1: single neutral CTA now that the off-chain save
+   *  auto-runs (no manual SAVE in this prompt). */
+  continue: "Continue",
   headerLabel: "Badge Earned",
 } as const;
 

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -149,6 +149,12 @@ export const MISSION_DETAIL_COPY = {
    *  on-chain Leaderboard Proof action (QA G3 2026-06-11). */
   saveScorePromise: "Climb the leaderboard",
   saveScoreCta: "Save score",
+  /** MiniPay delivery Lote 2 B2 (2026-07-08): the off-chain save auto-runs and
+   *  is free, so it is no longer a CTA. `scoreSaved` is the informative state
+   *  shown once persisted; `retrySaveCta` is the free manual fallback surfaced
+   *  only if the silent auto-save failed. */
+  scoreSaved: "Score saved",
+  retrySaveCta: "Retry save",
   /** MiniPay delivery audit B6 (2026-07-07): the on-chain SAVE is the
    *  gas-only submitScoreSigned flow, reframed as an OPTIONAL voluntary
    *  training proof (not an over-promised "for life"). Copy leads with the

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -1250,6 +1250,8 @@ const messages = {
     nowLabyrinthAriaFormat: "Empezar Laberinto {number}",
     saveScorePromise: "Sube en la tabla de líderes",
     saveScoreCta: "Guardar puntaje",
+    scoreSaved: "Puntaje guardado",
+    retrySaveCta: "Reintentar guardado",
     saveOnChainPromise: "Guarda tu prueba de entrenamiento de hoy",
     saveOnChainCta: "Guardar prueba",
     saving: "Guardando…",

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -1344,6 +1344,7 @@ const messages = {
     claimBadge: "OBTENER",
     submitScore: "GUARDAR",
     later: "Después",
+    continue: "Continuar",
     headerLabel: "¡Insignia obtenida!",
   },
   BADGE_SHEET_COPY: {

--- a/apps/web/src/lib/game/__tests__/context-action.test.ts
+++ b/apps/web/src/lib/game/__tests__/context-action.test.ts
@@ -12,11 +12,9 @@ const BASE: ContextActionState = {
   isCorrectChain: true,
 };
 
-describe("getRewardActions — SAVE and CLAIM are independent (no slot fight)", () => {
-  it("scorePending only → [submitScore]", () => {
-    expect(getRewardActions({ ...BASE, scorePending: true })).toEqual([
-      "submitScore",
-    ]);
+describe("getRewardActions — CLAIM is the only reward pin (SAVE removed, Lote 2 F1)", () => {
+  it("scorePending only → [] (off-chain save auto-runs, no SAVE pin)", () => {
+    expect(getRewardActions({ ...BASE, scorePending: true })).toEqual([]);
   });
 
   it("badgeClaimable only → [claimBadge]", () => {
@@ -25,10 +23,10 @@ describe("getRewardActions — SAVE and CLAIM are independent (no slot fight)", 
     ]);
   });
 
-  it("both → [submitScore, claimBadge] (SAVE primary, first)", () => {
+  it("both scorePending + badge → [claimBadge] (no SAVE pin)", () => {
     expect(
       getRewardActions({ ...BASE, scorePending: true, badgeClaimable: true }),
-    ).toEqual(["submitScore", "claimBadge"]);
+    ).toEqual(["claimBadge"]);
   });
 
   it("neither → []", () => {
@@ -74,10 +72,8 @@ describe("getRewardActions — liteMode=true", () => {
     expect(getRewardActions(BASE, { liteMode: true })).toEqual([]);
   });
 
-  it("Full behavior unchanged when liteMode=false (scorePendingOnly → [submitScore])", () => {
-    expect(getRewardActions({ ...BASE, scorePending: true }, { liteMode: false })).toEqual([
-      "submitScore",
-    ]);
+  it("Full (liteMode=false) also has no SAVE pin for a pending score → []", () => {
+    expect(getRewardActions({ ...BASE, scorePending: true }, { liteMode: false })).toEqual([]);
   });
 });
 
@@ -139,10 +135,10 @@ describe("getContextAction — liteMode=true", () => {
     ).toEqual("retry");
   });
 
-  it("Full behavior unchanged when liteMode=false — submitScore returns normally", () => {
+  it("Full (liteMode=false) — a pending score yields null when connected (no SAVE pin)", () => {
     expect(
       getContextAction({ ...BASE, scorePending: true }, { liteMode: false }),
-    ).toEqual("submitScore");
+    ).toEqual(null);
   });
 
   it("Full behavior unchanged — connectWallet for score when disconnected", () => {
@@ -200,16 +196,16 @@ describe("getContextAction", () => {
   });
 
   // ── Progression states ─────────────────────────────────
-  it("returns submitScore when score is pending", () => {
-    expect(getContextAction({ ...BASE, scorePending: true })).toEqual("submitScore");
+  it("returns null for a pending score when connected (SAVE pin removed, save auto-runs)", () => {
+    expect(getContextAction({ ...BASE, scorePending: true })).toEqual(null);
   });
 
   it("returns claimBadge when badge is claimable", () => {
     expect(getContextAction({ ...BASE, badgeClaimable: true })).toEqual("claimBadge");
   });
 
-  // ── Priority: claimBadge > submitScore ─────────────────
-  it("prioritizes claimBadge over submitScore", () => {
+  // ── claimBadge still wins the connected path ───────────
+  it("returns claimBadge when both a score is pending and a badge is claimable", () => {
     expect(getContextAction({ ...BASE, scorePending: true, badgeClaimable: true })).toEqual("claimBadge");
   });
 

--- a/apps/web/src/lib/game/context-action.ts
+++ b/apps/web/src/lib/game/context-action.ts
@@ -1,5 +1,4 @@
 export type ContextAction =
-  | "submitScore"
   | "useShield"
   | "claimBadge"
   | "retry"
@@ -17,27 +16,27 @@ export type ContextActionState = {
 };
 
 export type ContextActionOptions = {
-  /** When true, score save actions are suppressed (submitScore, and
-   *  connectWallet/switchNetwork triggered solely by a pending score).
-   *  Badge claim path (claimBadge, connectWallet for badge, switchNetwork
-   *  for badge) is preserved — badge claim is valid in Lite.
-   *  Default false → Full behavior unchanged. */
+  /** When true, badge claim is still valid but nothing else changes.
+   *  Score save is never a manual action anymore (MiniPay Lote 2 F1:
+   *  off-chain save auto-runs), so this flag no longer gates a submitScore
+   *  pin. Kept for the badge-path callers.
+   *  Default false. */
   liteMode?: boolean;
 };
 
-/** Reward-area actions (2026-06-10): SAVE and CLAIM are distinct functions
- *  and must NOT fight for one slot. In liteMode, submitScore is suppressed;
- *  claimBadge remains valid. */
-export type RewardAction = Extract<ContextAction, "submitScore" | "claimBadge">;
+/** Reward-area actions: CLAIM (badge) is the only reward pin. The off-chain
+ *  SAVE pin was removed (MiniPay Lote 2 F1) — the off-chain save auto-runs and
+ *  the on-chain proof is the only explicit save CTA. */
+export type RewardAction = Extract<ContextAction, "claimBadge">;
 
 export function getRewardActions(
   state: ContextActionState,
   options?: ContextActionOptions,
 ): RewardAction[] {
+  void options;
   if (state.phase === "failure") return [];
   if (!state.isConnected || !state.isCorrectChain) return [];
   const actions: RewardAction[] = [];
-  if (state.scorePending && !options?.liteMode) actions.push("submitScore");
   if (state.badgeClaimable) actions.push("claimBadge");
   return actions;
 }
@@ -54,13 +53,12 @@ export function getContextAction(
     return "retry";
   }
 
-  // In liteMode: badge path is the only on-chain action.
-  // Score save (submitScore / connectWallet for score / switchNetwork for score)
-  // is suppressed. connectWallet/switchNetwork are preserved ONLY when badge is pending.
+  // In liteMode: badge path is the only on-chain action. connectWallet/
+  // switchNetwork are preserved ONLY when a badge is pending.
   if (liteMode) {
     if (state.isConnected && state.isCorrectChain) {
       if (state.badgeClaimable) return "claimBadge";
-      return null; // submitScore suppressed
+      return null;
     }
     // Wallet-state actions only when badge is pending
     if (state.badgeClaimable) {
@@ -70,10 +68,13 @@ export function getContextAction(
     return null; // scorePendingOnly → null in Lite
   }
 
-  // Full behavior (liteMode=false)
+  // Full behavior (liteMode=false). The off-chain SAVE pin was removed
+  // (MiniPay Lote 2 F1): a pending score never yields a manual submitScore
+  // action — the off-chain save auto-runs. connectWallet/switchNetwork are
+  // still surfaced for a pending score so a guest is nudged to connect (which
+  // then lets the auto-save persist).
   if (state.isConnected && state.isCorrectChain) {
     if (state.badgeClaimable) return "claimBadge";
-    if (state.scorePending) return "submitScore";
     return null;
   }
 

--- a/apps/web/src/lib/scores/__tests__/save-basic-score-schema.test.ts
+++ b/apps/web/src/lib/scores/__tests__/save-basic-score-schema.test.ts
@@ -44,11 +44,32 @@ const QUOTA_RECALIBRATION_MIGRATION_PATH = join(
   "20260610020000_savescore_quota_recalibration.sql",
 );
 
+/** MiniPay Delivery Lote 2 (2026-07-08): off-chain save is ALWAYS FREE. The
+ *  forward CREATE OR REPLACE removes the paid branch entirely — no peones_spend,
+ *  no P0001 catch, no insufficient_peones, always mode='free'. This is the
+ *  currently-live definition; the asserts below pin its shape. */
+const ALWAYS_FREE_MIGRATION_PATH = join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260708120000_savescore_always_free.sql",
+);
+
 const migration = readFileSync(MIGRATION_PATH, "utf-8");
 const quotaRecalibrationMigration = readFileSync(
   QUOTA_RECALIBRATION_MIGRATION_PATH,
   "utf-8",
 );
+const alwaysFreeMigration = readFileSync(ALWAYS_FREE_MIGRATION_PATH, "utf-8");
+
+/** Isolate the body of the always-free save_basic_score for scoped asserts. */
+function alwaysFreeRpcBody(): string {
+  const startIdx = alwaysFreeMigration.search(
+    /create or replace function public\.save_basic_score/i,
+  );
+  expect(startIdx).toBeGreaterThan(-1);
+  return alwaysFreeMigration.slice(startIdx);
+}
 
 /** Isolate the body of the save_basic_score function for scoped asserts. */
 function rpcBody(): string {
@@ -195,5 +216,47 @@ describe("save_basic_score quota recalibration (Slice C3) — TS↔SQL lockstep"
   it("reuses peones_spend (no raw ledger insert) — same atomic contract", () => {
     expect(quotaRecalibrationMigration).toMatch(/public\.peones_spend\(/i);
     expect(quotaRecalibrationMigration).not.toMatch(/insert into public\.peones_ledger/i);
+  });
+});
+
+describe("save_basic_score ALWAYS-FREE (MiniPay Lote 2) — live definition", () => {
+  it("re-creates save_basic_score with the approved signature", () => {
+    expect(alwaysFreeMigration).toMatch(
+      /create or replace function public\.save_basic_score\([\s\S]*?p_save_id\s+text,[\s\S]*?p_wallet\s+text,[\s\S]*?p_attestation_hash\s+text,[\s\S]*?p_metadata\s+jsonb default null[\s\S]*?\)/i,
+    );
+  });
+
+  it("keeps the per-wallet advisory lock + duplicate guard", () => {
+    const body = alwaysFreeRpcBody();
+    expect(body).toMatch(/pg_advisory_xact_lock\(\s*hashtext\(\s*lower\(/i);
+    expect(body).toMatch(/'?duplicate'?/i);
+  });
+
+  it("NEVER calls peones_spend (the save_game sink never fires)", () => {
+    const body = alwaysFreeRpcBody();
+    expect(body).not.toMatch(/public\.peones_spend\(/i);
+  });
+
+  it("has NO paid branch — no P0001 catch, no insufficient_peones", () => {
+    const body = alwaysFreeRpcBody();
+    expect(body).not.toMatch(/when sqlstate 'P0001'/i);
+    expect(body).not.toMatch(/insufficient_peones/i);
+  });
+
+  it("always inserts mode='free', peones_spent=0", () => {
+    const body = alwaysFreeRpcBody();
+    // The only score_saves insert must be the free one.
+    expect(body).toMatch(/'free',\s*0/);
+    expect(body).not.toMatch(/'peones',\s*c_cost/i);
+  });
+
+  it("never inserts raw into peones_ledger", () => {
+    const body = alwaysFreeRpcBody();
+    expect(body).not.toMatch(/insert into public\.peones_ledger/i);
+  });
+
+  it("does NOT touch the legacy scores table or leaderboard_v", () => {
+    expect(alwaysFreeMigration).not.toMatch(/\bpublic\.scores\b/i);
+    expect(alwaysFreeMigration).not.toMatch(/leaderboard_v/i);
   });
 });

--- a/apps/web/src/lib/scores/__tests__/save-service.test.ts
+++ b/apps/web/src/lib/scores/__tests__/save-service.test.ts
@@ -33,19 +33,20 @@ describe("computeScoreSaveQuota", () => {
     expect(q.costPeones).toBe(0);
   });
 
-  it("freeUsed 3 → 0 remaining, requiresPeones, cost 1", () => {
+  // MiniPay Lote 2 (2026-07-08): off-chain save is ALWAYS FREE. Beyond the
+  // former free threshold there is NO paywall — never requiresPeones, cost 0.
+  it("freeUsed 3 → 0 remaining but still free (no paywall)", () => {
     const q = computeScoreSaveQuota("0xabc", 3);
     expect(q.freeRemaining).toBe(0);
-    expect(q.requiresPeones).toBe(true);
-    expect(q.costPeones).toBe(SCORE_SAVE_COST_PEONES);
-    expect(q.costPeones).toBe(1);
+    expect(q.requiresPeones).toBe(false);
+    expect(q.costPeones).toBe(0);
   });
 
-  it("freeUsed > 3 → still requiresPeones, remaining clamped at 0, cost 1", () => {
+  it("freeUsed > 3 → still free, never charges Peones", () => {
     const q = computeScoreSaveQuota("0xabc", 9);
     expect(q.freeRemaining).toBe(0);
-    expect(q.requiresPeones).toBe(true);
-    expect(q.costPeones).toBe(1);
+    expect(q.requiresPeones).toBe(false);
+    expect(q.costPeones).toBe(0);
   });
 
   it("negative freeUsed clamps to 0", () => {
@@ -72,11 +73,12 @@ describe("computeScoreSaveQuota", () => {
     expect(q.wallet).toBe("0xdeadbeef");
   });
 
-  it("proActive does NOT change the result in MVP", () => {
+  it("proActive does NOT change the result (always free either way)", () => {
     const withPro = computeScoreSaveQuota("0xabc", 5, true);
     const without = computeScoreSaveQuota("0xabc", 5, false);
     expect(withPro).toEqual(without);
-    expect(withPro.requiresPeones).toBe(true);
+    expect(withPro.requiresPeones).toBe(false);
+    expect(withPro.costPeones).toBe(0);
     expect(withPro.freeLimit).toBe(3);
   });
 });

--- a/apps/web/src/lib/scores/save-service.ts
+++ b/apps/web/src/lib/scores/save-service.ts
@@ -89,8 +89,16 @@ function clampUsed(freeUsed: number): number {
 /**
  * Pure quota math. `freeUsed` is the per-wallet count of existing
  * `score_saves` rows (counted server-side). `proActive` is reserved for
- * a future PRO quota bump — it is intentionally ignored in MVP so the
- * signature is stable when that lands.
+ * a future PRO quota bump — it is intentionally ignored so the signature
+ * is stable when that lands.
+ *
+ * MiniPay Delivery Lote 2 (2026-07-08): off-chain save is now ALWAYS FREE.
+ * Persisting a basic score/progress never costs Peones and works at a 0
+ * balance, matching the always-free `save_basic_score` RPC
+ * (20260708120000_savescore_always_free.sql). So `requiresPeones` is always
+ * `false` and `costPeones` is always `0`, regardless of `freeUsed`. The
+ * `freeUsed`/`freeRemaining` fields remain as informational counters only —
+ * they no longer gate a paywall and are no longer surfaced in the UI.
  */
 export function computeScoreSaveQuota(
   wallet: string,
@@ -98,20 +106,20 @@ export function computeScoreSaveQuota(
   proActive?: boolean,
 ): ScoreSaveQuota {
   // `proActive` is reserved for a future PRO quota bump; intentionally
-  // unused in MVP. Reference it as a no-op to keep the param documented.
+  // unused. Reference it as a no-op to keep the param documented.
   void proActive;
 
   const used = clampUsed(freeUsed);
   const freeRemaining = Math.max(0, FREE_SCORE_SAVE_LIMIT - used);
-  const requiresPeones = freeRemaining === 0;
 
   return {
     wallet: wallet.toLowerCase(),
     freeLimit: FREE_SCORE_SAVE_LIMIT,
     freeUsed: used,
     freeRemaining,
-    requiresPeones,
-    costPeones: requiresPeones ? SCORE_SAVE_COST_PEONES : 0,
+    // Always free: no paywall, no sink. See RPC always-free migration.
+    requiresPeones: false,
+    costPeones: 0,
   };
 }
 

--- a/apps/web/supabase/migrations/20260708120000_savescore_always_free.sql
+++ b/apps/web/supabase/migrations/20260708120000_savescore_always_free.sql
@@ -1,0 +1,93 @@
+-- Chesscito — SaveScore off-chain is ALWAYS FREE (MiniPay Delivery Lote 2)
+--
+-- Founder decision 2026-07-08: off-chain basic save must never cost Peones.
+-- Persisting a score/progress is normal app behaviour, not a purchase, so the
+-- `save_game` sink is NEVER executed for a basic save. Saving works even with a
+-- 0 Peones balance. The on-chain proof (voluntary, gas-only) is the only
+-- value action — it lives entirely outside this RPC and is untouched.
+--
+-- Applied forward via CREATE OR REPLACE; earlier migrations
+-- (20260609000000_score_saves_init.sql, 20260610020000_savescore_quota_
+-- recalibration.sql) are NOT edited. The function body is byte-identical to the
+-- recalibration EXCEPT the PAID branch is removed:
+--   - no public.peones_spend call (sink `save_game` never fires)
+--   - no P0001 catch, no `insufficient_peones` return
+--   - every save inserts mode='free', peones_spent=0
+-- `score_saves.mode` still permits 'peones' for historical rows (that CHECK is
+-- unchanged); we simply stop writing new 'peones' rows from basic saves.
+--
+-- Coach / hint / shield sinks are separate spend targets and keep charging.
+-- p_attestation_hash stays in the signature for call-site compatibility but is
+-- no longer used (the free path never attested a spend).
+
+create or replace function public.save_basic_score(
+  p_save_id          text,
+  p_wallet           text,
+  p_level_id         int,
+  p_score            int,
+  p_time_ms          int,
+  p_game_id          text,
+  p_attestation_hash text,
+  p_metadata         jsonb default null
+)
+returns jsonb
+language plpgsql
+volatile
+as $$
+declare
+  v_wallet     text;
+  v_used       int;
+  v_balance    bigint;
+  v_dup_mode   text;
+  v_dup_spent  int;
+begin
+  v_wallet := lower(p_wallet);
+
+  -- 0. Serialise every save for this wallet within the transaction.
+  perform pg_advisory_xact_lock(hashtext(lower(p_wallet)));
+
+  -- 1. Dedup. The UNIQUE on save_id is the hard guard.
+  select mode, peones_spent into v_dup_mode, v_dup_spent
+    from public.score_saves
+   where save_id = p_save_id;
+
+  if found then
+    v_used := (select count(*) from public.score_saves where wallet = v_wallet);
+    v_balance := coalesce(
+      (select balance from public.peones_balances where wallet = v_wallet), 0);
+    return jsonb_build_object(
+      'status', 'duplicate',
+      'mode', v_dup_mode,
+      'freeUsed', v_used,
+      'requiresPeones', false,
+      'spent', v_dup_spent,
+      'balance', v_balance,
+      'scoreSaveId', p_save_id
+    );
+  end if;
+
+  -- 2. ALWAYS-FREE path — no quota gate, no balance touched, no sink. Off-chain
+  --    persistence is unconditionally free.
+  insert into public.score_saves
+    (save_id, wallet, level_id, score, time_ms, game_id, mode, peones_spent, metadata)
+  values
+    (p_save_id, v_wallet, p_level_id, p_score, p_time_ms, p_game_id, 'free', 0, p_metadata);
+
+  v_used := (select count(*) from public.score_saves where wallet = v_wallet);
+  v_balance := coalesce(
+    (select balance from public.peones_balances where wallet = v_wallet), 0);
+
+  return jsonb_build_object(
+    'status', 'saved',
+    'mode', 'free',
+    'freeUsed', v_used,
+    'requiresPeones', false,
+    'spent', 0,
+    'balance', v_balance,
+    'scoreSaveId', p_save_id
+  );
+end;
+$$;
+
+comment on function public.save_basic_score(text, text, int, int, int, text, text, jsonb) is
+  'SaveScore basic atomic RPC. advisory-lock per wallet -> dedup -> ALWAYS-FREE insert (mode=free, peones_spent=0). Never calls peones_spend; the save_game sink never fires for basic saves. Works at 0 balance. Off-chain persistence is unconditionally free (MiniPay Lote 2, 2026-07-08).';

--- a/docs/audits/2026-07-08-pr181-lote2-review.md
+++ b/docs/audits/2026-07-08-pr181-lote2-review.md
@@ -1,0 +1,150 @@
+# Review enfocado — PR #181 (MiniPay Lote 2)
+
+Fecha: 2026-07-08 · Branch `chore/minipay-delivery-lote2-offchain-free-save`
+
+## Veredicto (actualizado): 🟢 APPROVE — F1 cerrado, F2 mitigado
+
+Estado inicial fue 🟡 REQUEST CHANGES por (F1) B2 incompleto y (F2) orden de
+deploy. Ambos resueltos (ver "Cierre" al final). B1 + migración sólidos.
+
+### Runbook de deploy (F2 — orden seguro, ya ejecutado)
+
+1. Aplicar la migración `20260708120000_savescore_always_free.sql` PRIMERO
+   (`supabase db push` desde `apps/web/`, contra la DB correcta). ✅ hecho
+   manualmente por el founder antes del merge/deploy.
+2. LUEGO merge + deploy del código.
+
+Aplicar la migración antes es seguro con el código viejo (pasa una attestation
+real a un RPC always-free que la ignora). El orden inverso dejaría al RPC viejo
+cobrando + recibiendo `p_attestation_hash: null` en la rama paid.
+
+---
+
+## 1. ¿`save_basic_score` queda always-free desde DB/RPC? ✅ SÍ
+
+`20260708120000_savescore_always_free.sql` (`CREATE OR REPLACE`):
+- Dedup (`save_id` UNIQUE) → `duplicate`; en cualquier otro caso inserta
+  `mode='free', peones_spent=0` y devuelve `saved/free`.
+- Sin `c_free_limit`, sin gate de cuota, sin `peones_spend`, sin `P0001`, sin
+  `insufficient_peones`. Todas las vars declaradas se usan; no quedan refs a
+  vars eliminadas. SQL válido.
+
+## 2. ¿Se eliminó `peones_spend` / sink `save_game` para LEARN save? ✅ SÍ
+
+- RPC: no llama `peones_spend`. `route.ts`: no construye attestation, pasa
+  `p_attestation_hash: null`, sin ramas peones/409.
+- `save_game` SIGUE existiendo como spend target en `spend-service.ts`
+  (taxonomía + lockstep + idempotency key), pero **nadie lo invoca** para el
+  save de LEARN. Correcto: el target vivo ≠ cobro.
+
+## 3. ¿Idempotencia / seguridad / return shape? ✅ SÍ
+
+- Idempotencia: `pg_advisory_xact_lock` por wallet + UNIQUE `save_id` + dedup →
+  `duplicate`. Preservado.
+- Seguridad: sin `SECURITY DEFINER` (igual que el original); `CREATE OR REPLACE`
+  conserva grants/owner. Sin cambio de postura (se llama con service role).
+- Return shape: `status/mode/freeUsed/requiresPeones/spent/balance/scoreSaveId`.
+  Se quitaron `freeLimit`/`freeRemaining` del jsonb, pero el route los recomputa
+  vía `computeScoreSaveQuota(wallet, row.freeUsed)`; solo lee `freeUsed`, `status`,
+  `mode`. Sin ruptura.
+
+## 4. ¿Coach/hint/shield siguen cobrando? ¿PLAY Save Victory intacto? ✅ SÍ
+
+- `peones_spend` y los targets `coach/hint/shield` no se tocaron. Solo se
+  reemplazó `save_basic_score`.
+- Arena / VictoryNFT / permit mint: sin cambios (ningún archivo de PLAY en el
+  diff).
+
+## 5. ¿UI sin "free saves left" y único CTA dorado? 🟠 PARCIAL — ver F1
+
+- ✅ `result-overlay`: pills `free saves left` + Peones gastados removidos.
+- ✅ `mission-detail-sheet`: CTA verde → estado informativo `✓ Score saved` /
+  retry gratis; dorado `Save proof` intacto.
+- 🟠 **Persisten CTAs verdes de save off-chain en otras surfaces (F1).**
+
+## 6. ¿Cómo se aplica la migración en deploy/CI? 🔴 MANUAL — ver F2
+
+No hay workflow de CI ni script `db push`. La migración se aplica a mano con
+`supabase db push` desde `apps/web/`. **Mergear el PR NO aplica la migración.**
+
+---
+
+## Hallazgos
+
+### F1 — 🟠 MEDIO · B2 incompleto: save off-chain sigue como CTA verde en 3 surfaces
+Además del mission sheet (ya colapsado), `handleSubmitScore()` sigue cableado
+como acción verde manual en:
+- `ContextualActionSlot` SAVE pin — reward area (`exercises-screen.tsx:2442`, `2476`)
+- `PieceCompleteSheet` `onSubmitScore` (`:2660`)
+- `BadgeEarnedPrompt` `onSubmitScore` (`:2713`)
+
+**Impacto:** con el auto-save, en el happy path estas se vuelven transitorias
+(spinner → se retiran al pasar a `isSavedAtParity`). Pero en el path de FALLO y
+en esas surfaces de cierre siguen mostrando un CTA verde de guardado. La
+prioridad #5 ("único CTA dorado") NO se cumple globalmente — solo en el mission
+sheet.
+
+**Sin bug de correctitud:** los guards (`submittingScoreRef` / `isSubmitBusy`)
+evitan doble POST; todo es gratis (B1). Es un gap de alcance/UX, no de datos.
+
+**Decisión requerida:** ¿B2 abarca solo el mission sheet, o todas las surfaces?
+Si es global → colapsar también SAVE pin / PieceComplete / BadgeEarned a estado
+informativo (o retirarlos, dado que el auto-save ya persiste).
+
+### F2 — 🔴 ALTO · Orden de deploy de la migración
+Como el apply es manual y el código nuevo pasa `p_attestation_hash: null`:
+- Si el **código se despliega ANTES** de aplicar la migración, el RPC viejo
+  (aún con rama paid) para usuarios con ≥3 saves intentaría `peones_spend(...
+  null ...)` → posible fallo/registro anómalo, y **seguiría cobrando** hasta el
+  apply.
+- **Orden seguro:** aplicar la migración PRIMERO (`supabase db push`), LUEGO
+  desplegar el código. Aplicar la migración antes es seguro con el código viejo
+  (pasa una attestation real a un RPC always-free que la ignora).
+
+### F3 — 🟢 BAJO · Copy muerta
+`saveScoreCta`, `saveScorePromise` (editorial/es), `peonesSpentLabel`,
+`freeSavesLeftLabel` quedan sin consumir. Cleanup opcional (cuidar paridad i18n).
+
+### F4 — 🟢 BAJO · Chattiness del auto-save
+Auto-save por cada score nuevo → una fila por ejercicio completado. Intencional,
+gratis, idempotente. Solo nota.
+
+---
+
+## Cierre (2026-07-08)
+
+### F2 — ✅ MITIGADO
+Migración aplicada manualmente contra la DB correcta ANTES del merge/deploy
+(founder). Runbook documentado arriba.
+
+### F1 — ✅ CERRADO
+Se removió el save off-chain como CTA verde/manual en las 3 surfaces restantes,
+dejando el auto-save + el dorado on-chain `Save proof` como único CTA accionable:
+- **ContextualActionSlot SAVE pin** — se eliminó la acción `submitScore` del
+  sistema de acciones (`context-action.ts` ya no la produce;
+  `ContextAction`/`RewardAction`/`ContextualActionSlot` sin `submitScore`). El
+  nudge connectWallet/switchNetwork para score pendiente se preserva (guía al
+  guest a conectar → auto-save persiste).
+- **PieceCompletePrompt** — se removió el prop/botón `onSubmitScore`; las CTAs de
+  continuación (next piece / labyrinth / choose piece) avanzan el flujo.
+- **BadgeEarnedPrompt** — el `PrincipalButton` verde `SAVE` pasó a un único
+  `Continue` neutro (`onContinue`); el score auto-guarda.
+- i18n: `BADGE_EARNED_COPY.continue` en EN + ES.
+
+**Nota:** el único save manual que queda es el fallback neutro (no verde)
+`Retry save` en el mission sheet, visible SOLO si el auto-save falla. No compite
+en el happy path. Si se quiere eliminar también, es follow-up.
+
+Verificación F1: typecheck limpio · lint limpio (archivos tocados) · 746 tests
+(exercises + game) passing.
+
+### F3 — 🟢 pendiente (no bloqueante)
+Copy muerta: `MISSION_DETAIL_COPY.saveScoreCta`/`saveScorePromise`,
+`RESULT_OVERLAY_COPY.score.peonesSpentLabel`/`freeSavesLeftLabel`,
+`BADGE_EARNED_COPY.submitScore`/`later`, `PIECE_COMPLETE_COPY.submitScore`,
+`FOOTER_CTA_COPY.submitScore`. Cleanup opcional cuidando paridad i18n.
+
+## Recomendación final: **APPROVE**
+
+B1/migración sólidos. F1 cerrado, F2 mitigado. Listo para merge cuando el founder
+lo decida (migración ya aplicada).

--- a/docs/backlog/2026-07-08-tactical-day-gift-proof-of-consistency-lote-2.5.md
+++ b/docs/backlog/2026-07-08-tactical-day-gift-proof-of-consistency-lote-2.5.md
@@ -1,0 +1,51 @@
+# Backlog / Lote 2.5 — Tactical Day Gift + Proof of Consistency
+
+> **Estado:** documentado, NO implementar en Lote 2. Registrado 2026-07-08.
+> Cluster siguiente al Lote 2 (off-chain free save). No tocar en esta entrega.
+
+## Flujo objetivo (futuro)
+
+1. Al completar **GREAT FOCUS DAY**, NO mandar directo al HUB.
+2. Completar GREAT FOCUS **desbloquea el Tactical Day Gift**.
+3. El usuario **resuelve el tactical/gift** como cierre de sesión (experiencia
+   completa de ~10–15 min).
+4. Tras resolverlo → mostrar **cierre / reward / progreso**.
+5. En ese cierre aparece el CTA **opcional**:
+   > "Save today's training proof"
+6. Si el usuario **no hace la tx** en ese momento (o pierde la pantalla), debe
+   poder hacerla **después desde el fuego del día**.
+7. El **fuego del día** funciona como **entry point / fallback** para completar
+   la *proof of consistency* del día.
+8. El gift/tactic **NO** debe estar expuesto directamente en el HUB header como
+   acción suelta si eso permite **saltarse** la experiencia completa.
+
+## Reglas de producto asociadas (mantener, no cambiar en Lote 2)
+
+Tres conceptos distintos — no confundir:
+
+| # | Concepto | Qué cuenta | Protegido por |
+|---|----------|-----------|---------------|
+| 1 | **Exercise COMBO** | Ejercicios consecutivos exitosos dentro de LEARN | Shield actual |
+| 2 | **Daily Streak** | Días consecutivos completando el daily | (nada aún) |
+| 3 | **Arena Win Streak** | Victorias consecutivas en PLAY | (nada aún) |
+
+- El **Shield actual protege el Exercise COMBO**, NO el Daily Streak.
+- **NO** implementar Daily Streak recovery ahora.
+- **NO** crear Daily Recovery Shield ahora.
+- **NO** cambiar esta lógica en Lote 2.
+
+## Fuera de alcance de Lote 2 (recordatorio)
+
+- No implementar el flujo Tactical Day Gift.
+- No implementar el fuego del día como fallback de tx.
+- No mover el gift/tactic fuera de su experiencia.
+
+## Open questions (para cuando se retome)
+
+- ¿Dónde vive el estado "proof pendiente del día" (Redis / Supabase / local)?
+- ¿El fuego del día ya tiene un componente entry point reutilizable? (ver
+  Focus Passport: `lib/daily/passport.ts` + `components/hub/focus-passport.tsx`).
+- ¿La proof on-chain reusa el rail de `save today's training proof` on-chain de
+  LEARN (gas-only) o define uno nuevo?
+- Enumerar estados UI del gift: locked / unlocked / in-progress / solved /
+  proof-pending / proof-saved (requisito CLAUDE.md antes de implementar).

--- a/docs/specs/2026-07-08-minipay-lote2-offchain-free-save.md
+++ b/docs/specs/2026-07-08-minipay-lote2-offchain-free-save.md
@@ -1,0 +1,155 @@
+# Mini-spec — MiniPay Delivery Lote 2: Off-chain save gratis + colapsar CTA verde
+
+> Fecha: 2026-07-08 · Branch objetivo: `chore/minipay-delivery-lote2-offchain-free-save`
+> Precede a Lote 2.5 (Tactical Day Gift + Proof of Consistency, ver
+> `docs/backlog/2026-07-08-tactical-day-gift-proof-of-consistency-lote-2.5.md`).
+
+## Objetivo
+
+- Off-chain save = **gratis** (nunca cobra Peones, funciona con 0 Peones).
+- Peones **no** se usan para persistencia básica.
+- On-chain proof = **única** acción explícita de valor.
+- PLAY **Save Victory** intacto. MAX_SHIELDS intacto. COMBO Shield intacto.
+
+## Estado actual (as-is)
+
+- **Gate de cobro vive en el RPC Postgres** `save_basic_score`
+  (`supabase/migrations/20260610020000_savescore_quota_recalibration.sql`):
+  3 saves gratis por wallet (lifetime), luego **1 Peón** vía `peones_spend`
+  con sink `save_game`. Devuelve `insufficient_peones` si no alcanza.
+- `route.ts` (`/api/scores/save`) construye la attestation `save_game` +
+  idempotency `spend:save_game:{saveId}` y mapea el jsonb del RPC.
+- `save-service.ts`: `FREE_SCORE_SAVE_LIMIT = 3`, `SCORE_SAVE_COST_PEONES = 1`,
+  `computeScoreSaveQuota()` marca `requiresPeones` cuando se agotan los free.
+- UI: `mission-detail-sheet.tsx:337` → botón **verde** `Save score · {score}`
+  (`shop-item-tile-buy-pill--green`) + botón **dorado** on-chain
+  `Save proof` (`--gold`). `result-overlay.tsx:362` muestra pill
+  `{freeSavesLeft} free saves left`.
+
+---
+
+## B1 — Save off-chain gratis (server/DB) · commit 1
+
+### Contrato (to-be)
+
+- El save off-chain SIEMPRE persiste `mode='free', peones_spent=0`.
+- Nunca invoca `peones_spend` → sink `save_game` **nunca** se ejecuta como cobro.
+- Nunca devuelve `insufficient_peones`. Funciona con balance 0.
+- `duplicate` sigue existiendo (dedup por `save_id`).
+- Retry → nuevo intento → sigue gratis.
+- Coach / hint / shield **no se tocan** (siguen cobrando por su propia lógica).
+
+### Cambios
+
+1. **Nueva migración** `2026xxxx_savescore_always_free.sql` —
+   `CREATE OR REPLACE FUNCTION public.save_basic_score(...)` (misma firma):
+   - Elimina la rama PAID: sin `peones_spend`, sin `P0001`, sin
+     `insufficient_peones`.
+   - Siempre inserta `mode='free', peones_spent=0` y devuelve `saved/free`.
+   - `duplicate` conservado. Advisory lock conservado.
+   - `p_attestation_hash` permanece en la firma (compat) pero no se usa.
+   - Comentario nuevo explicando "always-free, off-chain persistence".
+2. `save-service.ts`:
+   - `computeScoreSaveQuota()` → `requiresPeones` siempre `false`,
+     `costPeones` siempre `0`. `freeRemaining` deja de ser presión (B2 lo
+     retira de la UI).
+   - Documentar que la persistencia básica ya no consume el sink `save_game`.
+   - `SCORE_SAVE_COST_PEONES` / `FREE_SCORE_SAVE_LIMIT`: mantener export si algún
+     test/lockstep lo referencia; re-anotar semántica (ya no gatilla cobro).
+3. `route.ts`:
+   - La rama `insufficient_peones` (409) queda inalcanzable → removerla o
+     dejarla como defensa muerta documentada (preferido: removerla para no
+     mentir el contrato). La construcción de la attestation `save_game`
+     pasa a ser innecesaria → simplificar.
+
+### Tests (primero) — B1
+
+- Route: 4º, 5º… save → `saved/free` (nunca `peones`, nunca 409).
+- Route: balance 0 → `saved/free`.
+- Route: nunca se llama `peones_spend` (ya cubierto por
+  "only ever calls save_basic_score RPC"; reforzar que no hay 409).
+- Retry (nuevo saveId) → gratis.
+- Schema test (`save-basic-score-schema.test.ts`): nuevas aserciones sobre la
+  migración always-free (no `peones_spend`, no `insufficient_peones` en el
+  cuerpo vigente). Ajustar/segregar las aserciones legacy que leen el init.
+- Lockstep TS↔SQL revisado para no romper.
+
+---
+
+## B2 — Colapsar/reducir botón verde (UI/copy) · commit 2
+
+### Objetivo
+
+- El verde off-chain **no** comunica compra ni compite con el dorado on-chain.
+- Único CTA explícito de valor = **on-chain proof** (dorado, sin cambios).
+- Off-chain = guardado gratuito automático / estado informativo.
+
+### Enfoque (preferido)
+
+1. **Auto-guardar off-chain** una vez al alcanzar el estado listo con score
+   pendiente (`phase === "ready" && scorePendingNew && address`), disparando
+   `handleSubmitScore()` de forma idempotente:
+   - Guardas: `submittingScoreRef` (una sola vez) + dedup server por `saveId`
+     (`duplicate` es no-op) → sin doble guardado.
+2. Reemplazar el **botón verde** por un **estado informativo** no accionable:
+   `✓ Score saved` (chip/pill tipo texto, no botón, sin costo, sin Peones).
+3. **Fallback de recuperación**: si el auto-save falla (network/503), mostrar
+   un botón manual `Save score` (gratis, sin paywall, estilo neutro que NO
+   compite con el dorado) para que el usuario no quede bloqueado.
+4. `result-overlay.tsx`: **retirar** el pill `{freeSavesLeft} free saves left`
+   y el plumbing `freeSavesLeft` asociado (ya sin sentido).
+5. Copy i18n paridad ES/EN en `editorial.ts` + `messages/es.ts`
+   (`scoreSaved` / `savedAutomatically`).
+
+### Estados UI (enumeración, requisito CLAUDE.md)
+
+| Estado | Verde off-chain | Dorado on-chain |
+|--------|-----------------|-----------------|
+| score pendiente, auto-save en curso | spinner breve o nada | visible (proof) |
+| auto-save OK | `✓ Score saved` (informativo) | visible (proof) |
+| auto-save falló | botón `Save score` (gratis, neutro) | visible (proof) |
+| ya guardado (duplicate) | `✓ Score saved` | visible/estado guardado |
+| sin score pendiente | oculto | oculto |
+
+### No cambiar (B2)
+
+- Lógica on-chain / dorado `Save proof`.
+- PLAY Save Victory / NFT trophy.
+- Flujo GREAT FOCUS, Tactical Day Gift, fuego del día.
+- Overlays completos (solo el bloque de save CTA).
+
+---
+
+## Restricciones globales
+
+- No crear NFT de LEARN. No ELO/ranking. No Daily Streak recovery.
+- No tocar MAX_SHIELDS. No reabrir Lote 1 salvo bug directo.
+- i18n parity ES/EN. Commits atómicos. Tests afectados → suite → lint → typecheck.
+
+## Commits
+
+1. `feat(scores): off-chain save is always free (no Peones sink)` — B1 DB+server+tests.
+2. `feat(learn): collapse off-chain save CTA into informative state` — B2 UI/copy+tests.
+3. (opcional) `docs: Lote 2 spec + Lote 2.5 backlog + delivery audit`.
+
+## Riesgos
+
+- **Migración hosted**: la always-free `save_basic_score` se aplica en
+  deploy/CI (no dashboard). Verificar que el CREATE OR REPLACE no rompa el
+  contrato de `score_saves` (mode check sigue `in ('free','peones')`; solo
+  dejamos de escribir `'peones'` desde saves, filas históricas intactas).
+- **Auto-save timing (B2)**: el efecto debe correr exactamente una vez; guardas
+  ref + dedup server. Fallback manual cubre fallos.
+- **Peones acumulados**: usuarios que ya gastaron Peones en saves previos no se
+  reembolsan (fuera de alcance; nota QA).
+- **Lockstep TS↔SQL**: cambiar el modelo de cobro sin romper el guard que pinea
+  constantes; revisar `save-basic-score-schema.test.ts`.
+
+## QA manual esperado
+
+- LEARN: completar ejercicio con 0 Peones → score se guarda (off-chain) sin
+  prompt de compra; aparece `✓ Score saved`; dorado `Save proof` sigue como
+  único CTA accionable.
+- Repetir 4+ veces → nunca pide Peones.
+- Coach/hint/shield siguen cobrando.
+- PLAY: Save Victory intacto.


### PR DESCRIPTION
## MiniPay Delivery Lote 2 — Off-chain save gratis + colapsar CTA verde

Precede a Lote 2.5 (Tactical Day Gift + Proof of Consistency, documentado, no implementado).

### B1 — Save off-chain siempre gratis (server/DB)
- Nueva migración `20260708120000_savescore_always_free.sql`: `CREATE OR REPLACE save_basic_score` elimina la rama paid (sin `peones_spend`, sin `P0001`, sin `insufficient_peones`); todo save inserta `mode='free', peones_spent=0`. El sink `save_game` **nunca** se ejecuta para persistencia básica. Funciona con balance 0. Advisory lock + dedup preservados; filas históricas `'peones'` intactas.
- `save-service`: `computeScoreSaveQuota` → `requiresPeones=false`, `costPeones=0` siempre.
- `route`: quita la attestation `save_game` (pasa `p_attestation_hash: null`) y las ramas `insufficient_peones`/409.
- Coach / hint / shield: sinks separados, **sin cambios**, siguen cobrando.

### B2 — Auto-save + estado informativo (UI/copy)
- Auto-save silencioso al completar (idempotente, una vez por score, con fallback ante fallo).
- `mission-detail-sheet`: fuera el CTA verde `Save score`. Ahora: `✓ Score saved` informativo, `Retry save` gratis solo si el auto-save falló, `Saving…` mientras corre. El dorado on-chain `Save proof` queda como único CTA de valor.
- `result-overlay`: retirados los pills de `free saves left` + Peones gastados; el overlay de score muestra solo las estrellas.
- i18n: `scoreSaved` / `retrySaveCta` en editorial (EN) + es.ts (paridad).

### No tocado
Lógica on-chain · PLAY Save Victory / NFT · MAX_SHIELDS · COMBO Shield · Daily Streak · Tactical Day Gift / fuego del día (Lote 2.5).

### Verificación
- Full suite: **4688 tests / 390 files passing**. Typecheck limpio. Lint limpio.

### QA manual esperado
- LEARN con 0 Peones: completar ejercicio → score se guarda solo, sin prompt de compra; aparece `✓ Score saved`; dorado `Save proof` = único CTA accionable.
- Repetir 4+ veces → nunca pide Peones.
- Coach/hint/shield siguen cobrando. PLAY Save Victory intacto.

### Riesgo
- La migración always-free se aplica en **deploy/CI** (no dashboard). Verificar tras merge→deploy.

Wolfcito 🐾 @akawolfcito
