### PR TITLE
fix(exercises): unpin the daily-limit progression deadlock

### DIFF
--- a/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
@@ -75,6 +75,41 @@ describe("ExerciseDrawer — rotation (visibleExerciseIds set)", () => {
     expect(screen.queryByText("Vertical move")).not.toBeInTheDocument(); // rook-2
   });
 
+  /* Regression (2026-07-09): rotation hid every exercise the player had
+   * already solved, so the sheet could show nothing but locked nodes and
+   * offered no way to replay finished work. Completed exercises always
+   * belong on the path, whether or not today's rotation picked them. */
+  it("always renders completed exercises outside today's visible set", () => {
+    render(
+      <ExerciseDrawer
+        {...baseProps}
+        stars={starsById(3, 2)} // rook-1, rook-2 completed; neither is in `visible`
+        totalStars={5}
+        onNavigate={vi.fn()}
+        visibleExerciseIds={visible}
+      />,
+    );
+    expect(screen.getByText("Horizontal move")).toBeInTheDocument(); // rook-1
+    expect(screen.getByText("Vertical move")).toBeInTheDocument(); // rook-2
+    // Unplayed and unrotated stays hidden.
+    expect(screen.queryByText("Corner capture")).not.toBeInTheDocument(); // rook-4
+  });
+
+  it("a completed exercise surfaced by the rotation fix is replayable", () => {
+    const onNavigate = vi.fn();
+    render(
+      <ExerciseDrawer
+        {...baseProps}
+        stars={starsById(3, 2)}
+        totalStars={5}
+        onNavigate={onNavigate}
+        visibleExerciseIds={visible}
+      />,
+    );
+    clickRow("Horizontal move"); // rook-1 → pool index 0
+    expect(onNavigate).toHaveBeenCalledWith(0);
+  });
+
   it("visible-set exercises are still gated by the linear senda", () => {
     // rook-8 (pool index 7) is in the visible set but senda still applies:
     // with stars={} maxAllowed=0, so index 7 > 0 → locked.

--- a/apps/web/src/components/exercises/exercise-drawer.tsx
+++ b/apps/web/src/components/exercises/exercise-drawer.tsx
@@ -138,7 +138,10 @@ export function ExerciseDrawer({
   }
 
   function lockedFor(exercise: Exercise, index: number): boolean {
-    if (rotationOn && !visibleExerciseIds!.has(exercise.id)) return true
+    const isDone = (stars[exercise.id] ?? 0) > 0
+    // Rotation gates only fresh exercises. Solved ones stay open forever.
+    if (rotationOn && !isDone && !visibleExerciseIds!.has(exercise.id))
+      return true
     return index > maxAllowed
   }
 
@@ -148,10 +151,15 @@ export function ExerciseDrawer({
     onNavigate(index)
   }
 
+  // Rotation picks today's fresh set, but anything already solved stays on
+  // the path — the player must always be able to walk back and replay it.
   const rows = exercises
     .map((exercise, index) => ({ exercise, index }))
     .filter(
-      ({ exercise }) => !rotationOn || visibleExerciseIds!.has(exercise.id),
+      ({ exercise }) =>
+        !rotationOn ||
+        visibleExerciseIds!.has(exercise.id) ||
+        (stars[exercise.id] ?? 0) > 0,
     )
 
   const orderedRows = interleaveTrainingRows(rows, labyrinthNodes ?? [])

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -1290,9 +1290,12 @@ export function ExercisesScreen({
       hapticSuccess();
       // Session-over freeze: once the daily limit is reached the player can
       // keep replaying completed exercises as practice, but no stars are
-      // persisted. Read the quota BEFORE recordExtraConsumed below so the
-      // attempt that *reaches* the limit (a fresh exercise) still counts.
-      const scoringFrozen = shouldFreezeScoring(CHESSCITO_LITE_MODE, getDailySession());
+      // persisted. A fresh solve always persists — see shouldFreezeScoring.
+      const scoringFrozen = shouldFreezeScoring(
+        CHESSCITO_LITE_MODE,
+        getDailySession(),
+        isReplay,
+      );
       // Compute earned stars + bump streak BEFORE setPhase so the
       // WELL DONE PhaseFlash sees both on its first render.
       //
@@ -2136,15 +2139,14 @@ export function ExercisesScreen({
         position.rank === activeLabyrinth.targetPos.rank;
       if (!reached) return;
       const stars = labyrinthStars(movesCount, activeLabyrinth.optimalMoves);
-      // Session-over freeze: practice replays past the daily limit do not
-      // update the recorded best (read quota before recordExtraConsumed below).
-      const scoringFrozen = shouldFreezeScoring(CHESSCITO_LITE_MODE, getDailySession());
+      // Labyrinths sit outside the daily session: they never spend a quota
+      // slot and their best is never frozen. They feed no score, so there is
+      // nothing to farm — and the path auto-advances the player into one,
+      // which used to silently eat the slot the next exercise needed.
       // Read previous best BEFORE recording so the overlay can
       // contextualize the new score against the player's history.
       const previousBest = getLabyrinthBest(selectedPiece, activeLabyrinth.id);
-      const isNewBest = scoringFrozen
-        ? false
-        : recordLabyrinthBest(selectedPiece, activeLabyrinth.id, movesCount);
+      const isNewBest = recordLabyrinthBest(selectedPiece, activeLabyrinth.id, movesCount);
       setLabyrinthCompleted({
         moves: movesCount,
         optimal: activeLabyrinth.optimalMoves,
@@ -2152,11 +2154,6 @@ export function ExercisesScreen({
         previousBest,
         isNewBest,
       });
-
-      // B2.3a: track extra content consumption (Lite-only; idempotent).
-      if (CHESSCITO_LITE_MODE) {
-        recordExtraConsumed(buildContentId("labyrinth", selectedPiece, activeLabyrinth.id));
-      }
 
       track("labyrinth_complete", {
         labyrinth_id: activeLabyrinth.id,

--- a/apps/web/src/lib/daily/__tests__/session-quota.test.ts
+++ b/apps/web/src/lib/daily/__tests__/session-quota.test.ts
@@ -228,26 +228,26 @@ describe("computeApplyDevUnlock", () => {
 // ─── CONSTANTS sanity check ───────────────────────────────────────────────────
 
 describe("constants", () => {
-  it("FREE_EXTRA_QUOTA is 5", () => expect(FREE_EXTRA_QUOTA).toBe(5));
+  it("FREE_EXTRA_QUOTA is 10 (the session default)", () => expect(FREE_EXTRA_QUOTA).toBe(10));
   it("PACK_EXTRA_SLOTS is 5", () => expect(PACK_EXTRA_SLOTS).toBe(5));
-  it("HARD_MAX_EXTRAS equals free + 2 packs = 15", () => expect(HARD_MAX_EXTRAS).toBe(15));
+  it("HARD_MAX_EXTRAS equals free + 2 packs = 20", () => expect(HARD_MAX_EXTRAS).toBe(20));
 });
 
 // ─── parseSessionLimit (single env-backed knob) ──────────────────────────────
 
 describe("parseSessionLimit", () => {
-  it("defaults to 5 when unset", () => {
-    expect(parseSessionLimit(undefined)).toBe(5);
+  it("defaults to 10 when unset", () => {
+    expect(parseSessionLimit(undefined)).toBe(10);
   });
   it("parses a positive integer string", () => {
     expect(parseSessionLimit("8")).toBe(8);
   });
-  it("falls back to 5 for non-numeric values", () => {
-    expect(parseSessionLimit("abc")).toBe(5);
+  it("falls back to 10 for non-numeric values", () => {
+    expect(parseSessionLimit("abc")).toBe(10);
   });
-  it("falls back to 5 for zero or negative values", () => {
-    expect(parseSessionLimit("0")).toBe(5);
-    expect(parseSessionLimit("-3")).toBe(5);
+  it("falls back to 10 for zero or negative values", () => {
+    expect(parseSessionLimit("0")).toBe(10);
+    expect(parseSessionLimit("-3")).toBe(10);
   });
   it("SESSION_EXERCISE_LIMIT is the source of FREE_EXTRA_QUOTA", () => {
     expect(FREE_EXTRA_QUOTA).toBe(SESSION_EXERCISE_LIMIT);

--- a/apps/web/src/lib/daily/__tests__/session-quota.test.ts
+++ b/apps/web/src/lib/daily/__tests__/session-quota.test.ts
@@ -134,16 +134,16 @@ describe("isAtFreeLimit", () => {
   it("false when only 2 consumed", () => {
     expect(isAtFreeLimit(sessionWith(["exercise:rook:rook-1", "exercise:rook:rook-2"]))).toBe(false);
   });
-  it("false when only 3 consumed (free quota is now 5)", () => {
-    const ids = ["exercise:rook:rook-1", "exercise:rook:rook-2", "exercise:rook:rook-3"];
+  it("false one short of the free quota", () => {
+    const ids = Array.from({ length: FREE_EXTRA_QUOTA - 1 }, (_, i) => `exercise:rook:rook-${i + 1}`);
     expect(isAtFreeLimit(sessionWith(ids, 0))).toBe(false);
   });
-  it("true when 5 consumed and no paid packs", () => {
-    const ids = Array.from({ length: 5 }, (_, i) => `exercise:rook:rook-${i + 1}`);
+  it("true at the free quota with no paid packs", () => {
+    const ids = Array.from({ length: FREE_EXTRA_QUOTA }, (_, i) => `exercise:rook:rook-${i + 1}`);
     expect(isAtFreeLimit(sessionWith(ids, 0))).toBe(true);
   });
-  it("false when 5 consumed but has paid pack (remaining slots available)", () => {
-    const ids = Array.from({ length: 5 }, (_, i) => `exercise:rook:rook-${i + 1}`);
+  it("false at the free quota when a paid pack adds room", () => {
+    const ids = Array.from({ length: FREE_EXTRA_QUOTA }, (_, i) => `exercise:rook:rook-${i + 1}`);
     expect(isAtFreeLimit(sessionWith(ids, 1))).toBe(false);
   });
   it("false when at hard max (uses isAtHardMax instead)", () => {
@@ -279,13 +279,28 @@ describe("isSessionOver", () => {
 describe("shouldFreezeScoring", () => {
   it("never freezes when not in Lite mode", () => {
     const ids = Array.from({ length: FREE_EXTRA_QUOTA }, (_, i) => `exercise:rook:rook-${i + 1}`);
-    expect(shouldFreezeScoring(false, sessionWith(ids, 0))).toBe(false);
+    expect(shouldFreezeScoring(false, sessionWith(ids, 0), true)).toBe(false);
   });
   it("does not freeze in Lite before the limit", () => {
-    expect(shouldFreezeScoring(true, sessionWith(["exercise:rook:rook-1"]))).toBe(false);
+    expect(shouldFreezeScoring(true, sessionWith(["exercise:rook:rook-1"]), true)).toBe(false);
   });
-  it("freezes in Lite once the session is over", () => {
+  it("freezes a replay in Lite once the session is over", () => {
     const ids = Array.from({ length: FREE_EXTRA_QUOTA }, (_, i) => `exercise:rook:rook-${i + 1}`);
-    expect(shouldFreezeScoring(true, sessionWith(ids, 0))).toBe(true);
+    expect(shouldFreezeScoring(true, sessionWith(ids, 0), true)).toBe(true);
+  });
+
+  /* Regression (2026-07-09): a session-over freeze applied to a FRESH
+   * exercise discarded its first stars. Progression gates on those stars
+   * (`lastCompleted + 1` in exercise-drawer), so the player stayed pinned
+   * on that exercise forever — no 10★, no badge. A first solve always
+   * persists; the daily limit is enforced by locking fresh content in the
+   * drawer, not by silently voiding a solve already on the board. */
+  it("never freezes a fresh exercise, even past the limit", () => {
+    const ids = Array.from({ length: FREE_EXTRA_QUOTA }, (_, i) => `exercise:rook:rook-${i + 1}`);
+    expect(shouldFreezeScoring(true, sessionWith(ids, 0), false)).toBe(false);
+  });
+  it("never freezes a fresh exercise at hard max", () => {
+    const ids = Array.from({ length: HARD_MAX_EXTRAS }, (_, i) => `exercise:rook:rook-${i}`);
+    expect(shouldFreezeScoring(true, sessionWith(ids, 2), false)).toBe(false);
   });
 });

--- a/apps/web/src/lib/daily/session-quota.ts
+++ b/apps/web/src/lib/daily/session-quota.ts
@@ -113,12 +113,19 @@ export function isSessionOver(state: DailySessionState): boolean {
 
 /** Whether star/progress writes should be frozen for this completion.
  *  Lite-only: once the session is over, replays are practice and must not
- *  add stars or improve recorded bests. */
+ *  add stars or improve recorded bests.
+ *
+ *  A FRESH solve (isReplay=false) is never frozen. Progression gates on
+ *  persisted stars — the drawer unlocks up to `lastCompleted + 1` — so
+ *  voiding a first solve pins the player on that exercise for good. The
+ *  daily limit is enforced by locking fresh content in the drawer, never
+ *  by discarding a solve the player already has on the board. */
 export function shouldFreezeScoring(
   liteMode: boolean,
   state: DailySessionState,
+  isReplay: boolean,
 ): boolean {
-  return liteMode && isSessionOver(state);
+  return liteMode && isReplay && isSessionOver(state);
 }
 
 // ─── Pure state transitions ──────────────────────────────────────────────────

--- a/apps/web/src/lib/daily/session-quota.ts
+++ b/apps/web/src/lib/daily/session-quota.ts
@@ -20,10 +20,11 @@ import { dispatchDailySessionChanged } from "@/lib/daily/session-events";
 
 /** Single source of truth for how many exercises a daily session grants
  *  before it ends ("Great focus today!"). Tune it with ONE env var,
- *  `NEXT_PUBLIC_CHESSCITO_SESSION_LIMIT` (defaults to 5). */
+ *  `NEXT_PUBLIC_CHESSCITO_SESSION_LIMIT` (defaults to 10 — one full piece
+ *  at 3★ each, so the 10★ badge stays reachable in a single good day). */
 export function parseSessionLimit(raw: string | undefined): number {
   const n = raw ? Number.parseInt(raw, 10) : NaN;
-  return Number.isFinite(n) && n > 0 ? n : 5;
+  return Number.isFinite(n) && n > 0 ? n : 10;
 }
 
 export const SESSION_EXERCISE_LIMIT = parseSessionLimit(


### PR DESCRIPTION
## What happened

On the 18★ device the player could solve exercise 5 forever and never advance: no new stars, no 10★, no Claim Badge. The exercises sheet showed nodes 6 and 7, both locked, and nothing else.

Three defects stacked:

1. **`shouldFreezeScoring` voided fresh solves.** Past the daily limit it froze *every* completion, first solves included. The drawer unlocks up to `lastCompleted + 1`, and `lastCompleted` reads persisted stars — so a fresh exercise solved past the limit pinned the player on it permanently. WELL DONE flashed; the stars went nowhere.
2. **Labyrinths spent a session slot.** `getLabyrinthForAutoAdvance` pushes the player into a labyrinth unprompted, so the day burned as `ex1..ex4 + labyrinth` and the 5th exercise was born frozen. Labyrinths feed no score; there was nothing to farm.
3. **Rotation hid completed exercises.** The sheet filtered to today's visible set and `lockedFor` rejected the rest again on the same rule, leaving a sheet with nothing tappable.

The reset landing at UTC midnight (19:00 in UTC-5) is why the modal offered 7 hours after a 20-hour wait. Working as designed, but it is what kept the deadlock alive across sessions.

## Why the suite was green

`session-quota.test.ts` only exercised the `shouldFreezeScoring` predicate in isolation. Nothing covered the composition frozen → 0★ → drawer gate. Both new regressions are written against that seam.

## Also here

Session limit 5 → 10 (one full piece at 3★ each). `NEXT_PUBLIC_CHESSCITO_SESSION_LIMIT` is build-time and already updated in Preview/Production; it needs a redeploy to take effect.

## Verification

- `pnpm exec tsc --noEmit` clean, eslint clean on touched files.
- **4747 passing (395 files)**, run before each commit. Baseline was 4743; the 4 new tests are the regressions above.
- No VR baseline covers the exercises drawer, so none went stale.

## Left deliberately

A *fresh* labyrinth is still gated once the session ends — it no longer spends a slot, but `isLabReplayable` treats it as new content. Consistent with "session over, nothing new", worth revisiting.

Wolfcito 🐾 @akawolfcito