### PR TITLE
fix(learn): decouple on-chain Save proof CTA from off-chain auto-save gate

### DIFF
--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -67,6 +67,7 @@ import { useSaveScoreState } from "@/hooks/use-save-score-state";
 import { ConnectPromptToast } from "@/components/connect-prompt/connect-prompt-toast";
 import { useConnectPrompt } from "@/lib/connect-prompt/use-connect-prompt";
 import { TxProgressSteps } from "@/components/redesign/tx-progress-steps";
+import { canSaveOnChain as deriveCanSaveOnChain } from "@/lib/exercises/save-proof-state";
 import { deriveTxToastState } from "@/lib/exercises/tx-toast-state";
 import { useMiniPay } from "@/hooks/use-minipay";
 import { useSplashLoader } from "@/hooks/use-splash-loader";
@@ -1052,6 +1053,18 @@ export function ExercisesScreen({
     canSaveScore && totalStars >= 1 && localScoreNum > lastSavedScore;
   const isSavedAtParity =
     lastSavedScore > 0 && localScoreNum === lastSavedScore;
+  // The on-chain proof CTA must NOT share `scorePendingNew` with the B2
+  // auto-save, which closes that gate the moment its POST resolves. It is
+  // gated on the absence of a real receipt instead — see
+  // `lib/exercises/save-proof-state`.
+  const canSaveOnChain = deriveCanSaveOnChain({
+    canSaveScore,
+    hasScoreboard: scoreboardAddress != null,
+    totalStars,
+    localScore: localScoreNum,
+    lastSavedScore,
+    lastSavedTxHash,
+  });
 
   // Tx phase tracking for the TxProgressSteps toast. The toast remains
   // mounted while the tx is in flight AND for `SAVE_DONE_HOLD_MS` after
@@ -2305,7 +2318,7 @@ export function ExercisesScreen({
           scoreSaved={isSavedAtParity}
           saveFailed={autoSaveFailed}
           onRetrySave={() => void handleSubmitScore()}
-          canSaveOnChain={scorePendingNew && scoreboardAddress != null}
+          canSaveOnChain={canSaveOnChain}
           onSaveOnChain={() => void handleSaveScoreOnChain()}
           isSavingOnChain={isScoreWriting || isSubmitConfirming}
           shieldCount={shieldCount}

--- a/apps/web/src/lib/exercises/__tests__/save-proof-state.test.ts
+++ b/apps/web/src/lib/exercises/__tests__/save-proof-state.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  canSaveOnChain,
+  hasOnchainProof,
+  type SaveProofInputs,
+} from "../save-proof-state";
+
+/** Wallet connected, on Celo, scoreboard configured, one star earned,
+ *  score 120 pending — the shape right after a new personal best. */
+const PENDING: SaveProofInputs = {
+  canSaveScore: true,
+  hasScoreboard: true,
+  totalStars: 1,
+  localScore: 120,
+  lastSavedScore: 0,
+  lastSavedTxHash: null,
+};
+
+/** After the B2 silent auto-save resolves: score is persisted off-chain
+ *  (recordSaveFor writes an EMPTY txHash) so parity is reached but no
+ *  on-chain proof exists. This is the P1 regression case. */
+const SAVED_OFFCHAIN: SaveProofInputs = {
+  ...PENDING,
+  lastSavedScore: 120,
+  lastSavedTxHash: "",
+};
+
+/** After `submitScoreSigned` confirms: parity + a real receipt hash. */
+const PROVEN_ONCHAIN: SaveProofInputs = {
+  ...PENDING,
+  lastSavedScore: 120,
+  lastSavedTxHash: "0xabc123",
+};
+
+describe("hasOnchainProof", () => {
+  it("is false before any save", () => {
+    expect(hasOnchainProof(PENDING)).toBe(false);
+  });
+
+  it("is false after an off-chain save (empty txHash is not a receipt)", () => {
+    expect(hasOnchainProof(SAVED_OFFCHAIN)).toBe(false);
+  });
+
+  it("is true once a real tx hash covers the current score", () => {
+    expect(hasOnchainProof(PROVEN_ONCHAIN)).toBe(true);
+  });
+
+  it("is false when the proven score is stale (player improved since)", () => {
+    expect(
+      hasOnchainProof({ ...PROVEN_ONCHAIN, localScore: 150 }),
+    ).toBe(false);
+  });
+
+  it("is true when the proven score exceeds the current one", () => {
+    // Defensive: a lower local score must not re-arm the CTA. Can happen
+    // if progress is reset locally while the save state survives.
+    expect(
+      hasOnchainProof({ ...PROVEN_ONCHAIN, localScore: 90 }),
+    ).toBe(true);
+  });
+});
+
+describe("canSaveOnChain", () => {
+  it("shows the proof CTA for a brand-new pending score", () => {
+    expect(canSaveOnChain(PENDING)).toBe(true);
+  });
+
+  it("KEEPS showing the proof CTA after the off-chain auto-save lands", () => {
+    // P1 regression guard: B2's auto-save reaches parity and used to
+    // close `scorePendingNew`, which silently hid the golden CTA.
+    expect(canSaveOnChain(SAVED_OFFCHAIN)).toBe(true);
+  });
+
+  it("hides the proof CTA once the score is proven on-chain", () => {
+    expect(canSaveOnChain(PROVEN_ONCHAIN)).toBe(false);
+  });
+
+  it("re-arms the proof CTA when the player beats a proven score", () => {
+    expect(canSaveOnChain({ ...PROVEN_ONCHAIN, localScore: 150 })).toBe(true);
+  });
+
+  it("hides the CTA when no scoreboard is deployed (fail-closed, no dead CTA)", () => {
+    expect(canSaveOnChain({ ...PENDING, hasScoreboard: false })).toBe(false);
+  });
+
+  it("hides the CTA when the wallet preconditions are unmet", () => {
+    // canSaveScore folds address + isConnected + isCorrectChain + levelId.
+    expect(canSaveOnChain({ ...PENDING, canSaveScore: false })).toBe(false);
+    expect(canSaveOnChain({ ...SAVED_OFFCHAIN, canSaveScore: false })).toBe(false);
+  });
+
+  it("hides the CTA before the first star is earned", () => {
+    expect(canSaveOnChain({ ...PENDING, totalStars: 0 })).toBe(false);
+  });
+
+  it("hides the CTA when there is no score to prove", () => {
+    expect(
+      canSaveOnChain({ ...PENDING, totalStars: 1, localScore: 0 }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/exercises/save-proof-state.ts
+++ b/apps/web/src/lib/exercises/save-proof-state.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure derivation of the LEARN "Save proof" (on-chain Leaderboard Proof)
+ * CTA visibility.
+ *
+ * Extracted from `exercises-screen.tsx` because the inline gate
+ * (`scorePendingNew && scoreboardAddress != null`) shared its pending
+ * flag with MiniPay Lote 2 B2's silent off-chain auto-save: the auto-save
+ * reached score parity and closed `scorePendingNew`, hiding the golden
+ * CTA within the latency of one POST. The on-chain proof is a separate
+ * value action and must not be gated on off-chain persistence state.
+ *
+ * The discriminator is `lastSavedTxHash`: the off-chain save persists an
+ * EMPTY hash (there is no receipt), while `submitScoreSigned` persists
+ * the real one. Empty hash ⇒ saved, but not proven.
+ *
+ * Known caveat (accepted 2026-07-08): save state is per-device
+ * localStorage, so a fresh device re-arms the CTA even when the score is
+ * already on the Scoreboard. Re-proving costs gas but is otherwise
+ * harmless; cross-device reconciliation (`leaderboard_full_v.has_onchain`)
+ * is out of scope here.
+ */
+
+export type SaveProofInputs = {
+  /** Wallet preconditions, folded upstream: address + isConnected +
+   *  isCorrectChain + levelId > 0. */
+  canSaveScore: boolean;
+  /** A Scoreboard address resolves for the active chain. Fail-closed:
+   *  without it the CTA would broadcast nowhere. */
+  hasScoreboard: boolean;
+  /** Stars earned for the active piece. */
+  totalStars: number;
+  /** Current local score for the active piece. */
+  localScore: number;
+  /** Last score persisted for this piece (off-chain OR on-chain). */
+  lastSavedScore: number;
+  /** Receipt hash of the last persisted save. Empty string for off-chain
+   *  saves, null when this device has never saved. */
+  lastSavedTxHash: string | null;
+};
+
+/** True when the current score is already covered by a confirmed on-chain
+ *  receipt. A stale proof (player has since improved) does not count. */
+export function hasOnchainProof(inputs: SaveProofInputs): boolean {
+  const hasReceipt =
+    inputs.lastSavedTxHash !== null && inputs.lastSavedTxHash !== "";
+  return hasReceipt && inputs.lastSavedScore >= inputs.localScore;
+}
+
+/** True when the golden "Save proof" CTA should be offered. */
+export function canSaveOnChain(inputs: SaveProofInputs): boolean {
+  if (!inputs.canSaveScore || !inputs.hasScoreboard) return false;
+  if (inputs.totalStars < 1 || inputs.localScore <= 0) return false;
+  return !hasOnchainProof(inputs);
+}


### PR DESCRIPTION
## P1 — el CTA dorado "Save proof" era casi inalcanzable

El CTA on-chain (Leaderboard Proof) de LEARN estaba gateado por `scorePendingNew`, el mismo flag que consume el auto-save off-chain silencioso de MiniPay Lote 2 (B2). Apenas resolvía el POST del auto-save, `recordSaveFor` alcanzaba paridad de score, `scorePendingNew` pasaba a `false` y el CTA desaparecía.

Resultado: solo visible dentro de la ventana de latencia del POST, y solo si el mission sheet ya estaba abierto. En el happy path, inalcanzable — justo lo contrario del objetivo de Lote 2 ("la prueba on-chain es el único CTA de valor accionable").

## Fix

Gatear por la **ausencia de un receipt real** en vez de por el estado del save off-chain. `useSaveScoreState` ya distingue los dos caminos:

- save off-chain → persiste `lastSavedTxHash` **vacío** (no hay receipt)
- `submitScoreSigned` → persiste el hash real

Sin flag nuevo, sin round-trip al server. Lógica extraída a `lib/exercises/save-proof-state.ts` como función pura (mismo precedente que `tx-toast-state.ts`).

```
hasOnchainProof = txHash no vacío && lastSavedScore >= localScore
canSaveOnChain  = canSaveScore && hasScoreboard && totalStars >= 1
                  && localScore > 0 && !hasOnchainProof
```

## Caveat conocido (aceptado)

El save state es localStorage por device, así que un device nuevo re-arma el CTA aunque el score ya esté en el Scoreboard. Volver a probar cuesta gas y es inofensivo. La reconciliación cross-device vía `leaderboard_full_v.has_onchain` queda fuera de scope.

## Lote 2 intacto

No se tocan el auto-save, `contextActionState.scorePending` ni el prop `canSaveScore` del sheet. `handleSaveScoreOnChain` ya se gateaba con `canSaveScore` (no con `scorePendingNew`), así que funciona en paridad sin cambios.

## Verificación

- 4707 tests passing (391 files), incluidos 13 nuevos en `save-proof-state.test.ts` (TDD, rojo→verde)
- `tsc --noEmit` limpio
- VR: 51 passed, 1 failed (`hub-shop-sheet-open`) — **preexistente en `main`**, confirmado corriendo el test con el cambio stasheado. Baseline stale desde varios commits atrás (espera Coach Credits, PRO $1.99, Streak Shield $0.03; la app hoy muestra PRO "Coming soon"). No refrescado acá: es una decisión aparte.

Wolfcito 🐾 @akawolfcito
