### PR TITLE
fix(content): cap the pool at the builder write, and raise the invariant to 100/piece

### DIFF
--- a/apps/web/src/app/api/admin/content/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/content/__tests__/route.test.ts
@@ -23,12 +23,24 @@ vi.mock("@/lib/server/demo-signing", () => ({
 const supabaseMock = vi.hoisted(() => ({
   from: vi.fn(),
   upsert: vi.fn(),
+  select: vi.fn(),
 }));
 vi.mock("@/lib/supabase/server", () => ({
   getSupabaseServer: vi.fn(() => supabaseMock),
 }));
 
+/** Minimal stand-in for the postgrest builder: `.eq()` chains, `await` resolves. */
+function selectChain(result: { data: { id: string }[] | null; error: unknown }) {
+  const chain: Record<string, unknown> = {
+    eq: () => chain,
+    then: (resolve: (value: typeof result) => unknown) => resolve(result),
+  };
+  return chain;
+}
+
 import { POST } from "../route";
+import { EXERCISES } from "@/lib/game/exercises";
+import { MAX_EXERCISES_PER_PIECE } from "@/lib/game/score";
 import { revalidateTag } from "next/cache";
 import { enforceRateLimit } from "@/lib/server/demo-signing";
 import { getSupabaseServer } from "@/lib/supabase/server";
@@ -69,10 +81,21 @@ function authed(body: unknown) {
   return req({ kind: "exercise", record: body }, { "x-admin-token": TOKEN });
 }
 
+/** Pretend the piece already carries these enabled overlay exercises. */
+function withStoredOverlay(ids: string[], error: unknown = null) {
+  supabaseMock.select.mockReturnValue(
+    selectChain({ data: error ? null : ids.map((id) => ({ id })), error }),
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  supabaseMock.from.mockReturnValue({ upsert: supabaseMock.upsert });
+  supabaseMock.from.mockReturnValue({
+    upsert: supabaseMock.upsert,
+    select: supabaseMock.select,
+  });
   supabaseMock.upsert.mockResolvedValue({ error: null });
+  withStoredOverlay([]);
   mockedSupabase.mockReturnValue(supabaseMock as never);
   process.env.ADMIN_TOKEN = TOKEN;
 });
@@ -135,5 +158,69 @@ describe("POST /api/admin/content", () => {
     expect(opts).toMatchObject({ onConflict: "kind,id,stage" });
     expect(row).toMatchObject({ stage: "draft" }); // Save lands at draft
     expect(mockedRevalidate).toHaveBeenCalledWith("content");
+  });
+});
+
+describe("POST /api/admin/content — pool capacity", () => {
+  /** Overlay ids that bring rook's merged pool to exactly `size`. */
+  function fillTo(size: number) {
+    const extra = size - EXERCISES.rook.length;
+    return Array.from({ length: extra }, (_, i) => `rook-extra-${i}`);
+  }
+
+  it("accepts the write that lands exactly on the invariant", async () => {
+    withStoredOverlay(fillTo(MAX_EXERCISES_PER_PIECE - 1));
+
+    const res = await POST(authed(validRecord()));
+
+    expect(res.status).toBe(200);
+    expect(supabaseMock.upsert).toHaveBeenCalled();
+  });
+
+  it("refuses, and never writes, the exercise that would outgrow the invariant", async () => {
+    // The player-facing failure this prevents: a pool past the invariant lets
+    // the client compute a score above MAX_SUBMITTABLE_SCORE, and every
+    // on-chain save for that piece starts returning 400.
+    withStoredOverlay(fillTo(MAX_EXERCISES_PER_PIECE));
+
+    const res = await POST(authed(validRecord()));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.errors[0]).toContain(String(MAX_EXERCISES_PER_PIECE));
+    expect(supabaseMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it("still accepts a write that disables an exercise when the pool is over the cap", async () => {
+    withStoredOverlay(fillTo(MAX_EXERCISES_PER_PIECE + 5));
+
+    const res = await POST(authed(validRecord({ disabled: true })));
+
+    expect(res.status).toBe(200);
+    expect(supabaseMock.upsert).toHaveBeenCalled();
+  });
+
+  it("does not cap labyrinths — they never feed the score", async () => {
+    withStoredOverlay(fillTo(MAX_EXERCISES_PER_PIECE + 5));
+
+    const res = await POST(
+      req(
+        { kind: "labyrinth", record: validRecord({ kind: "labyrinth" }) },
+        { "x-admin-token": TOKEN },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(supabaseMock.upsert).toHaveBeenCalled();
+  });
+
+  it("fails closed, never writing, when the capacity read errors", async () => {
+    withStoredOverlay([], { message: "boom" });
+
+    const res = await POST(authed(validRecord()));
+
+    expect(res.status).toBe(500);
+    expect(supabaseMock.upsert).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/admin/content/route.ts
+++ b/apps/web/src/app/api/admin/content/route.ts
@@ -17,6 +17,8 @@ import { NextResponse } from "next/server";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { revalidateTag } from "next/cache";
 import { buildCatalog, type LabyrinthRecord } from "@/lib/content/catalog";
+import { exceedsPoolCap, projectedPoolSize } from "@/lib/content/pool-capacity";
+import { MAX_EXERCISES_PER_PIECE } from "@/lib/game/score";
 import { getSupabaseServer } from "@/lib/supabase/server";
 import { enforceRateLimit, getRequestIp } from "@/lib/server/demo-signing";
 import type {
@@ -92,6 +94,46 @@ export async function POST(request: Request) {
   const built = pool[record.piece]?.find((e) => e.id === record.id);
   if (!built) return err(["validation produced no puzzle"], 400);
 
+  const supabase = getSupabaseServer();
+  if (!supabase) return err(["content store unavailable"], 503);
+
+  // 5b. Pool capacity. A piece grown past MAX_EXERCISES_PER_PIECE lets the client
+  //     compute a score above MAX_SUBMITTABLE_SCORE, and every on-chain save for
+  //     that piece starts failing with a 400 — for the player, not for us. Refuse
+  //     here instead, where the author reads the message and reacts. Labyrinths
+  //     are exempt: they never feed the score.
+  if (kind === "exercise") {
+    const { data: storedIds, error: capacityError } = await supabase
+      .from("content_overlay")
+      .select("id")
+      .eq("kind", "exercise")
+      .eq("piece", record.piece)
+      .eq("disabled", false);
+
+    // Fail closed: without a reliable count we cannot promise the invariant.
+    if (capacityError || !storedIds) {
+      return err([capacityError?.message ?? "capacity check failed"], 500);
+    }
+
+    const capacity = {
+      piece: record.piece,
+      recordId: record.id,
+      disabled: Boolean(record.disabled),
+      overlayIds: storedIds.map((r: { id: string }) => r.id),
+    };
+    if (exceedsPoolCap(capacity)) {
+      return err(
+        [
+          `pool for "${record.piece}" would reach ${projectedPoolSize(capacity)} exercises, ` +
+            `over the ${MAX_EXERCISES_PER_PIECE} allowed per piece. ` +
+            `Raise MAX_EXERCISES_PER_PIECE in lib/game/score.ts (it also raises the ` +
+            `score ceiling the signer validates), or disable an exercise first.`,
+        ],
+        400,
+      );
+    }
+  }
+
   // 6. Persist the delta. optimal_moves is BFS-verified (trusted by read path).
   const updated_at = new Date().toISOString();
   const row: ContentOverlayRow = {
@@ -113,8 +155,6 @@ export async function POST(request: Request) {
     stage: "draft",
   };
 
-  const supabase = getSupabaseServer();
-  if (!supabase) return err(["content store unavailable"], 503);
   const { error } = await supabase
     .from("content_overlay")
     .upsert(row, { onConflict: "kind,id,stage" });

--- a/apps/web/src/lib/content/__tests__/pool-capacity.test.ts
+++ b/apps/web/src/lib/content/__tests__/pool-capacity.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { EXERCISES } from "@/lib/game/exercises";
+import { exceedsPoolCap, projectedPoolSize } from "@/lib/content/pool-capacity";
+
+const ROOK_BASELINE = EXERCISES.rook.length;
+
+function input(over: Partial<Parameters<typeof projectedPoolSize>[0]> = {}) {
+  return {
+    piece: "rook" as const,
+    recordId: "rook-overlay-1",
+    disabled: false,
+    overlayIds: [] as readonly string[],
+    ...over,
+  };
+}
+
+describe("projectedPoolSize — what the merged pool becomes after this write", () => {
+  it("counts a brand-new overlay exercise on top of the baseline", () => {
+    expect(projectedPoolSize(input())).toBe(ROOK_BASELINE + 1);
+  });
+
+  it("does not grow when the write overwrites a baseline exercise", () => {
+    expect(projectedPoolSize(input({ recordId: EXERCISES.rook[0].id }))).toBe(ROOK_BASELINE);
+  });
+
+  it("does not double-count an overlay id that is already stored", () => {
+    expect(
+      projectedPoolSize(input({ recordId: "rook-overlay-1", overlayIds: ["rook-overlay-1"] })),
+    ).toBe(ROOK_BASELINE + 1);
+  });
+
+  it("counts every distinct overlay id already stored", () => {
+    expect(
+      projectedPoolSize(input({ recordId: "rook-overlay-3", overlayIds: ["rook-overlay-1", "rook-overlay-2"] })),
+    ).toBe(ROOK_BASELINE + 3);
+  });
+
+  it("shrinks the pool when the write disables an overlay exercise", () => {
+    expect(
+      projectedPoolSize(input({ recordId: "rook-overlay-1", overlayIds: ["rook-overlay-1"], disabled: true })),
+    ).toBe(ROOK_BASELINE);
+  });
+
+  it("shrinks the pool when the write disables a baseline exercise", () => {
+    expect(
+      projectedPoolSize(input({ recordId: EXERCISES.rook[0].id, disabled: true })),
+    ).toBe(ROOK_BASELINE - 1);
+  });
+});
+
+describe("exceedsPoolCap — the builder is where a too-large pool must be refused", () => {
+  it("allows a write that lands exactly on the cap", () => {
+    const overlayIds = Array.from({ length: 4 }, (_, i) => `rook-extra-${i}`);
+
+    expect(
+      exceedsPoolCap(input({ recordId: "rook-extra-last", overlayIds, cap: ROOK_BASELINE + 5 })),
+    ).toBe(false);
+  });
+
+  it("refuses the write that would push the pool one past the cap", () => {
+    const overlayIds = Array.from({ length: 5 }, (_, i) => `rook-extra-${i}`);
+
+    expect(
+      exceedsPoolCap(input({ recordId: "rook-extra-last", overlayIds, cap: ROOK_BASELINE + 5 })),
+    ).toBe(true);
+  });
+
+  it("never refuses a write that shrinks the pool, even when already over the cap", () => {
+    const overlayIds = Array.from({ length: 9 }, (_, i) => `rook-extra-${i}`);
+
+    expect(
+      exceedsPoolCap(
+        input({ recordId: "rook-extra-0", overlayIds, disabled: true, cap: ROOK_BASELINE + 5 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("defaults to the score invariant, so the builder and the signer agree", async () => {
+    const { MAX_EXERCISES_PER_PIECE } = await import("@/lib/game/score");
+    const overlayIds = Array.from(
+      { length: MAX_EXERCISES_PER_PIECE - ROOK_BASELINE },
+      (_, i) => `rook-extra-${i}`,
+    );
+
+    expect(exceedsPoolCap(input({ recordId: "one-too-many", overlayIds }))).toBe(true);
+  });
+});

--- a/apps/web/src/lib/content/pool-capacity.ts
+++ b/apps/web/src/lib/content/pool-capacity.ts
@@ -1,0 +1,66 @@
+/**
+ * Pool capacity for the content builder.
+ *
+ * `/api/sign-score` validates a submitted score against `MAX_SUBMITTABLE_SCORE`,
+ * which is priced from `MAX_EXERCISES_PER_PIECE`. Nothing stopped the builder
+ * from growing a piece's pool past that: the overlay appends exercises live,
+ * and the guard test in `score.test.ts` only inspects the BASELINE catalog. A
+ * piece grown past the invariant through the builder would have silently
+ * reproduced the 400 that broke on-chain saves — for the player, not the author.
+ *
+ * So the refusal belongs here, at the write. Rejecting the author is cheap: he
+ * sees the message and adjusts. Rejecting the player is an incident.
+ *
+ * Only exercises are capped. Labyrinths do not feed the score (`labyrinthStars`
+ * writes to `recordLabyrinthBest`, never to `progress.stars`).
+ */
+
+import { EXERCISES } from "@/lib/game/exercises";
+import { MAX_EXERCISES_PER_PIECE } from "@/lib/game/score";
+import type { ExerciseCatalog } from "@/lib/game/rotation";
+import type { PieceId } from "@/lib/game/types";
+
+export type PoolCapacityInput = {
+  piece: PieceId;
+  /** id of the exercise being written. */
+  recordId: string;
+  /** true when this write disables (removes) the exercise. */
+  disabled: boolean;
+  /** ids of the ENABLED exercise overlay rows already stored for this piece. */
+  overlayIds: readonly string[];
+  /** Defaults to the score invariant — the two must never drift apart. */
+  cap?: number;
+  baseline?: ExerciseCatalog;
+};
+
+/**
+ * Size of the merged pool once this write lands. The overlay replaces a
+ * baseline exercise when ids collide and appends otherwise, so the projection
+ * is a set union — never a sum.
+ */
+export function projectedPoolSize({
+  piece,
+  recordId,
+  disabled,
+  overlayIds,
+  baseline = EXERCISES,
+}: PoolCapacityInput): number {
+  const ids = new Set<string>(baseline[piece].map((exercise) => exercise.id));
+  for (const id of overlayIds) ids.add(id);
+
+  if (disabled) ids.delete(recordId);
+  else ids.add(recordId);
+
+  return ids.size;
+}
+
+/**
+ * True when this write must be refused. A write that SHRINKS the pool is always
+ * allowed, so an author who somehow lands over the cap can still dig out.
+ */
+export function exceedsPoolCap(input: PoolCapacityInput): boolean {
+  if (input.disabled) return false;
+
+  const cap = input.cap ?? MAX_EXERCISES_PER_PIECE;
+  return projectedPoolSize(input) > cap;
+}

--- a/apps/web/src/lib/game/__tests__/score.test.ts
+++ b/apps/web/src/lib/game/__tests__/score.test.ts
@@ -32,7 +32,9 @@ describe("score — the submittable ceiling is a product invariant, not a derive
     expect(MAX_SUBMITTABLE_SCORE).toBe(
       MAX_EXERCISES_PER_PIECE * STARS_PER_EXERCISE * POINTS_PER_STAR,
     );
-    expect(MAX_SUBMITTABLE_SCORE).toBe(9000);
+    // Pinned so raising the invariant is a deliberate edit, never a drift.
+    expect(MAX_EXERCISES_PER_PIECE).toBe(100);
+    expect(MAX_SUBMITTABLE_SCORE).toBe(30_000);
   });
 
   /**

--- a/apps/web/src/lib/game/score.ts
+++ b/apps/web/src/lib/game/score.ts
@@ -40,10 +40,17 @@ export const POINTS_PER_STAR = 100;
 export const STARS_PER_EXERCISE = 3;
 
 /** Product invariant: the most exercises we allow a single piece to hold.
- *  Roughly 3× today's pools — room to keep authoring without touching this.
- *  Guarded by `score.test.ts`: outgrow it and CI fails, so the bump is a
- *  decision rather than an outage. */
-export const MAX_EXERCISES_PER_PIECE = 30;
+ *  Sized for the authoring roadmap (~100 per piece), not for today's 10.
+ *
+ *  Enforced in TWO places, and they must stay in sync:
+ *   - `score.test.ts` fails if a BASELINE pool outgrows it;
+ *   - `/api/admin/content` refuses a builder write that would outgrow it,
+ *     which is the path the overlay actually uses (`lib/content/pool-capacity.ts`).
+ *
+ *  Raising it is a one-line decision. Leaving it stale is an outage: the score
+ *  ceiling below is priced from it, and a pool past the ceiling makes every
+ *  on-chain save for that piece fail with a 400. */
+export const MAX_EXERCISES_PER_PIECE = 100;
 
 /** The bound `/api/sign-score` validates `score` against. */
 export const MAX_SUBMITTABLE_SCORE =

--- a/docs/testing/2026-07-09-re-smoke-checklist.md
+++ b/docs/testing/2026-07-09-re-smoke-checklist.md
@@ -1,0 +1,63 @@
+# Re-smoke — 3 fixes (2026-07-09)
+
+**Dónde:** `preview.chesscito.com` desde MiniPay, con el **teléfono de 18★** (el que fallaba).
+Ese device reproduce los tres bugs a la vez; en uno nuevo no verías nada.
+
+**Plata real:** Celo Mainnet. Todo este checklist es **gas-only**, ~$0 en tokens.
+
+**Antes de empezar:** confirma que el preview trae `195ce2a6` o posterior.
+
+---
+
+## 1. Badge Claim — el botón que no existía
+
+Abre el sheet de badges (tab del dock).
+
+- [ ] La **torre** aparece como **Claimable**, con el pill verde `Claim`.
+      Antes: las 6 piezas en `Locked`, sin importar tus estrellas.
+- [ ] La línea de stats dice algo como `18/180 ★`, no `0/90 ★`.
+      Ambos números estaban mal: el numerador siempre 0, el denominador con pools de 5.
+- [ ] Toca `Claim` → firma → tx a Badges `0xf92759E5…`. Gas-only.
+- [ ] Tras el claim, la torre pasa a **Owned**.
+
+**Si el pill verde no aparece:** el fix no llegó, o tu torre tiene <10★. Revisa el contador.
+
+## 2. Save proof on-chain — el 400 con 18★
+
+- [ ] Con la torre en 18★, abre el mission sheet y toca el CTA dorado.
+- [ ] Debe **firmar** y mandar tx a Scoreboard `0x1681aAA1…`. Gas-only.
+      Antes: `POST /api/sign-score → 400` en 40ms, la tx nunca salía.
+- [ ] Vuelve a abrir el sheet: el CTA dorado ya **no** debe estar (ya hay proof on-chain).
+
+**Cómo confirmar que fue de verdad:** busca la tx en Celoscan, método `submitScoreSigned`.
+
+**Ojo con el cooldown:** el contrato tiene `submitCooldown = 60s` y `maxSubmissionsPerDay = 25`.
+Si guardas dos veces seguidas verás un error genérico "Try again" que en realidad es el cooldown.
+No es un bug nuevo; es la deuda de decodificar los custom errors. Espera un minuto.
+
+## 3. Display de estrellas (sanity, no bloqueante)
+
+- [ ] El mission sheet muestra el máximo de la pieza como **30**, no 15.
+      Solo se notaría si el catálogo crece; se verifica de paso.
+
+---
+
+## Qué NO smokear
+
+- **Shield en el Shop**: no existe, se retiró en `5c8e0f5d`. No es un bug.
+- **Laberintos**: no alimentan el score. Nada que verificar acá.
+- **PLAY Save Victory** y **Get Peones**: ya pasaron el 2026-07-08, sin cambios desde entonces.
+
+---
+
+## Resultado
+
+| # | Ítem | ✅/❌ | Hash / nota |
+|---|------|------|-------------|
+| 1 | Badge Claim visible + tx | | |
+| 1b | Stats line `18/180 ★` | | |
+| 2 | Save proof firma (era 400) | | |
+| 2b | CTA dorado desaparece post-proof | | |
+| 3 | Máximo de pieza = 30 | | |
+
+Si el 2 pasa, LEARN queda con su primer smoke on-chain completo y se puede cerrar el bloque.


### PR DESCRIPTION
Closes a hole opened by #187, found while thinking through the authoring roadmap: the founder is about to add exercises per piece, unevenly, through the content builder.

## The guard was watching the wrong door

#187 shipped a test that fails if a **baseline** pool outgrows `MAX_EXERCISES_PER_PIECE`. But the content builder does not write to the baseline — it appends to the Supabase overlay, live, with no redeploy. `merged-catalog.ts:135` does `list.push(entry)` for an id the baseline has never seen, and `/api/admin/content` BFS-validates the puzzle without ever looking at pool size.

So growing rook to 35 exercises through the builder kept CI green, while the player's client computed `35 × 3 × 100 = 10500` against a ceiling of 9000 and every on-chain save for that piece started returning 400.

That is the original defect wearing a different hat: **two sources of truth, one of them watched.** The guard protected the path we are not going to use.

## The refusal belongs at the write

`/api/admin/content` now projects what the merged pool becomes after the write and rejects anything that would outgrow the invariant, naming the number and telling the author what to do about it.

Rejecting the author is cheap: he reads the message and adjusts. Rejecting the player is an incident with no message at all — it is the incident we spent this whole session fixing.

Design notes, each with a test:

- The projection is a **set union, not a sum**. The overlay replaces a baseline exercise when ids collide and appends otherwise, so re-saving an existing exercise never grows the pool.
- A write that **disables** an exercise is always allowed, even when the pool is already over the cap. An author who lands over it can still dig out.
- The capacity read **fails closed** (500, no upsert). Without a reliable count we cannot promise the invariant, and this route is fail-closed everywhere else.
- **Labyrinths are exempt.** `labyrinthStars` writes to `recordLabyrinthBest` and never touches `progress.stars`, so they do not feed the score. Authored freely.

## The number

`MAX_EXERCISES_PER_PIECE` rises from 30 to **100**, sized for the authoring roadmap rather than for today's pools of 10, taking the score ceiling to 30,000. The 30 was chosen as "3× today", which quietly coupled the invariant to current content — the very coupling this line of work exists to remove.

The test pins both `100` and `30_000`, so the next bump is a deliberate edit rather than a drift. The cost of raising it is one line; the cost of leaving it stale is an outage.

## Still open, and it is a design question, not a bug

The score is cumulative mastery per piece, so it is pool-size dependent: a player from a 100-exercise era has a ceiling 10× a player from a 10-exercise era, and the two are not comparable. Progress lives in localStorage and never resets, so "reset per season" has nothing to grip. If seasons and regional leaderboards are the plan, the scoring model wants normalizing (permille of mastery) before much on-chain history accumulates — cheap now, expensive later. Going to `gds-agent-game-designer` next.

## Verification

Full suite **4743/4743** across 395 files, `tsc --noEmit` clean.

Wolfcito 🐾 @akawolfcito
