### PR TITLE
fix(scores): guarded ceiling invariant, so the content builder can't resurrect the 400

### DIFF
--- a/apps/web/src/app/api/sign-score/__tests__/route-score-bounds.test.ts
+++ b/apps/web/src/app/api/sign-score/__tests__/route-score-bounds.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { getMaxSubmittableScore } from "@/lib/game/score";
+import { MAX_SUBMITTABLE_SCORE } from "@/lib/game/score";
 
 vi.mock("@/lib/server/demo-signing", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/server/demo-signing")>();
@@ -61,12 +61,18 @@ describe("POST /api/sign-score — score bounds", () => {
     expect((await submit(1800)).status).toEqual(200);
   });
 
-  it("signs a perfect run at the catalog ceiling", async () => {
-    expect((await submit(getMaxSubmittableScore())).status).toEqual(200);
+  it("signs a score above today's pools, as the content builder will produce", async () => {
+    // 11 exercises × 3★ × 100 — a pool the deployed baseline does not have.
+    // The route must not consult the live catalog to accept this.
+    expect((await submit(3300)).status).toEqual(200);
+  });
+
+  it("signs at the ceiling", async () => {
+    expect((await submit(MAX_SUBMITTABLE_SCORE)).status).toEqual(200);
   });
 
   it("rejects a score one point above the ceiling", async () => {
-    const res = await submit(getMaxSubmittableScore() + 1);
+    const res = await submit(MAX_SUBMITTABLE_SCORE + 1);
 
     expect(res.status).toEqual(400);
     expect((await res.json()).error).toEqual("Invalid score");

--- a/apps/web/src/app/api/sign-score/route.ts
+++ b/apps/web/src/app/api/sign-score/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getMaxSubmittableScore } from "@/lib/game/score";
+import { MAX_SUBMITTABLE_SCORE } from "@/lib/game/score";
 import {
   createDeadline,
   createNonce,
@@ -28,9 +28,9 @@ export async function POST(request: Request) {
     await enforceRateLimit(getRequestIp(request), player);
 
     const levelId = parseInteger(body.levelId, "levelId", 1, 10_000);
-    // Ceiling derived from the catalog, never hardcoded: a stale cap silently
-    // rejects the best players. See lib/game/score.ts.
-    const score = parseInteger(body.score, "score", 0, getMaxSubmittableScore());
+    // Input validation, not anti-cheat, and deliberately generous: a tight
+    // ceiling silently locks out the best players. See lib/game/score.ts.
+    const score = parseInteger(body.score, "score", 0, MAX_SUBMITTABLE_SCORE);
     const timeMs = parseInteger(body.timeMs, "timeMs", 1, 3_600_000);
     const nonce = createNonce();
     const deadline = createDeadline();

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -825,7 +825,12 @@ export function ExercisesScreen({
   const feeCurrency = useMemo(() => getMiniPayFeeCurrency(chainId), [chainId]);
   const levelId = useMemo(() => getLevelId(selectedPiece), [selectedPiece]);
   const score = useMemo(() => BigInt(Math.max(1, totalStars)) * POINTS_PER_STAR_BIG, [totalStars]);
-  const maxPossibleStars = useMemo(() => getMaxPossibleStars(selectedPiece), [selectedPiece]);
+  // Must read the SAME catalog `totalStars` is normalized against (the merged
+  // one), or an overlay-added exercise shows the player "33/30".
+  const maxPossibleStars = useMemo(
+    () => getMaxPossibleStars(selectedPiece, catalog),
+    [selectedPiece, catalog],
+  );
 
   // v1: tracks last-exercise time only. 1000n fallback after board reset
   // is safe — on-chain time is informational, not used for scoring.

--- a/apps/web/src/lib/game/__tests__/score.test.ts
+++ b/apps/web/src/lib/game/__tests__/score.test.ts
@@ -2,36 +2,20 @@ import { describe, expect, it } from "vitest";
 
 import { EXERCISES, PLAYABLE_PIECES } from "@/lib/game/exercises";
 import {
+  MAX_EXERCISES_PER_PIECE,
+  MAX_SUBMITTABLE_SCORE,
   POINTS_PER_STAR,
+  STARS_PER_EXERCISE,
   getMaxScoreForPiece,
-  getMaxSubmittableScore,
 } from "@/lib/game/score";
 
-describe("score — the submittable ceiling is derived from the catalog", () => {
+describe("score — what a piece's pool can actually produce", () => {
   it("scores a piece at 3 stars per exercise", () => {
     for (const piece of PLAYABLE_PIECES) {
       expect(getMaxScoreForPiece(piece)).toBe(
-        EXERCISES[piece].length * 3 * POINTS_PER_STAR,
+        EXERCISES[piece].length * STARS_PER_EXERCISE * POINTS_PER_STAR,
       );
     }
-  });
-
-  it("takes the ceiling from the largest pool, so no piece can out-score it", () => {
-    const ceiling = getMaxSubmittableScore();
-
-    for (const piece of PLAYABLE_PIECES) {
-      expect(getMaxScoreForPiece(piece)).toBeLessThanOrEqual(ceiling);
-    }
-    expect(ceiling).toBe(
-      Math.max(...PLAYABLE_PIECES.map((p) => getMaxScoreForPiece(p))),
-    );
-  });
-
-  it("tracks the real catalog: 10 exercises × 3★ × 100 pts = 3000", () => {
-    // Guards the regression: /api/sign-score capped at 1500, which is the
-    // ceiling for a 5-exercise pool. The pools grew to 10 and the cap did
-    // not, so every player past 15★ got a 400 on the on-chain save.
-    expect(getMaxSubmittableScore()).toBe(3000);
   });
 
   it("follows a catalog with different pool sizes", () => {
@@ -40,5 +24,34 @@ describe("score — the submittable ceiling is derived from the catalog", () => 
     >[1];
 
     expect(getMaxScoreForPiece("rook", tiny)).toBe(600);
+  });
+});
+
+describe("score — the submittable ceiling is a product invariant, not a derived value", () => {
+  it("is the invariant, priced out", () => {
+    expect(MAX_SUBMITTABLE_SCORE).toBe(
+      MAX_EXERCISES_PER_PIECE * STARS_PER_EXERCISE * POINTS_PER_STAR,
+    );
+    expect(MAX_SUBMITTABLE_SCORE).toBe(9000);
+  });
+
+  /**
+   * THE GUARD. This is the test that keeps the ceiling from going stale the way
+   * the old hardcoded 1500 did. If a baseline pool ever grows past the
+   * invariant, this fails and forces a deliberate bump of
+   * MAX_EXERCISES_PER_PIECE — instead of silently rejecting the best players.
+   */
+  it("no baseline pool may exceed the invariant", () => {
+    for (const piece of PLAYABLE_PIECES) {
+      expect(EXERCISES[piece].length).toBeLessThanOrEqual(MAX_EXERCISES_PER_PIECE);
+    }
+  });
+
+  it("leaves headroom for exercises added later through the content builder", () => {
+    // The overlay appends to a piece's pool live, with no redeploy. The ceiling
+    // must already cover pools the deployed baseline has never seen.
+    for (const piece of PLAYABLE_PIECES) {
+      expect(getMaxScoreForPiece(piece)).toBeLessThan(MAX_SUBMITTABLE_SCORE);
+    }
   });
 });

--- a/apps/web/src/lib/game/score.ts
+++ b/apps/web/src/lib/game/score.ts
@@ -1,46 +1,59 @@
 /**
- * Score arithmetic, shared by the client that computes a score and the
- * server that signs it.
+ * Score arithmetic for the exercises path.
  *
- * The two used to state the ceiling independently: `exercises-screen`
- * multiplied stars by 100, while `/api/sign-score` hardcoded a 1500 cap
- * described as "15 stars × 100 pts". That cap was the ceiling of a
- * 5-exercise pool. When the pools grew to 10, every player past 15★ began
- * getting a 400 on the on-chain save — the better the player, the more
- * certainly locked out. Deriving the ceiling from the catalog keeps the
- * bound honest as pools change.
+ * `MAX_SUBMITTABLE_SCORE` is the bound `/api/sign-score` validates against.
+ * It is **input validation, not an anti-cheat control** — be clear about this,
+ * because an earlier version of this file claimed otherwise. Nothing ties the
+ * `score` in the request body to real progress: progress lives in the player's
+ * localStorage and the server never sees it. Anyone can POST a maximal score
+ * for a piece they never played and it will be signed. The bound exists only to
+ * keep absurd values out of `signTypedData`. Real cheat resistance would mean
+ * deriving the score server-side from persisted progress — a feature, not a
+ * number.
  *
- * The cap is still a real anti-cheat bound: it rejects any score the
- * catalog cannot produce. It is just calibrated instead of guessed.
+ * So the ceiling is deliberately GENEROUS, and deliberately NOT derived from
+ * the live catalog:
+ *
+ *  - A tight ceiling is what caused the incident this replaces. The route
+ *    hardcoded 1500, described as "15 stars × 100 pts" — the ceiling of a
+ *    5-exercise pool. The pools grew to 10 and the cap did not, so crossing
+ *    15★ on any piece permanently broke that piece's on-chain save with a 400.
+ *    The better the player, the more certainly locked out.
+ *  - Deriving it from the merged catalog would put Supabase on the signing
+ *    path and reintroduce the same 400 intermittently: the page resolves the
+ *    catalog on render, the route would resolve it on save, and
+ *    `getMergedCatalog` is cached with a 60s TTL and a 2s overlay timeout that
+ *    falls back to baseline. Client and server can disagree.
+ *
+ * Instead the ceiling is a product invariant with a test that fails if any
+ * baseline pool ever outgrows it. The number cannot go stale in silence, which
+ * was the original defect. Exercises added through the content builder (which
+ * appends to a pool live, with no redeploy) are covered up to the invariant.
  */
 
-import { EXERCISES, PLAYABLE_PIECES } from "@/lib/game/exercises";
+import { EXERCISES } from "@/lib/game/exercises";
 import { getMaxPossibleStars } from "@/lib/game/progress-adapter";
 import type { ExerciseCatalog } from "@/lib/game/rotation";
 import type { PieceId } from "@/lib/game/types";
 
 export const POINTS_PER_STAR = 100;
+export const STARS_PER_EXERCISE = 3;
 
-/** Highest score a perfect run on `piece` can produce. */
+/** Product invariant: the most exercises we allow a single piece to hold.
+ *  Roughly 3× today's pools — room to keep authoring without touching this.
+ *  Guarded by `score.test.ts`: outgrow it and CI fails, so the bump is a
+ *  decision rather than an outage. */
+export const MAX_EXERCISES_PER_PIECE = 30;
+
+/** The bound `/api/sign-score` validates `score` against. */
+export const MAX_SUBMITTABLE_SCORE =
+  MAX_EXERCISES_PER_PIECE * STARS_PER_EXERCISE * POINTS_PER_STAR;
+
+/** Highest score a perfect run on `piece` can produce, for the given catalog.
+ *  Display and analysis only — never a validation bound (see the note above). */
 export function getMaxScoreForPiece(
   piece: PieceId,
   catalog: ExerciseCatalog = EXERCISES,
 ): number {
   return getMaxPossibleStars(piece, catalog) * POINTS_PER_STAR;
-}
-
-/**
- * Highest score ANY piece can produce — the bound `/api/sign-score` uses.
- * Per-piece would be tighter, but the route validates `score` before it
- * trusts `levelId` to name a piece, so the ceiling is taken across pieces.
- *
- * Reads the baseline catalog. A db-content overlay that grows a pool past
- * the baseline would need this recomputed server-side.
- */
-export function getMaxSubmittableScore(
-  catalog: ExerciseCatalog = EXERCISES,
-): number {
-  return Math.max(
-    ...PLAYABLE_PIECES.map((piece) => getMaxScoreForPiece(piece, catalog)),
-  );
 }

--- a/docs/reviews/2026-07-09-redteam-score-ceiling-plan.md
+++ b/docs/reviews/2026-07-09-redteam-score-ceiling-plan.md
@@ -1,0 +1,104 @@
+# Red-team del plan "techo por pieza desde el catálogo merged" (2026-07-09)
+
+Auto-crítica del plan que propuse para cerrar la clase de bug del cap de `/api/sign-score`
+cuando los ejercicios se agreguen desde el builder (db-content overlay).
+
+**Veredicto: matar los pasos 1 y 2. Conservar el 3. Reemplazar por un invariante explícito.**
+
+---
+
+## Hallazgo 1 (fatal) — el cap no es una defensa anti-cheat, y yo dije que sí
+
+Escribí en `score.ts` y en el mensaje del commit `6b93469`:
+
+> "El cap sigue siendo una cota anti-cheat real: rechaza cualquier score que el catálogo no
+> pueda producir."
+
+Es falso. **Nada ata el `score` del body al progreso real del jugador.** El progreso vive en
+`localStorage`; el servidor no lo ve. Un tramposo hace POST a `/api/sign-score` con
+`{levelId: 1, score: 3000}` sobre una pieza que jamás tocó, y el route lo firma. Siempre pudo.
+
+Entonces, ¿qué compra estrechar el techo de 3000 global a "3000 para torre, 1500 para peón"?
+Impide que el tramposo pida 3300 en vez de 3000. Nada. El bound solo sirve como validación de
+entrada (evitar valores absurdos antes de `signTypedData`), y para eso una cota generosa alcanza.
+
+Corolario: **toda la precisión que perseguía el plan no defiende nada.** Y la corrección de la
+doc/commit es obligatoria: el texto actual le miente al próximo lector.
+
+## Hallazgo 2 (fatal) — mi argumento de "ambos lados degradan juntos" es falso
+
+Se lo vendí al founder como la razón por la que el techo estricto era seguro:
+
+> "Si el overlay se cae, el cliente también sirve baseline, y `calculateTotalStarsFromIdMap`
+> descarta los ids desconocidos. Los dos lados degradan juntos."
+
+Correlacionado ≠ sincronizado. Son **dos requests distintos**:
+
+- `page.tsx:89` resuelve el catálogo al renderizar.
+- `/api/sign-score` lo resolvería al guardar, minutos después.
+- `getMergedCatalog` es `unstable_cache` con `revalidate: 60s` (`merged-catalog.ts:237`) y el
+  fetch del overlay tiene `OVERLAY_TIMEOUT_MS = 2000` (`:39`), con fallback silencioso a baseline.
+
+O sea: el cliente puede tener el catálogo con overlay en mano (11 ejercicios → 3300 pts) mientras
+el route, un minuto más tarde o durante un timeout de 2s, resuelve baseline y topa en 3000. **400.**
+
+Es exactamente el bug que estamos cerrando, reintroducido en versión rara e intermitente. Y "raro"
+aquí es *peor*, no mejor: el bug original lo cazó un smoke porque era determinista. Este no
+aparecería en ningún smoke; aparecería en el teléfono de un jugador, una vez, sin repro.
+
+## Hallazgo 3 (serio) — mete Supabase en la ruta de firma, a cambio de nada
+
+Hoy `/api/sign-score` depende solo de Upstash (rate limit). El plan le agregaría una lectura del
+catálogo respaldada por Supabase, con timeout de 2s, en el camino crítico de una operación de
+firma. Un hipo del content-DB pasaría a rechazar guardados on-chain.
+
+Se paga blast radius y latencia en un endpoint sensible, para comprar el bound del Hallazgo 1,
+que no defiende nada.
+
+---
+
+## Lo que sí sobrevive
+
+**Paso 3 (arreglar `exercises-screen.tsx:828`) se mantiene.** `getMaxPossibleStars(selectedPiece)`
+ignora el catálogo merged mientras `totalStars` lo usa. Con un ejercicio agregado por overlay, la
+UI mostraría "33/30". Es un bug de display real (`maxPossibleStars` solo alimenta un prop del
+mission sheet, `:2312`, sin gates), barato y sin acoplamiento nuevo.
+
+---
+
+## Contra-propuesta
+
+Un invariante de producto explícito, generoso, y testeado — sin DB en la ruta de firma:
+
+```
+MAX_EXERCISES_PER_PIECE = 30        // decisión de producto, no un dato derivado
+ceiling = MAX_EXERCISES_PER_PIECE * 3 * POINTS_PER_STAR   // 9000
+```
+
+- El route sigue **puro y síncrono**. Cero deps nuevas.
+- Agregar ejercicios por el builder O por `content/exercises.json` funciona sin tocar nada,
+  hasta 30 por pieza.
+- Un test afirma que **ningún pool del baseline excede el invariante**. Si algún día lo excedes,
+  CI falla y te obliga a subir la constante a conciencia. El número nunca se queda viejo en
+  silencio, que es la falla original.
+- Pools desiguales: irrelevante, el techo es uno solo y holgado.
+
+Costo honesto: el bound queda flojo. Dado el Hallazgo 1, flojo no cuesta nada.
+
+## Si de verdad quieres anti-cheat
+
+No es un cap. Es progreso verificable en el servidor (Supabase), y el score se deriva ahí, no se
+recibe del body. Es una feature, no un número. Fuera de alcance hoy; vale un backlog item.
+
+## Acciones
+
+1. ✅ Claim anti-cheat corregido en `score.ts` (el commit `6b93469` queda impreciso en el
+   historial; el código y la doc ya no lo repiten).
+2. ✅ Contra-propuesta implementada con TDD: `MAX_EXERCISES_PER_PIECE = 30` → techo 9000,
+   route puro y síncrono. El test guardián falla si un pool baseline supera el invariante.
+3. ✅ `exercises-screen.tsx` pasa el catálogo merged a `getMaxPossibleStars`. Sin seam
+   aislable (no hay harness de `ExercisesScreen`): cubierto por tsc + los tests de catálogo
+   del adapter, no por un test propio. Si se quiere cobertura, hay que extraer el seam.
+4. ⏳ Backlog: progreso verificable server-side (el único anti-cheat real).
+
+Suite 4728/4728, tsc limpio.


### PR DESCRIPTION
Follow-up to #186. The founder is about to start adding exercises and labyrinths per piece through the content builder, with uneven pool sizes. That is precisely the path on which the score-cap bug comes back, so we closed the class rather than the instance.

The first plan for closing it — derive the ceiling from the merged catalog, per piece — was red-teamed and killed. Full write-up in `docs/reviews/2026-07-09-redteam-score-ceiling-plan.md`. Two findings sank it.

## The cap is not an anti-cheat control, and #186 said it was

Nothing ties the `score` in the request body to real progress. Progress lives in the player's localStorage; the server never sees it. Anyone can POST a maximal score for a piece they never played and `/api/sign-score` will sign it. It always could.

So tightening the bound from "3000 globally" to "3000 for rook, 1500 for pawn" would have stopped a cheater from asking for 3300 instead of 3000 — which is to say it would have stopped nothing. The bound is input validation before `signTypedData`. That is all it ever was. `score.ts` now says so plainly; the claim in `6b93469`'s message stands uncorrected in history.

## Deriving it from the live catalog would have reintroduced the same 400

The page resolves the catalog on render (`page.tsx:89`). The route would resolve it on save. `getMergedCatalog` is `unstable_cache` with a 60s TTL, behind a 2s overlay timeout that falls back to baseline. Those are two requests against a cache that can expire between them, so the client can hold an overlay pool of 11 exercises (3300 points) while the route tops out at the baseline's 10 (3000). Same rejection — now intermittent, and without a reproduction.

That is strictly worse than the bug being fixed. The original was deterministic and a smoke caught it. This one would surface on one player's phone, once.

It would also have put Supabase on the signing path, which today depends on Upstash alone.

## What shipped instead

An explicit product invariant, `MAX_EXERCISES_PER_PIECE = 30` (roughly 3× today's pools), priced at 9000 points. The route stays pure and synchronous, with no new dependencies.

The load-bearing piece is the guard test: **if any baseline pool ever outgrows the invariant, CI fails.** That forces a deliberate bump instead of a silent rejection of the best players — which is exactly how the original 1500 survived the pools doubling from 5 to 10. Exercises added through the builder (which appends to a pool live, no redeploy) are covered up to the invariant. Uneven pools stop mattering: the ceiling is one number, and it is generous.

The honest cost: the bound is loose. Given the first finding, loose costs nothing.

## Also fixed

`exercises-screen` derived `maxPossibleStars` from the baseline catalog while `totalStars` is normalized against the merged one. An overlay-added exercise would have shown the player `33/30`. There is no `ExercisesScreen` test harness, so this wiring rests on `tsc` and the adapter's existing catalog tests rather than a test of its own — stated plainly rather than papered over.

## Not in scope

Real cheat resistance means deriving the score server-side from persisted progress. That is a feature, not a number. Backlogged.

Labyrinths were checked and do not feed the score: `labyrinthStars` writes to `recordLabyrinthBest`, never to `progress.stars`. They can be authored freely.

## Verification

Full suite **4728/4728** across 394 files, `tsc --noEmit` clean. The RED that mattered: `submit(3300)` returned 400 before this change and 200 after — the future bug, caught before it could happen.

Wolfcito 🐾 @akawolfcito
