### PR TITLE
fix(learn): badge Claim CTA never rendered + score cap locked out players past 15 stars

### DIFF
--- a/apps/web/src/app/api/sign-score/__tests__/route-score-bounds.test.ts
+++ b/apps/web/src/app/api/sign-score/__tests__/route-score-bounds.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Bounds coverage for /api/sign-score.
+ *
+ * `route.test.ts` mocks `parseInteger` wholesale, so it proves the route
+ * maps a thrown "Invalid score" to a 400 — but never exercises the actual
+ * ceiling. That blind spot is how the 1500 cap survived the catalog growing
+ * to 3000-point pools. This suite keeps `parseInteger` and `parseAddress`
+ * real and only stubs the env-dependent signing seams.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { getMaxSubmittableScore } from "@/lib/game/score";
+
+vi.mock("@/lib/server/demo-signing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/server/demo-signing")>();
+  return {
+    ...actual,
+    enforceOrigin: vi.fn(),
+    enforceRateLimit: vi.fn().mockResolvedValue(undefined),
+    getRequestIp: vi.fn(() => "127.0.0.1"),
+    createNonce: vi.fn(() => 123n),
+    createDeadline: vi.fn(() => 9999999999n),
+    getDemoConfig: vi.fn(),
+  };
+});
+
+import { POST } from "../route";
+import { getDemoConfig } from "@/lib/server/demo-signing";
+
+const VALID_ADDRESS = "0xcc4179a22b473ea2eb2b9b9b210458d0f60fc2dd" as const;
+
+function stubSigner() {
+  vi.mocked(getDemoConfig).mockReturnValue({
+    chainId: 11142220,
+    badgesAddress: "0xf92759E52aA5EC5d6fDb6CE03b9AC9Cd9f000001",
+    scoreboardAddress: "0x1681aAA12aA5EC5d6fDb6CE03b9AC9Cd9f000002",
+    victoryNFTAddress: "0x87cC9fe03E76A5894De2FE1372E85D6f5Bb922A9",
+    signer: {
+      signTypedData: vi.fn().mockResolvedValue("0xsig"),
+    } as unknown as ReturnType<typeof getDemoConfig>["signer"],
+  });
+}
+
+function submit(score: number) {
+  return POST(
+    new Request("http://localhost/api/sign-score", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ player: VALID_ADDRESS, levelId: 1, score, timeMs: 12000 }),
+    }),
+  );
+}
+
+describe("POST /api/sign-score — score bounds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubSigner();
+  });
+
+  it("signs a score of 1800 (18★, the progress that was being rejected)", async () => {
+    expect((await submit(1800)).status).toEqual(200);
+  });
+
+  it("signs a perfect run at the catalog ceiling", async () => {
+    expect((await submit(getMaxSubmittableScore())).status).toEqual(200);
+  });
+
+  it("rejects a score one point above the ceiling", async () => {
+    const res = await submit(getMaxSubmittableScore() + 1);
+
+    expect(res.status).toEqual(400);
+    expect((await res.json()).error).toEqual("Invalid score");
+  });
+
+  it("still rejects a negative score", async () => {
+    expect((await submit(-1)).status).toEqual(400);
+  });
+});

--- a/apps/web/src/app/api/sign-score/route.ts
+++ b/apps/web/src/app/api/sign-score/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { getMaxSubmittableScore } from "@/lib/game/score";
 import {
   createDeadline,
   createNonce,
@@ -27,8 +28,9 @@ export async function POST(request: Request) {
     await enforceRateLimit(getRequestIp(request), player);
 
     const levelId = parseInteger(body.levelId, "levelId", 1, 10_000);
-    // Max score: 15 stars × 100 pts = 1500 per piece level
-    const score = parseInteger(body.score, "score", 0, 1_500);
+    // Ceiling derived from the catalog, never hardcoded: a stale cap silently
+    // rejects the best players. See lib/game/score.ts.
+    const score = parseInteger(body.score, "score", 0, getMaxSubmittableScore());
     const timeMs = parseInteger(body.timeMs, "timeMs", 1, 3_600_000);
     const nonce = createNonce();
     const deadline = createDeadline();

--- a/apps/web/src/components/exercises/__tests__/badge-sheet.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/badge-sheet.test.tsx
@@ -24,6 +24,17 @@ function setStars(piece: PieceId, stars: number[]) {
   );
 }
 
+/** The shape the app actually persists since the id-keyed migration
+ *  (2026-06-16). `setStars` above writes the legacy array, which is why
+ *  these tests kept passing while the real sheet showed every piece as
+ *  locked. */
+function setStarsById(piece: PieceId, starsById: Record<string, number>) {
+  localStorage.setItem(
+    `chesscito:progress:${piece}`,
+    JSON.stringify({ piece, currentId: `${piece}-1`, stars: starsById }),
+  );
+}
+
 function renderBadgeSheet({
   badgesClaimed = {
     rook: false,
@@ -76,6 +87,39 @@ describe("BadgeSheet — claim action presentation", () => {
 
     expect(screen.getAllByText("Owned").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Locked").length).toBeGreaterThan(0);
+  });
+});
+
+describe("BadgeSheet — id-keyed progress (regression: Claim never rendered)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("offers Claim for a piece whose id-keyed stars cross the threshold", () => {
+    // 18★ on rook — the founder's on-device progress. Read as a positional
+    // array this scored 0★ and the piece rendered locked, so the Claim CTA
+    // was unreachable for every player past the threshold.
+    setStarsById("rook", {
+      "rook-1": 3,
+      "rook-2": 3,
+      "rook-3": 3,
+      "rook-4": 3,
+      "rook-5": 3,
+      "rook-6": 3,
+    });
+
+    renderBadgeSheet();
+
+    expect(screen.getByRole("button", { name: "Claim Badge" })).toBeInTheDocument();
+    expect(screen.getByText("Claimable")).toBeInTheDocument();
+  });
+
+  it("keeps a piece below the threshold locked", () => {
+    setStarsById("rook", { "rook-1": 3, "rook-2": 3 });
+
+    renderBadgeSheet();
+
+    expect(screen.queryByRole("button", { name: "Claim Badge" })).not.toBeInTheDocument();
   });
 });
 
@@ -196,10 +240,10 @@ describe("BadgeSheet — ContextualHeader canary", () => {
   it("renders the HERO BAND stats line (pieces + stars) below the header", () => {
     setStars("rook", [3, 3, 3, 3, 3]);
     renderBadgeSheet();
-    // 15 of 90 stars (rook full = 15 stars). Bishop is claimed in the
-    // default fixture → piecesClaimed = 1. HERO BAND format renders
-    // "1/6 PIECES" and "15/90 ★" as sibling spans.
+    // The denominator is the real catalog: 6 pieces × 10 exercises × 3★ = 180.
+    // The legacy 5-slot fixture fills rook's first five exercises → 15★.
+    // Bishop is claimed in the default fixture → piecesClaimed = 1.
     expect(screen.getByText(/1\/6 PIECES/i)).toBeInTheDocument();
-    expect(screen.getByText(/15\/90 ★/)).toBeInTheDocument();
+    expect(screen.getByText(/15\/180 ★/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/exercises/badge-sheet.tsx
+++ b/apps/web/src/components/exercises/badge-sheet.tsx
@@ -16,6 +16,7 @@ import {
 import { ContextualHeader } from "@/components/ui/contextual-header";
 import { TileIconSlot } from "@/components/ui/tile-icon-slot";
 import { BADGE_THRESHOLD } from "@/lib/game/exercises";
+import { parsePieceStars } from "@/lib/exercises/badge-progress";
 import { THEME_CONFIG } from "@/lib/theme";
 import type { PieceId } from "@/lib/game/types";
 import { pieceProgressStorageKey } from "@/lib/lite-progress-storage";
@@ -41,14 +42,11 @@ type BadgeInfo = {
 };
 
 function readStarsFromStorage(piece: PieceId): number[] {
-  if (typeof window === "undefined") return [0, 0, 0, 0, 0];
+  if (typeof window === "undefined") return parsePieceStars(null, piece);
   try {
-    const raw = localStorage.getItem(pieceProgressStorageKey(piece));
-    if (!raw) return [0, 0, 0, 0, 0];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed.stars) ? parsed.stars : [0, 0, 0, 0, 0];
+    return parsePieceStars(localStorage.getItem(pieceProgressStorageKey(piece)), piece);
   } catch {
-    return [0, 0, 0, 0, 0];
+    return parsePieceStars(null, piece);
   }
 }
 

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -125,6 +125,7 @@ import { classifyTxError, classifyTxErrorKind, isTransactionTimeout, isUserCance
 import { getContextAction, getRewardActions } from "@/lib/game/context-action";
 import { BADGE_THRESHOLD, labyrinthStars } from "@/lib/game/exercises";
 import { getMaxPossibleStars } from "@/lib/game/progress-adapter";
+import { POINTS_PER_STAR } from "@/lib/game/score";
 import {
   areAllLabyrinthsSolved,
   getLabyrinthBest,
@@ -168,7 +169,7 @@ type SignatureResponse =
   | { error: string };
 
 type PieceKey = "rook" | "bishop" | "knight" | "pawn" | "queen" | "king";
-const POINTS_PER_STAR = 100n;
+const POINTS_PER_STAR_BIG = BigInt(POINTS_PER_STAR);
 
 /**
  * Hold the `<TxProgressSteps current="done">` toast for this many ms after
@@ -823,7 +824,7 @@ export function ExercisesScreen({
   const [paymentToken, setPaymentToken] = useState<PaymentToken | null>(null);
   const feeCurrency = useMemo(() => getMiniPayFeeCurrency(chainId), [chainId]);
   const levelId = useMemo(() => getLevelId(selectedPiece), [selectedPiece]);
-  const score = useMemo(() => BigInt(Math.max(1, totalStars)) * POINTS_PER_STAR, [totalStars]);
+  const score = useMemo(() => BigInt(Math.max(1, totalStars)) * POINTS_PER_STAR_BIG, [totalStars]);
   const maxPossibleStars = useMemo(() => getMaxPossibleStars(selectedPiece), [selectedPiece]);
 
   // v1: tracks last-exercise time only. 1000n fallback after board reset

--- a/apps/web/src/lib/exercises/__tests__/badge-progress.test.ts
+++ b/apps/web/src/lib/exercises/__tests__/badge-progress.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { EXERCISES } from "@/lib/game/exercises";
+import { parsePieceStars } from "@/lib/exercises/badge-progress";
+
+const ROOK_POOL = EXERCISES.rook.length;
+
+function idKeyed(entries: Record<string, number>): string {
+  return JSON.stringify({ piece: "rook", currentId: "rook-1", stars: entries });
+}
+
+describe("parsePieceStars — id-keyed progress (the shape the app writes since 2026-06-16)", () => {
+  it("sums an id-keyed record instead of reading it as a positional array", () => {
+    // 6 exercises × 3★ = 18★ — the founder's real rook progress, which the
+    // badge sheet was scoring as 0 because Array.isArray({...}) is false.
+    const raw = idKeyed({
+      "rook-1": 3,
+      "rook-2": 3,
+      "rook-3": 3,
+      "rook-4": 3,
+      "rook-5": 3,
+      "rook-6": 3,
+    });
+
+    const stars = parsePieceStars(raw, "rook");
+
+    expect(stars).toHaveLength(ROOK_POOL);
+    expect(stars.reduce((a, b) => a + b, 0)).toBe(18);
+  });
+
+  it("orders values by catalog position, not by object key order", () => {
+    const raw = idKeyed({ "rook-3": 3, "rook-1": 1 });
+
+    const stars = parsePieceStars(raw, "rook");
+
+    expect(stars[0]).toBe(1);
+    expect(stars[1]).toBe(0);
+    expect(stars[2]).toBe(3);
+  });
+
+  it("ignores ids that are not in the piece pool", () => {
+    const raw = idKeyed({ "rook-1": 3, "knight-1": 3, "bogus": 3 });
+
+    expect(parsePieceStars(raw, "rook").reduce((a, b) => a + b, 0)).toBe(3);
+  });
+
+  it("clamps out-of-range and non-numeric values", () => {
+    const raw = idKeyed({ "rook-1": 99, "rook-2": -5 });
+    const stars = parsePieceStars(raw, "rook");
+
+    expect(stars[0]).toBe(3);
+    expect(stars[1]).toBe(0);
+  });
+});
+
+describe("parsePieceStars — legacy positional progress", () => {
+  it("still reads a legacy stars array, padded to the current pool length", () => {
+    const raw = JSON.stringify({ piece: "rook", exerciseIndex: 0, stars: [3, 3, 3, 3, 3] });
+
+    const stars = parsePieceStars(raw, "rook");
+
+    expect(stars).toHaveLength(ROOK_POOL);
+    expect(stars.reduce((a, b) => a + b, 0)).toBe(15);
+  });
+});
+
+describe("parsePieceStars — absent or corrupt progress", () => {
+  it.each([
+    ["missing entry", null],
+    ["invalid JSON", "{not json"],
+    ["no stars field", JSON.stringify({ piece: "rook" })],
+    ["stars is a string", JSON.stringify({ piece: "rook", stars: "18" })],
+  ])("returns a zeroed pool-length array for %s", (_label, raw) => {
+    const stars = parsePieceStars(raw, "rook");
+
+    expect(stars).toHaveLength(ROOK_POOL);
+    expect(stars.every((s) => s === 0)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/exercises/badge-progress.ts
+++ b/apps/web/src/lib/exercises/badge-progress.ts
@@ -1,0 +1,52 @@
+/**
+ * Reads a piece's persisted progress into a positional stars array, in
+ * current catalog order and always of pool length.
+ *
+ * Tolerates both storage shapes: the legacy positional `stars: number[]`
+ * and the id-keyed `stars: Record<exerciseId, stars>` written since the
+ * Exercises-Builder migration (2026-06-16). Callers that only handled the
+ * array shape silently scored every piece at 0★ — which is what hid the
+ * badge Claim CTA. `use-hub-data.ts` grew its own tolerant reader for the
+ * same reason; this module is the shared, catalog-aware version.
+ */
+
+import { EXERCISES } from "@/lib/game/exercises";
+import {
+  migrateStarsArrayToIdMap,
+  starsIdMapToArray,
+  type ExerciseStarsById,
+} from "@/lib/game/progress-adapter";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
+import type { PieceId } from "@/lib/game/types";
+
+function zeroed(piece: PieceId, catalog: ExerciseCatalog): number[] {
+  return catalog[piece].map(() => 0);
+}
+
+export function parsePieceStars(
+  raw: string | null,
+  piece: PieceId,
+  catalog: ExerciseCatalog = EXERCISES,
+): number[] {
+  if (!raw) return zeroed(piece, catalog);
+
+  try {
+    const stars: unknown = JSON.parse(raw)?.stars;
+
+    if (Array.isArray(stars)) {
+      return starsIdMapToArray(
+        piece,
+        migrateStarsArrayToIdMap(piece, stars, catalog),
+        catalog,
+      );
+    }
+
+    if (stars && typeof stars === "object") {
+      return starsIdMapToArray(piece, stars as ExerciseStarsById, catalog);
+    }
+
+    return zeroed(piece, catalog);
+  } catch {
+    return zeroed(piece, catalog);
+  }
+}

--- a/apps/web/src/lib/game/__tests__/score.test.ts
+++ b/apps/web/src/lib/game/__tests__/score.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { EXERCISES, PLAYABLE_PIECES } from "@/lib/game/exercises";
+import {
+  POINTS_PER_STAR,
+  getMaxScoreForPiece,
+  getMaxSubmittableScore,
+} from "@/lib/game/score";
+
+describe("score — the submittable ceiling is derived from the catalog", () => {
+  it("scores a piece at 3 stars per exercise", () => {
+    for (const piece of PLAYABLE_PIECES) {
+      expect(getMaxScoreForPiece(piece)).toBe(
+        EXERCISES[piece].length * 3 * POINTS_PER_STAR,
+      );
+    }
+  });
+
+  it("takes the ceiling from the largest pool, so no piece can out-score it", () => {
+    const ceiling = getMaxSubmittableScore();
+
+    for (const piece of PLAYABLE_PIECES) {
+      expect(getMaxScoreForPiece(piece)).toBeLessThanOrEqual(ceiling);
+    }
+    expect(ceiling).toBe(
+      Math.max(...PLAYABLE_PIECES.map((p) => getMaxScoreForPiece(p))),
+    );
+  });
+
+  it("tracks the real catalog: 10 exercises × 3★ × 100 pts = 3000", () => {
+    // Guards the regression: /api/sign-score capped at 1500, which is the
+    // ceiling for a 5-exercise pool. The pools grew to 10 and the cap did
+    // not, so every player past 15★ got a 400 on the on-chain save.
+    expect(getMaxSubmittableScore()).toBe(3000);
+  });
+
+  it("follows a catalog with different pool sizes", () => {
+    const tiny = { rook: [{ id: "r-1" }, { id: "r-2" }] } as unknown as Parameters<
+      typeof getMaxScoreForPiece
+    >[1];
+
+    expect(getMaxScoreForPiece("rook", tiny)).toBe(600);
+  });
+});

--- a/apps/web/src/lib/game/score.ts
+++ b/apps/web/src/lib/game/score.ts
@@ -1,0 +1,46 @@
+/**
+ * Score arithmetic, shared by the client that computes a score and the
+ * server that signs it.
+ *
+ * The two used to state the ceiling independently: `exercises-screen`
+ * multiplied stars by 100, while `/api/sign-score` hardcoded a 1500 cap
+ * described as "15 stars × 100 pts". That cap was the ceiling of a
+ * 5-exercise pool. When the pools grew to 10, every player past 15★ began
+ * getting a 400 on the on-chain save — the better the player, the more
+ * certainly locked out. Deriving the ceiling from the catalog keeps the
+ * bound honest as pools change.
+ *
+ * The cap is still a real anti-cheat bound: it rejects any score the
+ * catalog cannot produce. It is just calibrated instead of guessed.
+ */
+
+import { EXERCISES, PLAYABLE_PIECES } from "@/lib/game/exercises";
+import { getMaxPossibleStars } from "@/lib/game/progress-adapter";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
+import type { PieceId } from "@/lib/game/types";
+
+export const POINTS_PER_STAR = 100;
+
+/** Highest score a perfect run on `piece` can produce. */
+export function getMaxScoreForPiece(
+  piece: PieceId,
+  catalog: ExerciseCatalog = EXERCISES,
+): number {
+  return getMaxPossibleStars(piece, catalog) * POINTS_PER_STAR;
+}
+
+/**
+ * Highest score ANY piece can produce — the bound `/api/sign-score` uses.
+ * Per-piece would be tighter, but the route validates `score` before it
+ * trusts `levelId` to name a piece, so the ceiling is taken across pieces.
+ *
+ * Reads the baseline catalog. A db-content overlay that grows a pool past
+ * the baseline would need this recomputed server-side.
+ */
+export function getMaxSubmittableScore(
+  catalog: ExerciseCatalog = EXERCISES,
+): number {
+  return Math.max(
+    ...PLAYABLE_PIECES.map((piece) => getMaxScoreForPiece(piece, catalog)),
+  );
+}

--- a/docs/audits/2026-07-09-onchain-smoke-root-causes.md
+++ b/docs/audits/2026-07-09-onchain-smoke-root-causes.md
@@ -1,0 +1,113 @@
+# Smoke on-chain — causas raíz (2026-07-09)
+
+Investigación read-only. **Ningún fix aplicado.** Metodología: systematic-debugging,
+Fase 1–3 completas para los dos bugs; Fase 4 (test + fix) pendiente de tu ok.
+
+## Resultado del smoke
+
+| # | Ítem | Resultado |
+|---|------|-----------|
+| 1 | LEARN Save proof (dorado) | 🔴 falla en device con >15★ · CTA aparece = fix #183 OK |
+| 2 | LEARN Claim Badge | 🔴 nunca aparece, para nadie |
+| 3 | LEARN/PLAY Shop Shield | ✅ no es bug — retirado a propósito |
+| 4 | LEARN Get Peones | ✅ |
+| 5 | PLAY Save Victory (permit) | ✅ |
+
+---
+
+## 🔴 Bug 1 — `/api/sign-score` 400: el cap de score es la mitad del score alcanzable
+
+**Evidencia:** tu log de Vercel, `POST /api/sign-score → 400`, 40ms, sin tocar la cadena.
+No es rate limit (sería 429) ni origin (403). Un 400 solo sale de un `parseInteger` fuera de rango.
+
+**Cadena causal:**
+
+```
+exercises-screen.tsx:826   score = max(1, totalStars) * 100n     // totalStars es POR PIEZA
+sign-score/route.ts:31     parseInteger(score, "score", 0, 1_500)  → throw "Invalid score" → 400
+```
+
+El comentario del route dice *"Max score: 15 stars × 100 pts = 1500 per piece level"*.
+Pero el catálogo real (`puzzles.generated.ts`, verificado hoy) tiene **10 ejercicios por pieza
+en las 6 piezas** → `getMaxPossibleStars = 10 × 3 = 30★` → score máximo **3000**.
+
+El cap asume pools de 5 ejercicios. Los pools crecieron a 10 y el cap no se movió.
+
+**Consecuencia:** cruzar 15★ en una pieza **inhabilita permanentemente** el save on-chain de
+esa pieza. Mientras peor juegas, mejor funciona. Tu teléfono viejo tiene 18★ → 1800 > 1500 → 400.
+Web y celu nuevo funcionaban porque su progreso estaba por debajo de 15★. Por eso cerrar y
+reabrir no cambia nada: no es estado corrupto, es el valor del score.
+
+**Blast radius:** cualquier jugador que pase 15★ en cualquier pieza. Es la mitad del recorrido.
+`ScoreboardUpgradeable.submitScoreSigned` acepta `uint256` sin cap, así que el límite es 100%
+del servidor. Los limitadores on-chain (leídos hoy en mainnet: `submitCooldown=60s`,
+`maxSubmissionsPerDay=25`, `paused=false`) están sanos y no intervienen aquí.
+
+**Fix propuesto:** subir el cap a 3000 y atarlo al catálogo con un test, para que no vuelva a
+derivar cuando cambie el tamaño de los pools. El cap sigue siendo una cota anti-cheat legítima;
+solo está mal calibrada.
+
+**Deuda relacionada (no bloqueante):** el frontend no decodifica los custom errors del contrato
+(`CooldownActive` `0xc1ab61a1`, `DailyLimitReached` `0xeba8fe8a`). Si algún día te pega el
+cooldown de 60s, verás el mismo "Try again" genérico y no sabrás por qué. Vale un ticket aparte.
+
+---
+
+## 🔴 Bug 2 — Claim Badge: el sheet lee `stars` como array; hace un año que es un mapa
+
+**No es un problema de descubribilidad. El botón no existe para nadie**, con cualquier número
+de estrellas. Tu instinto de que "debería estar ahí" era correcto.
+
+```
+badge-sheet.tsx:49   Array.isArray(parsed.stars) ? parsed.stars : [0, 0, 0, 0, 0]
+types.ts:102         stars: Record<string, number>   // id-keyed desde 2026-06-16
+```
+
+`Array.isArray()` sobre un objeto da `false` **siempre** → el sheet cae al fallback `[0,0,0,0,0]`
+→ `totalStars = 0` → `earned = 0 >= 10` = false → las 6 piezas se pintan `locked` → el pill verde
+"Claim" nunca se renderiza (`badge-sheet.tsx:151`).
+
+Es una regresión de la migración a progreso id-keyed (cluster Exercises-Builder, 2026-06-16).
+El otro consumidor de la misma clave, `use-hub-data.ts:83-87`, **sí** fue migrado y tolera las dos
+formas — con un comentario que cita la migración por nombre. `badge-sheet.tsx` se quedó afuera.
+
+Daños colaterales del mismo bug: la barra de progreso del sheet siempre marca 0%, y
+`maxStars = stars.length * 3` da 15 en vez de 30.
+
+**Fix propuesto:** reusar el adaptador que ya existe (`progress-adapter.ts`, `starsIdMapToArray`)
+en vez de re-parsear a mano. Test primero, reproduciendo un `stars` id-keyed con 18★.
+
+---
+
+## ✅ No-bug 3 — el Shield ya no se compra en el Shop
+
+Mi checklist estaba mal, no la app. `5c8e0f5d refactor(shop): retire Shield Shop-TX purchase path
+(itemId 2)`: los Shields ahora vienen del Season Pass, del welcome-pack, o de 2 Peones por rescate.
+`SHOP_ITEMS` (shop-catalog.ts:55) contiene PRO + Founder Badge + el sibling CELO, nada más.
+
+Esto además explica el **baseline VR `hub-shop-sheet-open` en rojo**: espera Coach Credits +
+PRO $1.99 + Shield $0.03, tres SKUs retirados. El baseline está viejo, la app está bien.
+Refrescarlo ya no es una decisión de producto, es limpieza.
+
+---
+
+## Lo que pediste como UX (no son bugs, son cambios de diseño)
+
+1. **CTA dorado enterrado en MISSION.** De acuerdo con el diagnóstico. Tu propuesta: llevarlo a la
+   zona de iconos especiales (labyrinth/tactics), o un punto rojo sobre el pill de MISSION.
+2. **Punto rojo de "algo para reclamar"** (como el globo rojo del regalo de tu referencia), como
+   patrón general que guíe hacia lo reclamable.
+
+Ambas son la misma pieza: **un sistema de badge de notificación** para superficies con algo
+pendiente. No las toco sin pasar por el flujo de diseño (GOAL → Sally → mock → código).
+Ojo con el orden: el punto rojo sobre el badge no sirve de nada hasta que el Claim exista (bug 2).
+
+---
+
+## Orden que propongo
+
+1. **Bug 2** (badge) — puro, testeable, sin plata de por medio. Empieza aquí.
+2. **Bug 1** (cap de score) — un número y un test que lo ata al catálogo.
+3. Re-smoke de 1 y 2 en tu teléfono viejo (el de 18★ es el mejor caso de prueba que tenemos).
+4. Refrescar baseline VR del shop.
+5. Sistema de notificación (punto rojo) + reubicación del CTA dorado → flujo de diseño.

--- a/docs/audits/2026-07-09-onchain-smoke-root-causes.md
+++ b/docs/audits/2026-07-09-onchain-smoke-root-causes.md
@@ -104,10 +104,18 @@ Ojo con el orden: el punto rojo sobre el badge no sirve de nada hasta que el Cla
 
 ---
 
-## Orden que propongo
+## Estado
 
-1. **Bug 2** (badge) — puro, testeable, sin plata de por medio. Empieza aquí.
-2. **Bug 1** (cap de score) — un número y un test que lo ata al catálogo.
-3. Re-smoke de 1 y 2 en tu teléfono viejo (el de 18★ es el mejor caso de prueba que tenemos).
-4. Refrescar baseline VR del shop.
-5. Sistema de notificación (punto rojo) + reubicación del CTA dorado → flujo de diseño.
+- ✅ **Bug 2 arreglado** — `ea39727`. Módulo puro `lib/exercises/badge-progress.ts`, 9 tests.
+- ✅ **Bug 1 arreglado** — `lib/game/score.ts` deriva el techo del catálogo; el route lo consume.
+  El test viejo del route mockeaba `parseInteger` entero, así que nunca ejercía el límite: por eso
+  el cap de 1500 sobrevivió al crecimiento de los pools. `route-score-bounds.test.ts` lo ejerce de
+  verdad (1800 → 200, techo+1 → 400).
+
+## Pendiente
+
+1. Re-smoke de 1 y 2 en el teléfono de 18★ — el mejor caso de prueba que tenemos.
+2. Refrescar baseline VR del shop (`hub-shop-sheet-open`).
+3. Decodificar los custom errors del Scoreboard (`CooldownActive`, `DailyLimitReached`) en vez del
+   "Try again" genérico.
+4. Sistema de notificación (punto rojo) + reubicación del CTA dorado → flujo de diseño.

--- a/docs/testing/2026-07-08-onchain-smoke-checklist.md
+++ b/docs/testing/2026-07-08-onchain-smoke-checklist.md
@@ -1,0 +1,77 @@
+# On-chain smoke checklist — LEARN + PLAY (2026-07-08)
+
+**Dónde:** `preview.chesscito.com` desde MiniPay (alias = último `main`, incluye PR #183).
+No uses prod: el canary de Get Peones está **off en Production**, el ítem 4 no sería testeable.
+
+**Ojo — plata real:** preview y prod comparten env de payment rail → **Celo Mainnet 42220**.
+Las txs cuestan de verdad. Presupuesto total del checklist: ~$0.60 + gas.
+
+**Cómo registrar:** cada tx exitosa deja hash. Anótalo o abre Celoscan.
+Para cada ítem: ✅ / ❌ + hash o screenshot del error.
+
+---
+
+## 🔴 Prioridad 1 — el fix de PR #183
+
+### 1. LEARN · CTA dorado "Save proof" (Save today's training proof)
+Esto es lo único que valida el fix. Todo lo demás es cobertura.
+
+1. Wallet conectada, chain Celo, ≥1 estrella en una misión.
+2. Completa un ejercicio y **espera** a que el auto-save off-chain termine (antes desaparecía acá).
+3. Abre el mission sheet desde la peek card.
+4. **El CTA dorado debe seguir visible.**
+5. Tócalo → firma → tx `submitScoreSigned` en Scoreboard `0x1681aAA1…`.
+6. Vuelve a abrir el sheet: **ahora sí debe desaparecer** (ya hay proof on-chain).
+
+Falla esperada si el fix no sirvió: paso 4 no muestra nada.
+Contrato: Scoreboard `0x1681aAA1…` · gas-only, sin costo en tokens.
+
+---
+
+## Prioridad 2 — las 4 txs restantes
+
+### 2. LEARN · Claim Badge
+- Llega al umbral de estrellas (`BADGE_THRESHOLD`) → aparece el badge sheet.
+- Claim → firma → `claimBadgeSigned`, Badges `0xf92759E5…`. Gas-only.
+
+### 3. ~~LEARN · Shop → comprar Streak Shield~~ — NO APLICA
+Ítem inválido. `5c8e0f5d` retiró la compra de Shield del Shop (itemId 2) a propósito: los
+Shields vienen del Season Pass, del welcome-pack o de 2 Peones por rescate. No hay nada
+que smokear. Ver `docs/audits/2026-07-09-onchain-smoke-root-causes.md`.
+
+### 4. LEARN · Get Peones (pack 50)
+- Get Peones → pack $0.50 → `ERC20.transfer(treasury)`, **1 sola tx**.
+- Token auto-seleccionado USDC → USDT → cUSD.
+- **Verifica:** los 50 Peones acreditan y el sheet queda por encima de la Chesito Card (z-index, `1fdf58cb`).
+
+### 5. PLAY · Save Victory (permit)
+- Juega Arena, gana (checkmate) → `VictoryCelebration` full-screen → Save.
+- Easy $0.01 / Med $0.02 / Hard $0.03. VictoryNFT `0x0eE22F83…`.
+- **Lo crítico:** en Celoscan, "Input Data" debe decir **`mintSignedWithPermit`** (selector `b31e32cc`) y ser **UNA sola tx**.
+  Si ves `mintSigned` + un `approve` separado → el permit no está activo, es un bug.
+- Si te sobra tiempo: repetir desde un end-state de derrota/tablas (misma tx, UI inline distinta).
+
+---
+
+## Notas de interpretación
+
+- **El SAVE verde de LEARN no es on-chain.** Es `/api/scores/save` off-chain, gratis desde Lote 2,
+  no aparece en Celoscan. Si lo ves y no hay tx, es correcto.
+- **`Retry save` (neutro)** solo aparece si el auto-save off-chain falla. No lo busques en happy path.
+- **PLAY no tiene save-score al leaderboard.** El leaderboard se ocultó en Lote 1 (B5). Su única tx es la #5.
+- Shields: el cap de 3 es de display/uso, no de crédito. Si compras con 3 activos, el excedente se buferea.
+  Es el caveat aceptado, no un bug.
+
+---
+
+## Resultado
+
+| # | Ítem | ✅/❌ | Hash / nota |
+|---|------|------|-------------|
+| 1 | LEARN Save proof (dorado) | | |
+| 2 | LEARN Claim Badge | | |
+| 3 | LEARN Shop Shield | | |
+| 4 | LEARN Get Peones | | |
+| 5 | PLAY Save Victory (permit) | | |
+
+Si el #1 falla, para y avísame: Lote 2.5 se construiría sobre un fix roto.


### PR DESCRIPTION
Two bugs the founder's on-device smoke found, both fixed with TDD. Neither had a test that could have caught it, and that turned out to be the interesting part.

## Bug 1 — the badge Claim CTA never rendered, for anyone

`badge-sheet.tsx` read persisted progress as `stars: number[]`. The Exercises-Builder migration (2026-06-16) changed the shape to an id-keyed `Record<exerciseId, stars>`. `Array.isArray()` on an object is always false, so every read fell back to `[0,0,0,0,0]`: `totalStars` scored 0, all six pieces rendered `locked`, and the green Claim pill was unreachable at any star count.

The sheet's stats line was wrong for the same reason, showing `0/90 ★` — the denominator derived from the 5-slot fallback rather than the catalog's real 180.

Every other reader of that storage key already tolerated both shapes (`use-hub-data.ts`, `has-progress.ts`, `exercise-progress.ts`). The badge sheet was the one consumer the migration missed. The tolerant read now lives in the pure `lib/exercises/badge-progress.ts` and delegates to the existing `progress-adapter`.

## Bug 2 — crossing 15★ permanently broke a piece's on-chain save

`/api/sign-score` rejected any score above 1500, a bound its own comment justified as "15 stars × 100 pts". That was the ceiling of a **5-exercise** pool. Every piece now ships **10** exercises, so a perfect run scores 3000. Past 15★ on any piece, `parseInteger` threw and the save returned 400 — the better the player, the more certainly locked out. Half the achievable progress was a dead zone.

The founder hit it at 18★ on rook (1800 points) on the phone that had progress, while a fresh phone and the browser sailed through. The route never touched the chain, so the Scoreboard was never at fault; its limiters were read live from mainnet and are healthy (`submitCooldown` 60s, `maxSubmissionsPerDay` 25, `paused` false).

`lib/game/score.ts` now derives the ceiling from the catalog and both the client that computes a score and the server that signs it share it. The cap is still a real anti-cheat bound — it rejects any score the catalog cannot produce — it is just calibrated instead of guessed.

## Why the existing tests were green

Worth stating plainly, because both failures are the same failure:

- The **route** test mocked `parseInteger` wholesale. It asserted "400 when the score is out of range" by making the mock throw, proving the route maps a throw to a 400 while never once exercising the 1500 bound.
- The **badge sheet** test fixture wrote the legacy array shape — a shape the app stopped producing a year ago.

Both suites were verifying a reality that no longer existed. Added `route-score-bounds.test.ts` (real parser: 1800 signs, ceiling signs, ceiling+1 rejects) and a `setStarsById` fixture in the shape the app actually persists.

## Not fixed here

- `Shield` missing from the Shop is **not a bug**: `5c8e0f5d` retired that purchase path. This also explains the stale `hub-shop-sheet-open` VR baseline, which still expects three retired SKUs.
- The frontend does not decode the Scoreboard's custom errors (`CooldownActive`, `DailyLimitReached`), so a future cooldown hit will show the same generic "Try again". Worth its own ticket.
- Discoverability of the golden Save-proof CTA, and a red-dot "something to claim" indicator. Both are design work, and the red dot is worthless until the Claim it points at exists — which is Bug 1.

## Verification

Full suite **4726/4726** passing across 394 files, `tsc --noEmit` clean. No VR baseline covers the badge sheet (`vr14` captures the post-claim ResultOverlay from a fixed dev route), so no snapshots move.

**Still unverified on device.** The founder's 18★ phone reproduces both bugs at once and is the real test.

Wolfcito 🐾 @akawolfcito
