### PR TITLE
feat(landing): slides 1/2/3 each carry one idea, and the carousel ends on START

### DIFF
--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -404,29 +404,15 @@
     drop-shadow(0 3px 4px rgba(0, 0, 0, 0.32)) drop-shadow(0 1px 0 rgba(110, 65, 15, 0.45));
 }
 
-/* Local-only modifier (no apps/web equivalent) — gold PRO pill on slide 3,
-   same chip shape/shadow as .hub-hud-pill, cream gradient swapped for gold. */
-.onboarding-pill--gold {
-  background:
-    radial-gradient(circle at 30% 20%, rgba(255, 239, 100, 0.9), transparent 28%),
-    linear-gradient(145deg, #fbe04b 0%, #fcc00a 28%, #f3aa04 55%, #d38804 100%);
-  border: none;
-  border-radius: 22px;
-  box-shadow:
-    inset 0 3px 0 rgba(255, 255, 255, 0.45),
-    inset 0 -5px 0 rgba(142, 78, 0, 0.35);
-    /* 0 6px 0 #9a5a00,
-    0 0 0 2px rgba(255, 216, 74, 0.7),
-    0 6px 0 2px rgba(255, 216, 74, 0.7),
-    0 0 6px 2px rgba(255, 200, 40, 0.75),
-    0 8px 6px 2px rgba(255, 200, 40, 0.6),
-    0 12px 20px rgba(0, 0, 0, 0.35); */
-  text-shadow:
-    -1px -1px 0 #6b3a06,
-    1px -1px 0 #6b3a06,
-    -1px 1px 0 #6b3a06,
-    1px 1px 0 #6b3a06,
-    0 2px 2px rgba(0, 0, 0, 0.5);
-  filter: none;
-  color: #ffffff;
+/* The price of the thing the slide just described. A line, not a chip: a pill
+   is an object you own, and putting a price in the same tray as Focus Passport
+   tells the eye they are the same kind of thing. Slide 3's gold PRO pill lived
+   here until 2026-07-08, when its label ("PRO $1.99 includes Season Pass") was
+   promoted to the slide's headline, where an argument that load-bearing
+   belongs. Recover it from git if a gold treatment is ever wanted again. */
+.onboarding-price {
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  color: #5a4520;
 }

--- a/apps/landing/src/components/onboarding/__tests__/onboarding-carousel.test.tsx
+++ b/apps/landing/src/components/onboarding/__tests__/onboarding-carousel.test.tsx
@@ -20,16 +20,40 @@ describe("OnboardingCarousel", () => {
   it("slide 1 names both modes and sells neither", () => {
     renderWithIntl(<OnboardingCarousel />);
     expect(screen.getByText("Learn")).toBeInTheDocument();
-    expect(screen.getByText("Start from zero")).toBeInTheDocument();
+    expect(screen.getByText("From zero")).toBeInTheDocument();
     expect(screen.getByText("Play")).toBeInTheDocument();
     expect(screen.getByText("Full matches")).toBeInTheDocument();
     expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
   });
 
+  /**
+   * NEXT, NEXT, NEXT, START. The advance button never claims to start
+   * anything, so START means one thing everywhere: you are going in. That is
+   * also the word `welcome-back.tsx` puts in the same spot for a returning
+   * player, who never sees this carousel again.
+   */
+  it("labels the three advance buttons NEXT and only the final CTA START", () => {
+    renderWithIntl(<OnboardingCarousel />);
+
+    expect(screen.getByRole("button", { name: "NEXT" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "START" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
+
+    expect(screen.getByText("4 / 4")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "NEXT" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "START" })).toHaveAttribute(
+      "href",
+      "/api/enter?mode=learn",
+    );
+  });
+
   it("advances slide 1 -> 2 -> 3 -> 4 via the CTA button", () => {
     renderWithIntl(<OnboardingCarousel />);
 
-    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     expect(screen.getByText("2 / 4")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /decide better in 21 days/i })).toBeInTheDocument();
 
@@ -52,7 +76,7 @@ describe("OnboardingCarousel", () => {
    */
   it("slide 2 states the Season Pass price once and never mentions PRO", () => {
     renderWithIntl(<OnboardingCarousel />);
-    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
 
     expect(screen.getByText("Season Pass, $0.99")).toBeInTheDocument();
     expect(screen.queryByText(/PRO/)).not.toBeInTheDocument();
@@ -66,7 +90,7 @@ describe("OnboardingCarousel", () => {
    */
   it("slide 3 leads with the PRO argument and never says free", () => {
     renderWithIntl(<OnboardingCarousel />);
-    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
 
     expect(screen.getByText("Coach PRO, $1.99")).toBeInTheDocument();
@@ -75,11 +99,11 @@ describe("OnboardingCarousel", () => {
 
   it("slide 4 offers Learn as the only CTA, with Play reachable via a text link", () => {
     renderWithIntl(<OnboardingCarousel />);
-    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
 
-    expect(screen.getByRole("link", { name: /learn pieces/i })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "START" })).toHaveAttribute(
       "href",
       "/api/enter?mode=learn",
     );
@@ -104,7 +128,7 @@ describe("OnboardingCarousel", () => {
     const back = screen.getByRole("button", { name: /previous slide/i });
     expect(back).toBeDisabled();
 
-    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     expect(screen.getByText("2 / 4")).toBeInTheDocument();
     expect(back).not.toBeDisabled();
 
@@ -120,7 +144,7 @@ describe("OnboardingCarousel", () => {
 
   it("forward arrow is disabled on slide 4 (no slide 5); back arrow returns to slide 3", () => {
     renderWithIntl(<OnboardingCarousel />);
-    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     expect(screen.getByRole("heading", { name: /learn the pieces first/i })).toBeInTheDocument();

--- a/apps/landing/src/components/onboarding/__tests__/onboarding-carousel.test.tsx
+++ b/apps/landing/src/components/onboarding/__tests__/onboarding-carousel.test.tsx
@@ -6,8 +6,24 @@ describe("OnboardingCarousel", () => {
   it("renders slide 1 with a 1/4 progress counter and no Skip control", () => {
     renderWithIntl(<OnboardingCarousel />);
     expect(screen.getByText("1 / 4")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /daily focus ritual/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /two ways into chess/i })).toBeInTheDocument();
     expect(screen.queryByText(/skip/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * Slide 1's only job is orientation: this is chess, and there are two modes.
+   * It used to lead with "Turn chess into your daily focus ritual", which is
+   * slide 2's pitch, and spent its one moment of attention on a message the
+   * next screen makes better. The mode pills carry the whole payload, so they
+   * name the two paths rather than reading as loose feature chips.
+   */
+  it("slide 1 names both modes and sells neither", () => {
+    renderWithIntl(<OnboardingCarousel />);
+    expect(screen.getByText("Learn")).toBeInTheDocument();
+    expect(screen.getByText("Start from zero")).toBeInTheDocument();
+    expect(screen.getByText("Play")).toBeInTheDocument();
+    expect(screen.getByText("Full matches")).toBeInTheDocument();
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
   });
 
   it("advances slide 1 -> 2 -> 3 -> 4 via the CTA button", () => {
@@ -15,15 +31,46 @@ describe("OnboardingCarousel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "START" }));
     expect(screen.getByText("2 / 4")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /daily chess habit/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /decide better in 21 days/i })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     expect(screen.getByText("3 / 4")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /upgrade for coach pro/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /coach pro includes the season pass/i }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     expect(screen.getByText("4 / 4")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /learn the pieces first/i })).toBeInTheDocument();
+  });
+
+  /**
+   * Slides 2 and 3 are the only place the paid layer is ever explained: the
+   * cookie sends returning visitors straight past the carousel. Each screen
+   * states its price once, as a line of text. A price rendered as a pill reads
+   * as an item you own, sitting in the same tray as the thing it buys.
+   */
+  it("slide 2 states the Season Pass price once and never mentions PRO", () => {
+    renderWithIntl(<OnboardingCarousel />);
+    fireEvent.click(screen.getByRole("button", { name: "START" }));
+
+    expect(screen.getByText("Season Pass, $0.99")).toBeInTheDocument();
+    expect(screen.queryByText(/PRO/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/reward/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * "Play free" on slide 3 reinstated the very price inversion slide 4 was
+   * rebuilt to remove: the visitor read "free" here, then one screen later we
+   * recommend Learn, which runs through a $0.99 Season Pass.
+   */
+  it("slide 3 leads with the PRO argument and never says free", () => {
+    renderWithIntl(<OnboardingCarousel />);
+    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
+
+    expect(screen.getByText("Coach PRO, $1.99")).toBeInTheDocument();
+    expect(screen.queryByText(/free/i)).not.toBeInTheDocument();
   });
 
   it("slide 4 offers Learn as the only CTA, with Play reachable via a text link", () => {
@@ -80,7 +127,9 @@ describe("OnboardingCarousel", () => {
     expect(screen.getByRole("button", { name: /next slide/i })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: /previous slide/i }));
-    expect(screen.getByRole("heading", { name: /upgrade for coach pro/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /coach pro includes the season pass/i }),
+    ).toBeInTheDocument();
   });
 
   it("swipes left to advance and right to go back", () => {

--- a/apps/landing/src/components/onboarding/__tests__/pill.test.tsx
+++ b/apps/landing/src/components/onboarding/__tests__/pill.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Pill } from "@/components/onboarding/pill";
+
+describe("Pill", () => {
+  /**
+   * The label names the thing; the sublabel qualifies it. Until 2026-07-08 the
+   * scale said the opposite (label 0.6rem, sublabel 0.7rem) and the dimming
+   * landed on the larger of the two, so "21 focus days" outweighed "Focus
+   * Passport". Slide 1 gained sublabels in the same change, which would have
+   * tripled the defect.
+   */
+  it("renders the label larger than the sublabel, and dims only the sublabel", () => {
+    render(<Pill icon={null} label="Focus Passport" sublabel="21 focus days" />);
+
+    const label = screen.getByText("Focus Passport");
+    const sublabel = screen.getByText("21 focus days");
+
+    expect(label).toHaveClass("text-[0.7rem]");
+    expect(sublabel).toHaveClass("text-[0.6rem]");
+    expect(label.className).not.toContain("opacity-");
+    expect(sublabel).toHaveClass("opacity-80");
+  });
+
+  it("omits the sublabel node entirely when no sublabel is given", () => {
+    const { container } = render(<Pill icon={null} label="Saved games" />);
+    expect(container.querySelectorAll("span.text-\\[0\\.6rem\\]")).toHaveLength(0);
+  });
+});

--- a/apps/landing/src/components/onboarding/__tests__/welcome-back.test.tsx
+++ b/apps/landing/src/components/onboarding/__tests__/welcome-back.test.tsx
@@ -24,4 +24,18 @@ describe("WelcomeBack", () => {
       "/api/enter?mode=learn",
     );
   });
+
+  /**
+   * This screen used to render `slide1.headline`, so one string had to greet a
+   * returning player and orient a stranger at the same time. Now it owns its
+   * copy, and slide 1 can be rewritten without silently rewriting this.
+   */
+  it("greets a returning player with its own headline, not slide 1's", async () => {
+    render(await WelcomeBack({ preferredMode: "play" }));
+
+    expect(
+      screen.getByRole("heading", { name: /your board is waiting/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/two ways into chess/i)).not.toBeInTheDocument();
+  });
 });

--- a/apps/landing/src/components/onboarding/onboarding-carousel.tsx
+++ b/apps/landing/src/components/onboarding/onboarding-carousel.tsx
@@ -57,9 +57,7 @@ export function OnboardingCarousel() {
             href="/api/enter?mode=learn"
             className="primary-play-cta primary-play-cta--playhub hub-scaffold-practice-cta"
           >
-            <span className="primary-play-cta-label">
-              {slide4("startLearning")}
-            </span>
+            <span className="primary-play-cta-label">{slide4("cta")}</span>
           </a>
         )
       }

--- a/apps/landing/src/components/onboarding/pill.tsx
+++ b/apps/landing/src/components/onboarding/pill.tsx
@@ -28,7 +28,11 @@ export function Pill({
       >
         {icon}
       </span>
-      <span className="flex flex-col items-start leading-tight">
+      {/* `text-left` is load-bearing: SlideShell centers its whole content box,
+          and `items-start` only aligns the two spans as boxes, not the text
+          inside them. A sublabel that wraps would center its second line under
+          a left-aligned label. */}
+      <span className="flex flex-col items-start text-left leading-tight">
         {/* The label names the thing, the sublabel qualifies it, and the scale
             has to agree. It used to say the opposite (label 0.6, sublabel 0.7)
             with the dimming on the larger of the two, so "21 focus days"

--- a/apps/landing/src/components/onboarding/pill.tsx
+++ b/apps/landing/src/components/onboarding/pill.tsx
@@ -4,27 +4,24 @@ import type { ReactNode } from "react";
  * `.candy-tray-pill` + `.hub-hud-pill` are ported verbatim from apps/web
  * globals.css — the same HUD chip family used across the Hub — so these
  * pills match the in-app look exactly.
+ *
+ * A pill is a thing you own. Prices are not pills: they render as a line of
+ * text next to the tray, never inside it.
  */
 export function Pill({
   icon,
   label,
   sublabel,
-  tone = "cream",
   iconRem = 1.8,
 }: {
   icon: ReactNode;
   label: string;
   sublabel?: string;
-  tone?: "cream" | "gold";
   /** Overrides `.candy-tray-pill-icon--floating`'s default 1.8rem icon size. */
   iconRem?: number;
 }) {
   return (
-    <div
-      className={`candy-tray-pill hub-hud-pill w-full ${
-        tone === "gold" ? "onboarding-pill--gold" : ""
-      }`}
-    >
+    <div className="candy-tray-pill hub-hud-pill w-full">
       <span
         className="candy-tray-pill-icon--floating"
         style={{ width: `${iconRem}rem`, height: `${iconRem}rem` }}
@@ -32,8 +29,12 @@ export function Pill({
         {icon}
       </span>
       <span className="flex flex-col items-start leading-tight">
-        <span className="text-[0.6rem]">{label}</span>
-        {sublabel ? <span className="text-[0.7rem] opacity-80">{sublabel}</span> : null}
+        {/* The label names the thing, the sublabel qualifies it, and the scale
+            has to agree. It used to say the opposite (label 0.6, sublabel 0.7)
+            with the dimming on the larger of the two, so "21 focus days"
+            outweighed "Focus Passport". */}
+        <span className="text-[0.7rem]">{label}</span>
+        {sublabel ? <span className="text-[0.6rem] opacity-80">{sublabel}</span> : null}
       </span>
     </div>
   );

--- a/apps/landing/src/components/onboarding/slide-bodies.tsx
+++ b/apps/landing/src/components/onboarding/slide-bodies.tsx
@@ -39,6 +39,11 @@ function Heading({
   )
 }
 
+/**
+ * Shared skeleton across slides 1-3: art, then what it is, then why it matters,
+ * then the divider, then evidence, then the price. Slide 1 has no price and no
+ * evidence beyond its two mode pills.
+ */
 export function Slide1Body() {
   const t = useTranslations('onboarding.slide1')
   const assets = SLIDE_ASSETS[0]
@@ -65,15 +70,20 @@ export function Slide1Body() {
       <div className="-mt-1 flex flex-col items-center gap-2">
         <Heading headline={t('headline')} support={t('support')} />
       </div>
+      {/* The two pills carry this slide's entire payload: there are two modes,
+          and they are different doors. Bare labels read as feature chips, so
+          each one names the player it is for. */}
       <div className="flex w-full justify-center gap-3">
         <Pill
           icon={<ArtImage src={ICONS.learn} alt="" />}
           label={t('learnPill')}
+          sublabel={t('learnPillSub')}
           iconRem={2.3}
         />
         <Pill
           icon={<ArtImage src={ICONS.play} alt="" />}
           label={t('playPill')}
+          sublabel={t('playPillSub')}
           iconRem={2.3}
         />
       </div>
@@ -97,19 +107,15 @@ export function Slide2Body() {
         support={t('support')}
         headlineClassName="fantasy-title"
       />
-      <div className="h-2 flex gap-2.5">
-        <Pill
-          icon={<ArtImage src={ICONS.focusPassport} alt="" />}
-          label={t('passportLabel')}
-          sublabel={t('passportSub')}
-        />
-        <Pill
-          icon={<ArtImage src={ICONS.seasonPass} alt="" />}
-          label={t('seasonPassLabel')}
-          sublabel={t('seasonPassPrice')}
-        />
-      </div>
-      <p className="text-xs text-[#5a4520] mt-6">{t('footnote')}</p>
+      {/* Focus Passport is what the Season Pass opens, so it stands alone as
+          the evidence. The Season Pass itself is not a sibling chip: it is the
+          product, and it appears below as its price. */}
+      <Pill
+        icon={<ArtImage src={ICONS.focusPassport} alt="" />}
+        label={t('passportLabel')}
+        sublabel={t('passportSub')}
+      />
+      <p className="onboarding-price">{t('price')}</p>
     </>
   )
 }
@@ -137,14 +143,10 @@ export function Slide3Body() {
         />
         <Pill
           icon={<ArtImage src={ICONS.coachPro} alt="" />}
-          label={t('coachProPill')}
+          label={t('coachReviewPill')}
         />
       </div>
-      <Pill
-        icon={<ArtImage src={ICONS.pro} alt="" className="w-8" />}
-        label={t('proPill')}
-        tone="gold"
-      />
+      <p className="onboarding-price">{t('price')}</p>
     </>
   )
 }

--- a/apps/landing/src/components/onboarding/slide-bodies.tsx
+++ b/apps/landing/src/components/onboarding/slide-bodies.tsx
@@ -78,13 +78,13 @@ export function Slide1Body() {
           icon={<ArtImage src={ICONS.learn} alt="" />}
           label={t('learnPill')}
           sublabel={t('learnPillSub')}
-          iconRem={2.3}
+          iconRem={1.9}
         />
         <Pill
           icon={<ArtImage src={ICONS.play} alt="" />}
           label={t('playPill')}
           sublabel={t('playPillSub')}
-          iconRem={2.3}
+          iconRem={1.9}
         />
       </div>
     </>

--- a/apps/landing/src/components/onboarding/welcome-back.tsx
+++ b/apps/landing/src/components/onboarding/welcome-back.tsx
@@ -38,7 +38,9 @@ export async function WelcomeBack({ preferredMode }: { preferredMode: PreferredM
         />
       }
     >
-      <AvatarWithFade src={assets.avatarSrc} alt="" className="relative top-9 w-48" />
+      {/* Larger than slide 1's `w-48`: this screen carries no pills, no support
+          line and no divider, so the wolf gets the room they were using. */}
+      <AvatarWithFade src={assets.avatarSrc} alt="" className="relative top-9 w-56" />
       <div className="-mt-4 flex flex-col items-center z-10">
         <span className="fantasy-title text-xl font-extrabold text-[#3a2600]">
           {t("slide1.welcomeTo")}
@@ -51,7 +53,7 @@ export async function WelcomeBack({ preferredMode }: { preferredMode: PreferredM
       {/* Its own key. Borrowing `slide1.headline` made one string greet a
           returning player and orient a stranger at the same time, and pinned
           slide 1's copy to this screen. */}
-      <h1 className="fantasy-title mt-1 text-lg font-extrabold text-[#3a2600]">
+      <h1 className="fantasy-title mt-1 text-2xl font-extrabold text-[#3a2600]">
         {t("welcomeBack.headline")}
       </h1>
     </SlideShell>

--- a/apps/landing/src/components/onboarding/welcome-back.tsx
+++ b/apps/landing/src/components/onboarding/welcome-back.tsx
@@ -38,14 +38,22 @@ export async function WelcomeBack({ preferredMode }: { preferredMode: PreferredM
         />
       }
     >
-      <AvatarWithFade src={assets.avatarSrc} alt="" className="relative top-3 w-48" />
-      <div className="-mt-3 flex flex-col items-center gap-0.5">
-        <span className="text-sm font-extrabold text-[#3a2600]">
+      <AvatarWithFade src={assets.avatarSrc} alt="" className="relative top-9 w-48" />
+      <div className="-mt-4 flex flex-col items-center z-10">
+        <span className="fantasy-title text-xl font-extrabold text-[#3a2600]">
           {t("slide1.welcomeTo")}
         </span>
-        <ArtImage src={assets.titleSrc} alt="Chesscito" className="h-14 w-6/12" />
+        {/* `w-auto`, not `w-6/12`: ArtImage is object-contain, so a width cap
+            narrower than the wordmark binds before the height does and the art
+            never reaches its `h-12`. It rendered small, not stretched. */}
+        <ArtImage src={assets.titleSrc} alt="Chesscito" className="h-12 w-auto -mt-3" />
       </div>
-      <h1 className="-mt-2 text-2xl font-extrabold text-[#3a2600]">{t("slide1.headline")}</h1>
+      {/* Its own key. Borrowing `slide1.headline` made one string greet a
+          returning player and orient a stranger at the same time, and pinned
+          slide 1's copy to this screen. */}
+      <h1 className="fantasy-title mt-1 text-lg font-extrabold text-[#3a2600]">
+        {t("welcomeBack.headline")}
+      </h1>
     </SlideShell>
   );
 }

--- a/apps/landing/src/lib/content/messages/en.ts
+++ b/apps/landing/src/lib/content/messages/en.ts
@@ -14,10 +14,13 @@ const messages = {
       headline: "Two ways into chess.",
       support: "Learn the pieces, or jump straight into a match.",
       learnPill: "Learn",
-      learnPillSub: "Start from zero",
+      // Short enough to hold one line beside a 1.9rem icon at 390px. Two
+      // side-by-side pills leave each sublabel very little room, and a wrapped
+      // sublabel is the first thing the eye catches as wrong.
+      learnPillSub: "From zero",
       playPill: "Play",
       playPillSub: "Full matches",
-      cta: "START",
+      cta: "NEXT",
     },
     slide2: {
       // The surviving idea is decision making. Habit, focus, wellbeing and
@@ -43,7 +46,10 @@ const messages = {
       headline: "Learn the pieces first",
       support: "Play chess when you're ready.",
       learnDescription: "Build your daily chess habit.",
-      startLearning: "Learn Pieces",
+      // NEXT, NEXT, NEXT, START. The advance button never claims to start
+      // anything, so START keeps one meaning across the carousel and matches
+      // the word `welcome-back.tsx` puts in the same spot.
+      cta: "START",
       jumpToPlay: "Already know chess? Jump to Play",
     },
     welcomeBack: {

--- a/apps/landing/src/lib/content/messages/en.ts
+++ b/apps/landing/src/lib/content/messages/en.ts
@@ -1,30 +1,42 @@
+/**
+ * Slides 2 and 3 are the only place the paid layer is ever explained. The
+ * onboarding cookie sends returning visitors straight to their stored mode via
+ * `welcome-back.tsx`, so nobody sees this carousel twice. Neither slide has a
+ * buy button, which means neither one converts: they plant a single idea the
+ * visitor has to recognize weeks later, when the paywall shows up in-game.
+ * One idea per screen. A screen carrying four benefits leaves none behind.
+ */
 const messages = {
   onboarding: {
     progress: "{current} / {total}",
     slide1: {
       welcomeTo: "Welcome to",
-      headline: "Turn chess into your daily focus ritual.",
-      support: "Train your mind, build consistency, and grow one move at a time.",
+      headline: "Two ways into chess.",
+      support: "Learn the pieces, or jump straight into a match.",
       learnPill: "Learn",
+      learnPillSub: "Start from zero",
       playPill: "Play",
+      playPillSub: "Full matches",
       cta: "START",
     },
     slide2: {
-      headline: "Build a daily chess habit.",
-      support: "Train every day and unlock your reward path.",
+      // The surviving idea is decision making. Habit, focus, wellbeing and
+      // scatter all lost the coin flip, on purpose.
+      headline: "Decide better in 21 days.",
+      support: "A daily habit that trains how you choose, on the board and off it.",
       passportLabel: "Focus Passport",
       passportSub: "21 focus days",
-      seasonPassLabel: "Season Pass",
-      seasonPassPrice: "$0.99",
-      footnote: "Season Pass unlocks the reward path. PRO includes Season Pass.",
+      price: "Season Pass, $0.99",
       cta: "NEXT",
     },
     slide3: {
-      headline: "Play free. Upgrade for Coach PRO.",
-      support: "Play matches, save progress, and improve with Coach PRO.",
+      // The inclusion is the whole argument for PRO, so it is the headline.
+      // It used to be the label of a gold pill.
+      headline: "Coach PRO includes the Season Pass.",
+      support: "Your games get reviewed, and the 21 Day Challenge comes with it.",
       savedGamesPill: "Saved games",
-      coachProPill: "Coach PRO",
-      proPill: "PRO $1.99 includes Season Pass.",
+      coachReviewPill: "Coach review",
+      price: "Coach PRO, $1.99",
       cta: "NEXT",
     },
     slide4: {
@@ -35,6 +47,9 @@ const messages = {
       jumpToPlay: "Already know chess? Jump to Play",
     },
     welcomeBack: {
+      // Its own headline. It used to borrow slide 1's, which forced one string
+      // to greet a returning player and orient a stranger at the same time.
+      headline: "Your board is waiting.",
       cta: "START",
       notSureLink: "Not sure? See other modes",
     },

--- a/apps/landing/src/lib/content/messages/es.ts
+++ b/apps/landing/src/lib/content/messages/es.ts
@@ -4,36 +4,36 @@ import type { OnboardingMessages } from "./en";
  * Real ES copy for the onboarding slides. Typed against
  * `OnboardingMessages` so it can never silently drift out of shape
  * from the EN source. Branded product names (Season Pass, Coach PRO,
- * PRO, Focus Passport) stay in English; everything else is natural
- * Spanish. No em/en-dashes per the anti-AI-prose rule.
+ * PRO, Focus Passport, 21 Day Challenge) stay in English; everything else
+ * is natural Spanish. No em/en-dashes per the anti-AI-prose rule.
  */
 const messages: OnboardingMessages = {
   onboarding: {
     progress: "{current} / {total}",
     slide1: {
       welcomeTo: "Bienvenido a",
-      headline: "Convierte el ajedrez en tu ritual diario de enfoque.",
-      support: "Entrena tu mente, gana constancia y crece jugada a jugada.",
+      headline: "Dos caminos hacia el ajedrez.",
+      support: "Aprende las piezas, o entra directo a una partida.",
       learnPill: "Aprende",
+      learnPillSub: "Desde cero",
       playPill: "Juega",
+      playPillSub: "Partidas completas",
       cta: "EMPEZAR",
     },
     slide2: {
-      headline: "Crea un hábito diario de ajedrez.",
-      support: "Entrena cada día y desbloquea tu camino de recompensas.",
+      headline: "Decide mejor en 21 días.",
+      support: "Un hábito diario que entrena cómo eliges, en el tablero y fuera de él.",
       passportLabel: "Focus Passport",
       passportSub: "21 días de enfoque",
-      seasonPassLabel: "Season Pass",
-      seasonPassPrice: "$0.99",
-      footnote: "El Season Pass desbloquea el camino de recompensas. PRO incluye Season Pass.",
+      price: "Season Pass, $0.99",
       cta: "SIGUIENTE",
     },
     slide3: {
-      headline: "Juega gratis. Mejora con Coach PRO.",
-      support: "Juega partidas, guarda tu progreso y mejora con Coach PRO.",
+      headline: "Coach PRO incluye el Season Pass.",
+      support: "Tus partidas se revisan, y el 21 Day Challenge viene incluido.",
       savedGamesPill: "Partidas guardadas",
-      coachProPill: "Coach PRO",
-      proPill: "PRO $1.99 incluye Season Pass.",
+      coachReviewPill: "Revisión del Coach",
+      price: "Coach PRO, $1.99",
       cta: "SIGUIENTE",
     },
     slide4: {
@@ -44,6 +44,7 @@ const messages: OnboardingMessages = {
       jumpToPlay: "¿Ya sabes jugar? Ve a Play",
     },
     welcomeBack: {
+      headline: "Tu tablero te espera.",
       cta: "EMPEZAR",
       notSureLink: "¿No sabes cuál? Ver otros modos",
     },

--- a/apps/landing/src/lib/content/messages/es.ts
+++ b/apps/landing/src/lib/content/messages/es.ts
@@ -17,8 +17,8 @@ const messages: OnboardingMessages = {
       learnPill: "Aprende",
       learnPillSub: "Desde cero",
       playPill: "Juega",
-      playPillSub: "Partidas completas",
-      cta: "EMPEZAR",
+      playPillSub: "Partidas reales",
+      cta: "SIGUIENTE",
     },
     slide2: {
       headline: "Decide mejor en 21 días.",
@@ -40,7 +40,7 @@ const messages: OnboardingMessages = {
       headline: "Aprende las piezas primero",
       support: "Juega ajedrez cuando estés listo.",
       learnDescription: "Crea tu hábito diario de ajedrez.",
-      startLearning: "Aprende las piezas",
+      cta: "EMPEZAR",
       jumpToPlay: "¿Ya sabes jugar? Ve a Play",
     },
     welcomeBack: {

--- a/docs/handoffs/2026-07-08-learn-save-proof-gate-p1-handoff.md
+++ b/docs/handoffs/2026-07-08-learn-save-proof-gate-p1-handoff.md
@@ -1,0 +1,100 @@
+# Handoff — P1: LEARN "Save proof" gate decoupled from B2 auto-save (2026-07-08)
+
+## TL;DR
+El CTA dorado on-chain "Save proof" de LEARN estaba gateado por `scorePendingNew`,
+el mismo flag que consume el auto-save off-chain silencioso de MiniPay Lote 2 (B2).
+Apenas resolvía el POST del auto-save el gate se cerraba y el CTA desaparecía →
+prácticamente inalcanzable en el happy path. **FIXED y mergeado a `main`**
+(PR #183, merge commit `1a181d20`). Falta **smoke on-device** — no hay cobertura
+automatizada del cableado.
+
+## Completado
+- [PR #183] `fix(learn): decouple on-chain Save proof CTA from off-chain auto-save gate`
+  - Nuevo módulo puro `apps/web/src/lib/exercises/save-proof-state.ts`
+    (precedente: `tx-toast-state.ts`).
+  - 13 tests nuevos en `__tests__/save-proof-state.test.ts` (TDD rojo → verde).
+  - Cableado en `exercises-screen.tsx` (import + derivación ~L1055 + prop L2308).
+
+### El fix, en una línea
+Gatear por la **ausencia de un receipt real**, no por el estado del save off-chain.
+`useSaveScoreState` ya distinguía los dos caminos: el save off-chain persiste
+`lastSavedTxHash` **vacío** (`exercises-screen.tsx:1674`), `submitScoreSigned`
+persiste el hash real (`:1085`). Sin flag nuevo, sin round-trip al server.
+
+```
+hasOnchainProof = txHash no vacío && lastSavedScore >= localScore
+canSaveOnChain  = canSaveScore && hasScoreboard && totalStars >= 1
+                  && localScore > 0 && !hasOnchainProof
+```
+
+### Lote 2 intacto
+No se tocaron el auto-save, `contextActionState.scorePending` ni el prop
+`canSaveScore` del sheet. `handleSaveScoreOnChain` (`:1774`) ya se gateaba con
+`canSaveScore` y no con `scorePendingNew`, así que funciona en paridad sin cambios.
+
+## Estado actual
+- **Branch**: `main` (sincronizado con origin; rama del fix borrada en el merge).
+- **Build**: typecheck `tsc --noEmit` limpio.
+- **Tests**: 4707 passing / 391 files.
+- **VR**: 51 passed, **1 failed** → ver Blockers.
+- **Uncommitted**: solo los dos handoff docs (este + el de permit/tx-map).
+- **PRs abiertos**: ninguno.
+- **Deploy**: Preview `chesscito-pjpyevcsh-goodwolf.vercel.app` = commit `1a181d20`,
+  status success (GitHub deployment `5369130572`). Founder valida/deploya si hace falta.
+
+## Próximas tareas
+1. **Smoke on-device del CTA dorado** (ver script abajo). Es la única validación
+   real del fix — nivel 3 sin cobertura.
+2. Smokes on-chain pendientes de la sesión previa (sin PRO, sin Season Pass):
+   PLAY win-save vía permit; LEARN Claim Badge / Save Score on-chain / Get Peones /
+   Shop-Shield. Ver `2026-07-08-permit-preview-activation-and-tx-smoke-map-handoff.md`.
+3. **Lote 2.5** — Tactical Day Gift + Proof of Consistency
+   (`docs/backlog/2026-07-08-tactical-day-gift-proof-of-consistency-lote-2.5.md`).
+4. Backlog LEARN/PLAY items 1–11 + PLAY dock 4-slot
+   (`docs/backlog/2026-07-08-lote2-smoke-findings-learn-play-backlog.md`).
+
+## Script de smoke (Preview, MiniPay, wallet en Celo mainnet)
+1. Resolver un ejercicio hasta ganar ≥1 estrella y un score **nuevo** (mayor al
+   anterior de esa pieza).
+2. **Esperar a ver "✓ Score saved"** en el mission sheet. Esto valida la prueba:
+   garantiza que el auto-save ya cerró la ventana del POST donde el CTA aparecía
+   por accidente antes del fix.
+3. **Assertion:** el bloque dorado "Save today's training proof" + botón
+   "Save proof" visible **debajo** del "✓ Score saved". Pre-fix: no había nada.
+4. Tap → MiniPay firma → tx gas-only `submitScoreSigned` al Scoreboard
+   `0x1681aAA1`. En Celoscan: sin transfer ERC-20 más allá del gas.
+5. Confirmado el receipt: el CTA **desaparece**, "✓ Score saved" queda. Cerrar y
+   reabrir el sheet → no reaparece.
+6. Superar ese score → el CTA **vuelve** a armarse.
+
+**Control diferencial:** Producción todavía corre el código viejo. Mismos pasos allá
+→ el CTA no aparece en el paso 3. Aísla que el cambio es la causa, no el ambiente.
+
+## Blockers
+- **Ninguno para el fix.**
+- **VR stale baseline (preexistente, NO de este PR)**: `hub-shop-sheet-open` falla
+  en `main`. Confirmado corriendo el test con el cambio stasheado. El baseline
+  espera Coach Credits + PRO $1.99 + Streak Shield $0.03; la app hoy renderiza PRO
+  "Coming soon" y ninguno de esos tiles. Es drift de varios commits. **No refrescado
+  a propósito**: hornear el estado actual del Shop es una decisión de producto, no
+  un chore. Requiere confirmación del founder antes de `--update-snapshots`.
+
+## Open questions
+- **Nivel 3 sin cobertura**: no existe `exercises-screen.test.tsx`. Los 13 tests
+  cubren la función pura y `mission-detail-sheet.test.tsx:160-182` cubre el render
+  dado el prop — pero **nadie testea qué se le pasa al prop**, que es exactamente
+  donde vivía el bug. Founder eligió "solo smoke on-device" (2026-07-08); si la
+  regresión reaparece en un refactor futuro, considerar el test de cableado.
+- **Caveat cross-device (aceptado)**: el save state es localStorage por device, así
+  que un device nuevo re-arma el CTA aunque el score ya esté en el Scoreboard.
+  Re-probar cuesta gas, es inofensivo. Reconciliación vía
+  `leaderboard_full_v.has_onchain` queda fuera de scope.
+
+## Notas
+- Founder dejó una PK de pruebas sin fondos en dotenv local (`ONLY_TEST_NO_FUNDS_PK`).
+  No se usó ni se leyó en esta sesión. Confirmado que ese archivo está ignorado por
+  git (patrón sin slash en `.gitignore:15` → matchea en cualquier nivel).
+- Memoria actualizada: `project_learn_save_proof_gate_regression` marcada RESOLVED;
+  índice `MEMORY.md` refleja P1 cerrado + nota del baseline stale.
+
+Wolfcito 🐾 @akawolfcito

--- a/docs/handoffs/2026-07-08-permit-preview-activation-and-tx-smoke-map-handoff.md
+++ b/docs/handoffs/2026-07-08-permit-preview-activation-and-tx-smoke-map-handoff.md
@@ -1,0 +1,55 @@
+# Handoff — Permit-mint Preview activation + PLAY/LEARN on-chain tx smoke map (2026-07-08)
+
+## TL;DR
+- **Root cause found + FIXED**: "Save Victory" en PLAY caía al fallback **approve** (no pedía firma) porque `NEXT_PUBLIC_VICTORY_PERMIT_MINT_ENABLED` estaba **solo en Production**, no en **Preview** (donde el founder hace QA). Es `NEXT_PUBLIC_` → se congela en build-time; sin el flag, `isVictoryPermitMintEnabled()` = `false` y el bloque permit se salta por completo (no es el "segundo fallback por error técnico", es que el primer path ni se intenta).
+- **Founder activó el flag en Preview + redeploy → permit funcionó** (save por `mintSignedWithPermit`, 1 sola tx, sin approve). Confirmado on-device.
+- Sesión de QA en curso: smokes **sin Season Pass y sin PRO** en PLAY y LEARN. **Sin cambios de código** (working tree limpio).
+
+## Diagnóstico (cómo se encontró)
+1. `useMintVictory` (`apps/web/src/lib/coach/use-mint-victory.ts`): el bloque permit (L426-496) solo corre si `isVictoryPermitMintEnabled()`. En el `catch` (L489) un fallo técnico cae silenciosamente a approve (L498-520); una cancelación de usuario re-lanza.
+2. `isVictoryPermitMintEnabled()` (`feature-flags.ts:60`) = `process.env.NEXT_PUBLIC_VICTORY_PERMIT_MINT_ENABLED === "true"`.
+3. `vercel env ls` → el flag existía **solo en Production** (seteado ~2026-07-02). Ausente en Preview/Development.
+4. El handoff `2026-07-03-victory-nft-permit-mint-mainnet-activation-handoff.md` (L47) ya listaba "Enable flag in Production" como pendiente, pero nunca se replicó a Preview.
+
+## Tx verificada (contexto de la tx que el founder encontró)
+`0xfb19c319…301eee` (Celoscan) — save de derrota vía **approve/mintSigned** (path viejo, antes de activar permit):
+- `From` wallet `0xCc4179A2…` → `Interacted With` VictoryNFT proxy `0x0eE22F83…`.
+- 6 transfers USDT: pago NFT Easy $0.01 = **0.008 → treasury `0xcD3837DD…`** (80%) + **0.002 → prize pool `0x63DEfFD3…`** (20%); resto = gas pagado en USDT vía fee-currency abstraction de Celo/MiniPay (fee-collector `0x…Ce106A5`, con reembolso 0.001457 del gas no usado).
+- El mint ERC-721 (`0x0 → wallet`) va en la pestaña **NFT Transfers**/Logs (evento `VictoryMinted` con `tokenId`), no en la vista ERC-20.
+- **Permit vs approve** se distingue por el método en "Input Data": `mintSignedWithPermit` (selector `b31e32cc`, 1 tx) vs `mintSigned` (+ tx `approve` separada previa).
+
+## Mapa de smokes on-chain (sin PRO / sin Season Pass)
+
+### PLAY (arena) — **1 sola tx on-chain**
+- **Save Match / Save Victory** (`useMintVictory` → `mintSigned` / `mintSignedWithPermit`, VictoryNFT `0x0eE22F83…`). Único write on-chain del gameplay.
+- Alcanzable desde **5 end-states** (misma tx, distinta UI): **win/checkmate** (full-screen `VictoryCelebration`) · **loss** · **draw** · **stalemate** · **resign** (los 4 = Save inline en `arena-end-state.tsx`).
+- `save-score` al leaderboard **NO existe en PLAY** (vive en LEARN; además el leaderboard de PLAY quedó oculto en Lote 1 B5).
+- Faltaba cubrir: **win-save** (UI full-screen) y comparar **permit vs approve**.
+
+### LEARN (exercises) — **4 txs distintas** (`exercises-screen.tsx` L311-313: 3 `useWriteContract`)
+1. **Claim Badge** — gas-only, `/api/sign-badge` → `claimBadgeSigned` (Badges `0xf92759E5`). Se desbloquea al llegar a `BADGE_THRESHOLD` estrellas (`badge-sheet.tsx`, estado `claimable`). Único de LEARN.
+2. **Save Score on-chain** (Leaderboard Proof) — gas-only, `/api/sign-score` → `submitScoreSigned` (Scoreboard `0x1681aAA1`). Gated `canSaveOnChain = scorePendingNew && scoreboardAddress != null` (L2270). Único de LEARN.
+3. **Shop buy** — `writeShopAsync` → Shop `0x24846C77` (Shield, etc.).
+4. **Get Peones / PRO / Season Pass** — payment rail single-tx `ERC20.transfer(treasury)` (compartido con PLAY).
+
+**GOTCHA Save Score (dos caminos, `save-client.ts:6-15`):**
+- **Default = OFF-CHAIN** (`postScoreSave` → `/api/scores/save`): NO genera tx, no firma ni broadcast. Puede costar peones (ledger off-chain → puede devolver `insufficient_peones`).
+- **On-chain = opcional** (#2 arriba). El SAVE verde default NO aparece en Celoscan; solo el botón on-chain/Leaderboard Proof genera tx.
+
+## Estado actual
+- **Branch**: `main` (limpio, sin uncommitted). Sin PRs abiertos de esta sesión.
+- **Build**: sin cambios de código → baseline previo intacto.
+- **Preview**: flag `NEXT_PUBLIC_VICTORY_PERMIT_MINT_ENABLED=true` activo + redeployado. Permit verificado on-device.
+
+## Próximos pasos
+1. Continuar smokes sin PRO / sin Season Pass:
+   - PLAY: **win-save** (VictoryCelebration) por permit.
+   - LEARN: **Claim Badge** (gas-only), **Save Score on-chain** (Leaderboard Proof), **Get Peones** (pago), **Shop/Shield**.
+2. Reconciliar con el plan MiniPay delivery: Lote 2 (B1 free off-chain save + B2 collapse green SAVE) y Lote 3 (B4 MAX_SHIELDS 30→3). Ver `2026-07-08-minipay-delivery-lote1-handoff.md`.
+3. Confirmar consistencia del flag entre Preview y Production antes de listing (scope atómico Vercel).
+
+## Open questions
+- ¿El botón "Save Score on-chain" (Leaderboard Proof) está expuesto en la UI actual o queda dormido tras el default off-chain? Verificar en device durante el smoke.
+- MiniPay "unknown transaction / dev mode" para el contrato VictoryNFT: ¿bloquea usuarios reales o es solo warning? (pendiente pre-listing, ver handoff 2026-07-03).
+
+Wolfcito 🐾 @akawolfcito

--- a/docs/specs/2026-07-08-landing-slides-123-goals.md
+++ b/docs/specs/2026-07-08-landing-slides-123-goals.md
@@ -1,0 +1,60 @@
+# Landing slides 1/2/3 — goals (founder, 2026-07-08)
+
+Fuente: founder, sesión 2026-07-08. Slide 4 ya cerrado (PR #184), fuera de alcance.
+Este doc fija el GOAL de cada pantalla antes de la crítica de UX (Sally) y del mock.
+
+## Rol del carrusel
+
+Cuatro pantallas, una sola vez en la vida del visitante. Después de la primera
+selección la cookie lo manda directo al juego vía `welcome-back.tsx` — no vuelve
+a ver los slides. Por eso 2 y 3 son la **única** oportunidad de explicar la capa
+paga, y por eso existen.
+
+## Slide 1 — Welcome
+
+**Goal:** que un desconocido total salga sabiendo dos cosas y ninguna más:
+1. esto tiene que ver con ajedrez;
+2. hay dos modos, Learn y Play.
+
+No vender. No precios. Las dos pills (Learn / Play) son el mensaje completo.
+El CTA avanza el carrusel.
+
+**Acoplamiento:** `welcome-back.tsx` reusa `slide1.headline`, el avatar y el
+wordmark. Cambiarlos cambia la pantalla del visitante que regresa.
+
+## Slide 2 — Season Pass
+
+**Goal:** existe el Season Pass, cuesta $0.99, y estos son los beneficios; por eso
+deberías adquirirlo.
+
+Qué es el Season Pass para nosotros: la puerta de entrada al mundo de **Learn**.
+Es el acceso al 21 Day Challenge, que no es un set de retos sino un andamio para
+construir un hábito — el hábito de aprender, de entender, de sostener el cambio
+cognitivo. El beneficio real es bienestar mental, mejores tomas de decisión, y
+foco para gente dispersa.
+
+**Restricciones de copy:**
+- Hay rewards, pero NO se prometen como valor monetario. Se enuncian como apoyo
+  de la comunidad. (Ver `minipay-listing-safety`.)
+- Existe una capa paga y se dice sin rodeos.
+- El cruce con eventos del mundo real es dirección de producto, NO va al copy.
+
+## Slide 3 — Coach PRO
+
+**Goal:** esto es Coach PRO, cuesta $1.99, y por esto deberías elegirlo.
+
+**Cambio respecto de hoy:** el slide actual lidera con "Play free. Upgrade for
+Coach PRO." — mezcla el pitch de Play con el de PRO. El goal del founder es que
+la pantalla sea el pitch de PRO, no el de Play.
+
+**Argumento central:** PRO incluye Season Pass. Se ganan los dos. Y PRO es la
+puerta a lo que se va sumando en el camino: personalizaciones, avatares, apoyo
+en juego, y distribución del pool para quienes sostienen la consistencia ganada
+en Learn.
+
+## Preguntas abiertas
+
+- Si PRO incluye Season Pass, ¿el orden 2→3 es el correcto, o el visitante
+  aprende el precio menor primero y ancla ahí? (Para Sally.)
+- ¿Cuánto del "por esto deberías" cabe en el marco sin romper la composición
+  móvil de 390px? (Para el mock.)

--- a/docs/specs/2026-07-08-landing-slides-123-redesign-spec.md
+++ b/docs/specs/2026-07-08-landing-slides-123-redesign-spec.md
@@ -1,0 +1,137 @@
+# Landing slides 1/2/3 + Welcome Back — redesign spec
+
+Decisiones del founder (2026-07-08), sobre la crítica en
+`2026-07-08-landing-slides-123-ux-critique.md`:
+
+1. Separar `welcomeBack.headline` de `slide1.headline`. **Sí.** Y de paso
+   arreglar la tipografía y el tamaño del wordmark en Welcome Back.
+2. Idea única del slide 2: **la toma de decisiones.**
+3. Sacar "free" del headline del slide 3. **Sí.**
+
+---
+
+## Bug transversal: la jerarquía de la Pill está invertida
+
+`components/onboarding/pill.tsx` líneas 35-36:
+
+```tsx
+<span className="text-[0.6rem]">{label}</span>
+{sublabel ? <span className="text-[0.7rem] opacity-80">{sublabel}</span> : null}
+```
+
+El **sublabel es más grande que el label**. Hoy, en el slide 2, `Focus Passport`
+se renderiza a 0.6rem y `21 focus days` a 0.7rem. El dato secundario pesa más
+que el nombre. Y el `opacity-80` sobre el más grande empuja en la dirección
+contraria a la que la escala ya empujó.
+
+Esto no lo vimos antes porque solo el slide 2 usa `sublabel`. En cuanto el slide
+1 estrene sublabels (abajo), el defecto se multiplica por tres.
+
+**Fix:** label `text-[0.7rem]`, sublabel `text-[0.6rem] opacity-80`.
+
+---
+
+## Welcome Back — qué está mal, exactamente
+
+`components/onboarding/welcome-back.tsx` vs `Slide1Body`:
+
+| Elemento | Slide 1 | Welcome Back | Diagnóstico |
+|---|---|---|---|
+| "Welcome to" | `fantasy-title text-xl` | `text-sm` | **Sin `fantasy-title`.** Cae al body face en vez de Rowdies. Este es el "font que no se muestra bien". |
+| Wordmark | `h-12 w-auto` | `h-14 w-6/12` | No hay deformación (`ArtImage` es `object-contain`). Lo que pasa es que **`w-6/12` topea antes que `h-14`**: el wordmark es ancho, la caja mide 50% del contenedor, y la imagen se encoge para caber en el ancho sin llegar nunca a los 3.5rem de alto. Se ve chico. |
+| Avatar | `relative top-9 w-48` | `relative top-3 w-48` | Distinto offset vertical, sin razón registrada. |
+| Headline | `text-sm` (body face, a propósito) | `text-2xl` (body face) | A `text-2xl` el body face pide `fantasy-title`, o baja de tamaño. |
+
+**Fix:** `fantasy-title` en "Welcome to"; wordmark a `h-12 w-auto`; alinear el
+offset del avatar; headline propio (`welcomeBack.headline`) con face y tamaño
+decididos una vez.
+
+---
+
+## Esqueleto común
+
+```
+[ arte / avatar ]
+[ título ]              ← qué es
+[ una frase ]           ← por qué te importa
+[ ─── divider ─── ]
+[ evidencia ]           ← pills, 2 máx
+[ precio ]              ← una línea de texto, NO una pill
+```
+
+El precio deja de ser pill. Una pill es un chip de HUD, un objeto que poseés. Un
+precio es una condición. Ponerlo en el mismo contenedor que `Focus Passport` le
+dice al ojo que son la misma categoría de cosa.
+
+---
+
+## Copy propuesto (`messages/en.ts`)
+
+> Propuesta, no decisión. El copy es tuyo. Sin em-dashes (gate `anti-ai-prose`).
+> Todo cambio va simultáneo a `en.ts` y `es.ts` (`feedback_i18n_key_parity`).
+
+### Slide 1 — orientación
+
+| key | hoy | propuesto |
+|---|---|---|
+| `welcomeTo` | Welcome to | *(igual)* |
+| `headline` | Turn chess into your daily focus ritual. | **Two ways into chess.** |
+| `support` | Train your mind, build consistency, and grow one move at a time. | **Learn the pieces, or jump straight into a match.** |
+| `learnPill` | Learn | Learn + sublabel **Start from zero** |
+| `playPill` | Play | Play + sublabel **Full matches** |
+
+El headline viejo se muda de barrio: era el pitch del hábito, y el hábito es el
+slide 2.
+
+### Slide 2 — Season Pass, idea única = decisiones
+
+| key | hoy | propuesto |
+|---|---|---|
+| `headline` | Build a daily chess habit. | **Decide better in 21 days.** |
+| `support` | Train every day and unlock your reward path. | **A daily habit that trains how you choose, on the board and off it.** |
+| pills | Focus Passport / Season Pass $0.99 | solo **Focus Passport** + sublabel **21 focus days** |
+| precio | *(era pill)* | línea de texto: **Season Pass, $0.99** |
+| `footnote` | Season Pass unlocks the reward path. PRO includes Season Pass. | **eliminado** |
+
+Se va "reward path" (rozaba la promesa de valor monetario que tu propio goal
+prohíbe, y no decía de quién viene el reward). Se va el footnote: nombraba PRO
+una pantalla antes de que PRO exista, respondiendo una objeción que nadie tiene
+todavía. Ese argumento es el titular del slide 3.
+
+### Slide 3 — Coach PRO
+
+| key | hoy | propuesto |
+|---|---|---|
+| `headline` | Play free. Upgrade for Coach PRO. | **Coach PRO includes the Season Pass.** |
+| `support` | Play matches, save progress, and improve with Coach PRO. | **Your games get reviewed, and the 21 Day Challenge comes with it.** |
+| pills | Saved games / Coach PRO | **Saved games** / **Coach review** |
+| `proPill` | PRO $1.99 includes Season Pass. *(pill dorada)* | línea de texto: **Coach PRO, $1.99** |
+
+El argumento que estaba enterrado en un chip dorado sube a titular. Sale "free".
+
+---
+
+## Cambios de código
+
+1. `pill.tsx` — invertir la escala label/sublabel.
+2. `messages/en.ts` + `messages/es.ts` — copy nuevo, `welcomeBack.headline` nueva,
+   `slide2.footnote` y `slide3.proPill` fuera.
+3. `slide-bodies.tsx` — esqueleto común; matar el `h-2` del slide 2 (fija el
+   contenedor de pills en 8px y las pills lo desbordan; el `mt-6` del footnote
+   compensa a mano) y su `mt-6` acompañante; precio como línea.
+4. `welcome-back.tsx` — `fantasy-title`, wordmark `h-12 w-auto`, offset del
+   avatar, headline propio.
+5. Tests: `onboarding-carousel.test.tsx` referencia el copy. VR baselines de
+   landing si existen.
+
+---
+
+## Preguntas abiertas
+
+- **Slide 2:** ¿el "apoyo de la comunidad" (rewards no monetarios) queda fuera
+  del carrusel? Recomiendo que sí. Es una idea entera y vos elegiste decisiones.
+- **Slide 3:** las features futuras (avatares, personalizaciones, distribución
+  del pool) ¿quedan fuera? Recomiendo que sí, por lo mismo. PRO se vende con
+  "te llevás los dos", no con una lista.
+- **Slide 1:** ¿`headline` en `fantasy-title` ahora que es más corto? Hoy está en
+  body face a propósito, porque compite con "Welcome to" y el wordmark.

--- a/docs/specs/2026-07-08-landing-slides-123-ux-critique.md
+++ b/docs/specs/2026-07-08-landing-slides-123-ux-critique.md
@@ -1,0 +1,136 @@
+# Landing slides 1/2/3 — UX critique (Sally, 2026-07-08)
+
+Contra los goals en `2026-07-08-landing-slides-123-goals.md`.
+Código: `apps/landing/src/components/onboarding/slide-bodies.tsx` · copy `lib/content/messages/en.ts`.
+
+---
+
+## El hallazgo que reordena todo
+
+Los slides 2 y 3 tienen botón **NEXT**. No hay botón de compra. No existe
+destino de conversión en ninguna de las dos pantallas.
+
+Entonces el goal "por esto deberías adquirirlo" no se puede cumplir como está
+escrito, porque *no hay dónde adquirirlo*. Estas pantallas no venden: **siembran
+una idea que el visitante tiene que reconocer semanas después**, cuando el
+paywall aparezca dentro del juego. Se ven una sola vez en la vida.
+
+Eso cambia el criterio de diseño. No hay que meter el argumento de venta
+completo en 390px. Hay que dejar **una idea que sobreviva al olvido**, por
+pantalla. Una. Si el visitante sale del slide 2 recordando "el Season Pass es la
+puerta a los 21 días", ganamos. Si sale recordando cuatro beneficios y un precio,
+no recuerda ninguno.
+
+---
+
+## Slide 1 — el headline no es de esta pantalla
+
+**Goal:** ajedrez + dos modos. Nada más.
+
+**Hoy dice:** *"Turn chess into your daily focus ritual."* / *"Train your mind,
+build consistency, and grow one move at a time."*
+
+Eso es el pitch del **hábito**, que es el goal del slide 2. El slide 1 está
+gastando su único momento de atención en un mensaje que la pantalla siguiente
+repite mejor y con evidencia. Y no dice lo que sí tiene que decir: que hay dos
+modos y que son dos caminos distintos.
+
+Las pills `Learn` / `Play` cargan el mensaje entero de la pantalla, pero son dos
+etiquetas sueltas sin sublabel. Leen como *features*, no como *modos*. El `Pill`
+ya soporta `sublabel` (lo usa el slide 2) y acá está sin usar.
+
+**Acoplamiento crítico:** `welcome-back.tsx` renderiza `slide1.headline` a
+`text-2xl`, solo, sin support ni pills. O sea el mismo string tiene que funcionar
+como orientación para un desconocido y como saludo para alguien que vuelve.
+Son dos trabajos. **Recomiendo separar la key**: `welcomeBack.headline` propia.
+Sin eso, cualquier reescritura del slide 1 arrastra la pantalla de regreso.
+
+---
+
+## Slide 2 — jerarquía plana y un bug de layout
+
+**Goal:** qué es, cuánto vale, por qué lo querés.
+
+1. **Las dos pills no son hermanas.** `Focus Passport / 21 focus days` es una
+   *feature*. `Season Pass / $0.99` es el *producto con su precio*. Ponerlas lado
+   a lado, mismo tamaño, mismo tono, convierte el precio en un atributo más y no
+   en la propuesta. El producto no puede tener el mismo peso visual que su
+   contenido.
+
+2. **"unlock your reward path"** roza la promesa de valor monetario que el propio
+   goal prohíbe. "Reward path" además es vago: no dice qué es ni de quién viene.
+   El goal habla de *apoyo de la comunidad*; el copy no lo refleja.
+
+3. **El footnote nombra PRO** antes de que PRO exista para el visitante. Está
+   respondiendo una objeción que todavía nadie tiene. Ese argumento es el
+   corazón del slide 3 — dejarlo allá, donde pega.
+
+4. **El "por qué" no está.** Hábito, foco, decisiones, dispersión: nada de eso
+   sobrevivió al copy. Es lo único que el visitante debería llevarse.
+
+5. **Bug de composición:** `<div className="h-2 flex gap-2.5">` fija la altura del
+   contenedor de pills en **8px**. Las pills desbordan. Después un `mt-6` en el
+   footnote compensa a mano. Está sostenido con alambre.
+
+---
+
+## Slide 3 — la pantalla contradice su propio goal
+
+**Goal:** esto es Coach PRO, cuesta $1.99, por esto lo elegís.
+
+**Hoy dice:** *"Play free. Upgrade for Coach PRO."*
+
+Dos problemas, y el segundo es serio:
+
+1. **Lidera con Play**, no con PRO. La mitad del headline vende un producto que
+   no es el de esta pantalla.
+
+2. **Reintroduce "free"** — exactamente la palabra que el slide 4 eliminó, y por
+   la misma razón por la que la eliminó. El visitante lee "Play free" en el slide
+   3 y en el slide 4 le recomendamos Learn, que pasa por un Season Pass de $0.99.
+   Es la **misma inversión de preferencia** que ya se corrigió una pantalla más
+   adelante, reinstalada una pantalla antes. El slide 4 quedó blindado y el 3 le
+   abre la puerta de atrás.
+
+3. **El mejor argumento está enterrado.** "PRO includes Season Pass" vive como
+   *label de una pill dorada*. Es la razón entera por la que PRO tiene sentido
+   —te llevás los dos— y está tipografiada como un chip de HUD. Eso es un
+   titular, no una etiqueta.
+
+---
+
+## Pregunta abierta del founder: ¿2→3 es el orden correcto?
+
+**Sí, mantenerlo.** El visitante ve $0.99, lo entiende, y recién entonces aparece
+$1.99 diciendo "incluye eso que acabás de entender". El ancla baja primero hace
+que la inclusión se sienta como ganancia. Invertirlo obliga a explicar el Season
+Pass dos veces: una dentro de PRO y otra como producto suelto.
+
+---
+
+## Esqueleto propuesto (los tres iguales)
+
+Hoy cada slide inventa su propia estructura. Un carrusel se lee como *una* cosa,
+no como tres. Propongo un molde común, y que la variación viva en el arte:
+
+```
+[ arte / avatar ]
+[ título ]                 ← qué es
+[ una frase ]              ← por qué te importa a vos
+[ ─── divider ─── ]
+[ evidencia ]              ← pills: 2 máx, jerarquía clara
+[ precio, si aplica ]      ← una línea, no una pill
+```
+
+Slide 1 omite precio y evidencia (solo las dos pills de modo). Slides 2 y 3 lo
+usan completo. El divider ya existe y ya marca ese quiebre.
+
+---
+
+## Lo que le pido al founder antes del mock
+
+1. **Slide 1**: ¿separo `welcomeBack.headline` del `slide1.headline`? (Recomiendo
+   que sí; sin eso el rediseño del slide 1 toca la pantalla de regreso.)
+2. **Slide 2**: de las cinco ideas del goal —hábito, foco, decisiones,
+   dispersión, bienestar— ¿cuál es **la única** que quiere que sobreviva?
+3. **Slide 3**: ¿saco "free" del headline? (Recomiendo que sí, por lo de arriba.)


### PR DESCRIPTION
Slides 1/2/3 of the onboarding carousel, redesigned against goals the founder stated screen by screen. Slide 4 shipped in #184 and is untouched here except for its CTA label.

## The finding that reordered the work

Slides 2 and 3 have a NEXT button. There is no buy button anywhere in the carousel, and the onboarding cookie sends returning visitors straight past it via `welcome-back.tsx`. So these screens never convert. They plant one idea the visitor has to recognize weeks later, when the paywall shows up in-game. One idea per screen. A screen carrying four benefits leaves none behind.

## What changed

**Slide 1** led with "Turn chess into your daily focus ritual", which is slide 2's pitch, and never said the one thing it owed a stranger: there are two modes. It now says **"Two ways into chess."** and its mode pills name the player each door is for (`From zero` / `Full matches`).

**Slide 2** keeps decision making, the idea the founder picked, and drops "reward path" (it edged toward the monetary promise the goal forbids, and never said who the reward comes from). Its PRO footnote answered an objection nobody has yet, so it moved to slide 3. Headline: **"Decide better in 21 days."**

**Slide 3** said "Play free", reinstating one screen earlier the exact price inversion slide 4 was rebuilt to remove: the visitor reads "free" here, then one screen later we recommend Learn, which runs through a $0.99 Season Pass. Its strongest argument, that PRO includes the Season Pass, was the label of a gold pill. It is now the headline, and the gold pill is gone.

**Prices stop being pills.** A pill is a thing you own. A price rendered in the same tray as `Focus Passport` tells the eye they are the same kind of thing. Both prices are now a line of text.

**The carousel reads NEXT, NEXT, NEXT, START.** START used to mean "advance one screen" at the top of the funnel and nothing at the bottom, where slide 4 said "Learn Pieces". Now the advance button never claims to start anything, and START means one thing everywhere. It is also the word `welcome-back.tsx` puts in that exact spot.

## Two bugs found on the way

**`pill.tsx` had its hierarchy inverted:** label `0.6rem`, sublabel `0.7rem`, with `opacity-80` on the larger of the two. `21 focus days` outweighed `Focus Passport`. Only slide 2 used sublabels, so it went unseen; slide 1 gaining them would have tripled it.

**Sublabels wrapped and centered.** `SlideShell` centers its whole content box, and the pill's `items-start` only aligns the two spans as boxes, not the text inside them, so a wrapped second line centered under a left-aligned label. Fixed with `text-left` plus room to not wrap: icon `2.3rem` to `1.9rem`.

**`welcome-back.tsx` rendered `slide1.headline`,** so one string had to greet a returning player and orient a stranger at once, and any rewrite of slide 1 silently rewrote that screen. It now owns `welcomeBack.headline`. Its "Welcome to" was missing `fantasy-title` and fell back to the body face; its wordmark was `h-14 w-6/12`, and since `ArtImage` is `object-contain` the width cap bound before the height did, so the art rendered small rather than stretched. Both now match slide 1. The avatar goes `w-48` to `w-56`, taking the room the pills never used.

## Verification

- 36 tests passing (8 files), up from 35. Typecheck clean. `apps/landing` build green.
- Driven in Chromium at 390px: slide 1 (EN and ES, where `Partidas reales` is the longest sublabel), slide 4, and Welcome Back with the onboarding cookie set.
- Copy carries no em/en-dashes. `en.ts` and `es.ts` changed together; `es.ts` is typed against `OnboardingMessages`, so key drift cannot compile.

## Known, accepted

Removing slide 2's footnote and slide 3's gold pill left dead cream in the lower third of the frame. Founder reviewed the screenshots and called it imperceptible. The lever, if it ever matters, is `justify-center` on `SlideShell`'s content box, which also moves slide 4 (it depends on `mt-10` to clear the frame's crown).

Wolfcito 🐾 @akawolfcito
