### PR TITLE
feat(minipay): Lote 3 — MAX_SHIELDS 30→3 + cap all shield sources

### DIFF
--- a/apps/web/src/lib/shop/__tests__/shield-storage.test.ts
+++ b/apps/web/src/lib/shop/__tests__/shield-storage.test.ts
@@ -47,13 +47,53 @@ describe("shield-storage", () => {
     });
 
     it("over-credit drains naturally as user consumes", () => {
-      writeCreditedCache(33);
+      writeCreditedCache(10);
       window.localStorage.setItem(SHIELDS_CONSUMED_KEY, "2");
-      // 33 - 2 = 31, capped to 30
+      // 10 - 2 = 8, capped to MAX_SHIELDS (3)
       expect(readDisplayedShields()).toBe(MAX_SHIELDS);
+      window.localStorage.setItem(SHIELDS_CONSUMED_KEY, "8");
+      // 10 - 8 = 2 (below cap → shows through)
+      expect(readDisplayedShields()).toBe(2);
+    });
+  });
+
+  // ─── Lote 3 B4: MAX_SHIELDS = 3 cap across all credit sources ─────
+  describe("MAX_SHIELDS = 3 cap (Lote 3 B4)", () => {
+    it("the cap constant is 3", () => {
+      expect(MAX_SHIELDS).toBe(3);
+    });
+
+    // Every credit source funnels through `credited`; these prove the
+    // displayed count never exceeds 3 regardless of how much is credited.
+    it("0 shields + a +3 source → 3 (not more)", () => {
+      writeCreditedCache(3); // 0 existing + 3
+      expect(readDisplayedShields()).toBe(3);
+    });
+
+    it("1 shield + a +3 source → 3 (gains at most 2 effective)", () => {
+      writeCreditedCache(4); // effective 1, source adds 3
+      expect(readDisplayedShields()).toBe(3);
+    });
+
+    it("2 shields + a +3 source → 3, NOT 5", () => {
+      writeCreditedCache(5); // effective 2, source adds 3
+      expect(readDisplayedShields()).toBe(3);
+    });
+
+    it("3 shields + a +3 source → stays 3 (no more above the cap)", () => {
+      writeCreditedCache(6); // effective 3, source adds 3
+      expect(readDisplayedShields()).toBe(3);
+    });
+
+    it("Season Pass (+3) stacking Welcome Pack (+3) → displayed 3, excess buffered", () => {
+      writeCreditedCache(6); // Welcome 3 + Season 3, none consumed
+      window.localStorage.setItem(SHIELDS_CONSUMED_KEY, "0");
+      expect(readDisplayedShields()).toBe(3);
+      // The buffer (credited 6) means display holds at 3 until consumed > 3.
+      window.localStorage.setItem(SHIELDS_CONSUMED_KEY, "3");
+      expect(readDisplayedShields()).toBe(3); // buffer still refills
       window.localStorage.setItem(SHIELDS_CONSUMED_KEY, "4");
-      // 33 - 4 = 29
-      expect(readDisplayedShields()).toBe(29);
+      expect(readDisplayedShields()).toBe(2); // drains below cap
     });
   });
 

--- a/apps/web/src/lib/shop/shield-storage.ts
+++ b/apps/web/src/lib/shop/shield-storage.ts
@@ -13,7 +13,15 @@ export const SHIELDS_LEGACY_KEY = "chesscito:shields";
 export const SHIELDS_CONSUMED_KEY = "chesscito:shields:consumed";
 export const SHIELDS_CREDITED_CACHE_KEY = "chesscito:shields:credited-cache";
 
-export const MAX_SHIELDS = 30;
+/** Max ACTIVE (displayed/usable) shields. MiniPay Lote 3 B4 (2026-07-08):
+ *  30 → 3. The displayed count is `min(MAX_SHIELDS, credited - consumed)`, so
+ *  every source (Welcome Pack, Season Pass bonus, rescue) is capped here — no
+ *  source can leave the user showing more than 3. NOTE: `credited` is a
+ *  monotonic server counter and `consumed` is client-local, so two sources
+ *  can push `credited - consumed` above 3; the excess is buffered (drains as
+ *  the user consumes) rather than a hard reject. See risk note in the Lote 3
+ *  deliverable. */
+export const MAX_SHIELDS = 3;
 
 export type LegacyMigrationPayload = {
   legacy: number;


### PR DESCRIPTION
## MiniPay Delivery Lote 3 — B4 MAX_SHIELDS 30→3

### Cambio
`lib/shop/shield-storage.ts`: `MAX_SHIELDS` 30 → 3.

### Auditoría de fuentes de Shields (todas capadas)
El count mostrado = `min(MAX_SHIELDS, credited − consumed)` vía `readDisplayedShields()`, y **todas** las fuentes acreditan el mismo contador `credited`:
- **Welcome Pack / first gift** → `/api/welcome-pack/claim` → Redis `shieldsCredited` → cap 3.
- **Season Pass bonus** (`shieldsOnPurchase: 3`) → `/api/verify-payment` incby `shieldsCredited` → cap 3.
- **Rescue Gift-3-free** (variant C) → welcome-pack claim → `writeCreditedCache` → cap 3.
- **credited-shields cache** → el clamp vive en la lectura → cap 3.

Un solo cap cubre todas. Ninguna fuente deja al usuario mostrando >3.

### Comportamiento confirmado (tests)
- 0 + fuente +3 → 3
- 1 + fuente +3 → 3 (gana máx 2 efectivos)
- 2 + fuente +3 → 3, **NO 5**
- 3 + fuente +3 → 3 (nada por encima del cap)

### Verificación
- Suite: **4694 tests / 390 files passing** (+6 nuevos). Typecheck + lint limpios.

### QA manual esperado
- Con 0 shields, reclamar Welcome Pack → muestra 3 (no más).
- Con Season Pass activo + Welcome Pack → muestra 3, no 6.
- Consumir un shield en retry → baja de 3.
- COMBO Shield sigue protegiendo el Exercise COMBO (no Daily Streak).

### ⚠️ Riesgo detectado — Season Pass bonus stacking (buffer)
`credited` es un contador **monotónico server-side**; `consumed` es **client-local**. El server no conoce `consumed`, así que NO puede rechazar un crédito en origen. Si dos fuentes acreditan (Welcome +3 **y** Season Pass +3), `credited = 6`: el display se capa a 3, pero el excedente queda **buffered** y se rellena a medida que el usuario consume (hay que consumir >3 antes de bajar de 3). Es decir, el cap es de **display/uso simultáneo**, no un tope duro de créditos de por vida.

- Para el contexto founder-only/prelaunch es aceptable (el display nunca supera 3).
- Si se requiere un **tope duro** (Season Pass +3 sea no-op cuando ya hay 3), es un follow-up con cambio de modelo de contador (mover el cap al crédito, lo que requiere que el server conozca `consumed` o rediseñar credited→"available"). NO incluido aquí para no reabrir arquitectura.
- Pregunta abierta para el founder: ¿el bonus del Season Pass estaba diseñado para stackear por encima de 3? Si sí, el buffer actual lo respeta; si no, se necesita el follow-up de tope duro.

Wolfcito 🐾 @akawolfcito
