### PR TITLE
docs(learn): close the 2026-07-09 re-smoke + progression deadlock handoff

### DIFF
--- a/docs/backlog/2026-07-09-piece-unlocked-modal-visual-vocabulary.md
+++ b/docs/backlog/2026-07-09-piece-unlocked-modal-visual-vocabulary.md
@@ -1,0 +1,53 @@
+# Backlog — El modal "Piece Unlocked" quedó fuera del vocabulario visual
+
+**Detectado:** 2026-07-09, durante el re-smoke de LEARN en device.
+**Severidad:** cosmético. No bloquea nada.
+**Superficie:** `exercises-screen.tsx:2740-2766`.
+
+## Qué se ve
+
+El modal de desbloqueo de pieza (`Bishop Unlocked!`) llega justo después del
+`Badge Earned!`, y los dos no parecen del mismo juego:
+
+| | Badge Earned | Piece Unlocked |
+| --- | --- | --- |
+| Fondo | Panel con arte, marco verde, banda crema | `CandyGlassShell` — lima plano, sin marco |
+| CTA | Verde, primario del sistema | `variant="game-primary"` — marrón |
+| Cierre | Botón rojo de asset | Botón rojo de asset (este sí coincide) |
+
+Aparecen **en secuencia**, así que el salto se nota de golpe. El marrón del
+`Start Bishop` además compite con el marrón del texto del título en vez de
+leerse como la acción de la pantalla.
+
+## Qué hay que hacer
+
+Alinear el modal con el vocabulario del `BadgeEarnedPrompt` (`result-overlay.tsx`)
+y del `DailyLimitBanner` (`daily-limit-banner.tsx`), que ya comparten el patrón
+de panel con wallpaper de arte + CTA verde.
+
+Antes de tocar nada:
+
+1. **Auditar los assets canónicos** en `public/art/**`. El `DailyLimitBanner` usa
+   `bg-sesion-great.png/webp/avif`; puede existir ya un fondo reusable para el
+   unlock, o hay que pedirlo en resolución correcta (nunca upscalear).
+2. **No mintear un 6.º CTA.** `globals.css :root` ya define 5 familias de tokens
+   de CTA (`cta-token-system`). Consumir una existente; `/dev/button-gallery` las
+   muestra todas.
+3. El modal monta `sparkle-burst.lottie`. Es preexistente, se conserva; la regla
+   es no agregar Lotties nuevas.
+
+## Proceso
+
+Es un rediseño de UI, así que aplica `feedback_goal_then_mock_then_code`: el
+founder fija el GOAL, Sally (`bmad-agent-ux-designer`) critica, sale un mock, y
+recién ahí código. El mock decide la estructura, nunca el acabado.
+
+Al tocarlo, refrescar los baselines VR en el mismo PR.
+
+## Relacionado
+
+- `docs/handoffs/2026-07-09-daily-session-progression-deadlock-handoff.md` — la
+  sesión donde apareció.
+- El `MAX_STARS` hardcodeado del `Badge Earned` (`result-overlay.tsx:113`) toca
+  el mismo archivo vecino. Se pueden agrupar si se abre el cluster de pulido de
+  celebraciones.

--- a/docs/handoffs/2026-07-09-daily-session-progression-deadlock-handoff.md
+++ b/docs/handoffs/2026-07-09-daily-session-progression-deadlock-handoff.md
@@ -1,0 +1,120 @@
+# Handoff — Deadlock de progresión de la sesión diaria (2026-07-09)
+
+**Estado: CERRADO y verificado en device.** PR [#191](https://github.com/akawolfcito/chesscito/pull/191)
+mergeado a `main` (`0f44eadc`). Suite **4747 passing / 395 files**.
+El re-smoke de LEARN pasó completo contra `preview.chesscito.com`.
+
+---
+
+## Qué pasaba
+
+En el teléfono de 18★, el jugador resolvía el ejercicio 5, veía **WELL DONE**, y
+no ganaba nada: ni estrellas, ni el ejercicio 6, ni las 10★ del badge. El sheet
+de ejercicios mostraba los nodos 6 y 7, **ambos locked**, y nada más. Volver 20
+horas después no lo destrababa.
+
+Tres defectos apilados, todos con la suite en verde.
+
+### 1. El freeze anulaba los solves frescos
+
+`shouldFreezeScoring` congelaba **toda** completion una vez agotada la sesión
+diaria, incluido el primer solve de un ejercicio. La progresión se calcula sobre
+las estrellas persistidas — el drawer desbloquea hasta `lastCompleted + 1` — así
+que un ejercicio fresco resuelto pasado el límite dejaba al jugador clavado en
+él **para siempre**. El WELL DONE aparecía; las estrellas se tiraban.
+
+**Fix:** el freeze aplica solo a *replays*. El límite diario se aplica bloqueando
+contenido nuevo en el drawer, nunca anulando un solve que ya está en el tablero.
+
+### 2. Los laberintos gastaban ranura de sesión
+
+`getLabyrinthForAutoAdvance()` mete al jugador a un laberinto sin pedírselo, así
+que el día se consumía como `ej1..ej4 + laberinto` y **el 5.º ejercicio nacía
+congelado**. Los laberintos no alimentan el score: no había nada que farmear.
+
+**Fix:** los laberintos salen de la cuota. No gastan ranura ni congelan su best.
+
+### 3. La rotación escondía los ejercicios completados
+
+El sheet filtraba a los ids visibles de hoy y `lockedFor()` los rechazaba otra
+vez por la misma regla. Resultado: un sheet sin nada tapeable.
+
+**Fix:** la rotación gatea solo ejercicios frescos. Lo resuelto queda en la senda
+y sigue siendo tapeable.
+
+### Por qué "20 horas" no reseteaba
+
+El reset cae en medianoche **UTC**, que en UTC-5 son las 19:00 locales. Una
+sesión de noche y una tarde del día siguiente caen en el mismo día UTC. Por eso
+el modal ofrecía 7 horas tras 20 de espera. Funciona como fue diseñado, pero es
+lo que mantuvo vivo el deadlock entre sesiones.
+
+---
+
+## Por qué la suite estaba verde
+
+`session-quota.test.ts` probaba el predicado `shouldFreezeScoring` **aislado**.
+Nadie probaba la composición `congelado → 0★ → gate del drawer`. Otra instancia
+de `feedback_tests_green_against_dead_shape`: una suite verde puede verificar una
+realidad muerta.
+
+Las dos regresiones nuevas se escribieron contra esa costura. Y el test del
+drawer atrapó un segundo gate que se me había pasado: dejar de filtrar la fila no
+bastaba, porque `lockedFor()` volvía a bloquear por rotación.
+
+---
+
+## Commits
+
+| Commit | Qué |
+| --- | --- |
+| `9644ce52` | `fix(exercises)`: el freeze no toca un solve fresco; laberintos fuera de la cuota |
+| `bb6c686f` | `fix(exercises)`: los completados vuelven a la senda y son tapeables |
+| `624e67e7` | `feat(daily)`: límite de sesión 5 → 10 |
+
+**Producto:** el límite subió a 10 (una pieza completa a 3★ cada uno), porque con
+5 la sesión se acababa apenas empezaba y el badge quedaba a dos días.
+`NEXT_PUBLIC_CHESSCITO_SESSION_LIMIT` es build-time y ya está actualizado en
+Preview/Production por el founder. Un registro cubre ambos entornos.
+
+---
+
+## Verificado
+
+- `pnpm exec tsc --noEmit` limpio; eslint limpio en los archivos tocados.
+- **4747 passing (395 files)**, corrido antes de cada commit. Baseline 4743.
+- Los tests fallaban por la razón correcta antes del fix (4 rojos).
+- Ningún baseline VR cubre el drawer de ejercicios; ninguno quedó obsoleto.
+- **En device, contra preview:** el ejercicio 5 guarda estrellas, el 6 abre, el
+  badge de la torre se clamó ([`0x327e80ae…`](https://celoscan.io/tx/0x327e80aee165a4aa2486458038ad252a453fb9432ed16732c6a67dec9c96ff4b)),
+  la torre quedó **Owned**. La save proof no volvió a dar 400.
+
+---
+
+## Próximos pasos
+
+1. **`MAX_STARS` hardcodeado en el modal Badge Earned.** `result-overlay.tsx:113`
+   usa `EXERCISES_PER_PIECE * 3` (= 15) en vez del pool real, y `getCardUrl()`
+   clampa a 15 (`:181`, `:186`). Con la torre en 12★ y un pool de 10 el modal
+   dijo `12/15` y la tarjeta de Share hereda el error. Mismo patrón que #187, que
+   arregló el sheet pero no este modal. Cosmético; barato de cerrar.
+2. **Decodificar los custom errors.** `BadgeAlreadyClaimed`, `CooldownActive`
+   (`0xc1ab61a1`), `DailyLimitReached` (`0xeba8fe8a`). Hoy los tres salen como un
+   "Try again" genérico que no dice nada.
+3. **Refrescar el baseline VR `hub-shop-sheet-open`** — espera 3 SKUs retirados.
+   Deuda previa, no de este PR.
+
+## Preguntas abiertas
+
+- **¿Un laberinto fresco debe poder jugarse pasado el límite?** Ya no gasta
+  ranura, pero `isLabReplayable()` lo trata como contenido nuevo y lo bloquea. Es
+  coherente con "sesión terminada, nada nuevo", pero ahora es una decisión de
+  producto y no una consecuencia del código.
+- **¿El reset debe ser UTC o local?** Para un jugador en UTC-5 el día nuevo entra
+  a las 19:00, en plena sesión de noche. Cambiarlo a local rompe la rotación
+  determinista compartida entre devices; dejarlo confunde. Sin decidir.
+- **`/api/sign-badge` no verifica las estrellas.** Firma cualquier `levelId` entre
+  1 y 10000 (`sign-badge/route.ts:23`); el gate de 10★ vive solo en el cliente.
+  El contrato impide clamar **dos veces**, no clamar **sin merecerlo**. Es el
+  "server-verified progress" ya anotado como el único anti-cheat real, y hay que
+  cerrarlo antes de que un badge valga dinero.

--- a/docs/testing/2026-07-09-re-smoke-checklist.md
+++ b/docs/testing/2026-07-09-re-smoke-checklist.md
@@ -1,63 +1,68 @@
-# Re-smoke — 3 fixes (2026-07-09)
+# Re-smoke — 3 fixes (2026-07-09) — ✅ CERRADO
 
-**Dónde:** `preview.chesscito.com` desde MiniPay, con el **teléfono de 18★** (el que fallaba).
-Ese device reproduce los tres bugs a la vez; en uno nuevo no verías nada.
+**Dónde:** `preview.chesscito.com` desde MiniPay, con el **teléfono de 18★**.
+**Ejecutado:** 2026-07-09, en device real, contra preview con `0f44eadc`.
+**Resultado: los 3 ítems pasan.** LEARN tiene su primer smoke on-chain completo.
 
-**Plata real:** Celo Mainnet. Todo este checklist es **gas-only**, ~$0 en tokens.
-
-**Antes de empezar:** confirma que el preview trae `195ce2a6` o posterior.
-
----
-
-## 1. Badge Claim — el botón que no existía
-
-Abre el sheet de badges (tab del dock).
-
-- [ ] La **torre** aparece como **Claimable**, con el pill verde `Claim`.
-      Antes: las 6 piezas en `Locked`, sin importar tus estrellas.
-- [ ] La línea de stats dice algo como `18/180 ★`, no `0/90 ★`.
-      Ambos números estaban mal: el numerador siempre 0, el denominador con pools de 5.
-- [ ] Toca `Claim` → firma → tx a Badges `0xf92759E5…`. Gas-only.
-- [ ] Tras el claim, la torre pasa a **Owned**.
-
-**Si el pill verde no aparece:** el fix no llegó, o tu torre tiene <10★. Revisa el contador.
-
-## 2. Save proof on-chain — el 400 con 18★
-
-- [ ] Con la torre en 18★, abre el mission sheet y toca el CTA dorado.
-- [ ] Debe **firmar** y mandar tx a Scoreboard `0x1681aAA1…`. Gas-only.
-      Antes: `POST /api/sign-score → 400` en 40ms, la tx nunca salía.
-- [ ] Vuelve a abrir el sheet: el CTA dorado ya **no** debe estar (ya hay proof on-chain).
-
-**Cómo confirmar que fue de verdad:** busca la tx en Celoscan, método `submitScoreSigned`.
-
-**Ojo con el cooldown:** el contrato tiene `submitCooldown = 60s` y `maxSubmissionsPerDay = 25`.
-Si guardas dos veces seguidas verás un error genérico "Try again" que en realidad es el cooldown.
-No es un bug nuevo; es la deuda de decodificar los custom errors. Espera un minuto.
-
-## 3. Display de estrellas (sanity, no bloqueante)
-
-- [ ] El mission sheet muestra el máximo de la pieza como **30**, no 15.
-      Solo se notaría si el catálogo crece; se verifica de paso.
-
----
-
-## Qué NO smokear
-
-- **Shield en el Shop**: no existe, se retiró en `5c8e0f5d`. No es un bug.
-- **Laberintos**: no alimentan el score. Nada que verificar acá.
-- **PLAY Save Victory** y **Get Peones**: ya pasaron el 2026-07-08, sin cambios desde entonces.
+**Plata real:** Celo Mainnet. Todo fue gas-only, ~$0 en tokens.
 
 ---
 
 ## Resultado
 
 | # | Ítem | ✅/❌ | Hash / nota |
-|---|------|------|-------------|
-| 1 | Badge Claim visible + tx | | |
-| 1b | Stats line `18/180 ★` | | |
-| 2 | Save proof firma (era 400) | | |
-| 2b | CTA dorado desaparece post-proof | | |
-| 3 | Máximo de pieza = 30 | | |
+| --- | --- | --- | --- |
+| 1 | Badge Claim visible + tx | ✅ | [`0x327e80ae…`](https://celoscan.io/tx/0x327e80aee165a4aa2486458038ad252a453fb9432ed16732c6a67dec9c96ff4b) — torre quedó **Owned** |
+| 1b | Stats line no arranca en `0/90 ★` | ✅ | HUD mostró `★ 12` |
+| 2 | Save proof firma (era 400) | ✅ | Sin errores; el 400 con 18★ no reapareció |
+| 2b | CTA dorado desaparece post-proof | ✅ | |
+| 3 | Máximo de pieza = 30, no 15 | ⚠️ | El mission sheet sí; el modal **Badge Earned** todavía dice `12/15` (ver abajo) |
 
-Si el 2 pasa, LEARN queda con su primer smoke on-chain completo y se puede cerrar el bloque.
+---
+
+## 1. Badge Claim — el botón que no existía
+
+El pill verde `Claim` apareció sobre la torre y la tx entró. La torre pasó a **Owned**.
+
+**Nota de contrato:** el badge se clama **una sola vez por pieza y por wallet**.
+`BadgesUpgradeable.claimBadgeSigned()` guarda `hasClaimedBadge[player][levelId]`
+y revierte con `BadgeAlreadyClaimed` en el segundo intento
+(`BadgesUpgradeable.sol:112`). Es **soulbound**: `_update()` revierte cualquier
+transferencia que no sea el mint (`:150`). Seis piezas, seis claims posibles.
+
+Si vuelves a tocar Claim vas a ver un "Try again" genérico — es el
+`BadgeAlreadyClaimed` sin decodificar, no un bug nuevo.
+
+## 2. Save proof on-chain — el 400 con 18★
+
+Firma y manda tx a Scoreboard `0x1681aAA1…`. Gas-only. Confirmado en device.
+
+**Ojo con el cooldown:** `submitCooldown = 60s`, `maxSubmissionsPerDay = 25`.
+Dos saves seguidos dan un "Try again" que en realidad es el cooldown.
+
+## 3. Display de estrellas
+
+El mission sheet muestra el máximo real del pool. **El modal `Badge Earned` no.**
+Mostró `12/15` con la torre en 12★. `result-overlay.tsx:113` hardcodea
+`MAX_STARS = EXERCISES_PER_PIECE * 3` (5 × 3 = 15) en vez de leer el pool real,
+y `getCardUrl()` clampa las estrellas a 15 (`:181`, `:186`), así que la tarjeta
+de Share también miente. Cosmético, no bloquea. Ver el handoff.
+
+---
+
+## El bloqueo que descubrió este re-smoke
+
+El re-smoke no pudo arrancar hasta arreglar un deadlock de progresión: el
+jugador resolvía el ejercicio 5 una y otra vez sin ganar estrellas ni
+desbloquear el 6. Tres defectos apilados, arreglados en el PR #191
+(`0f44eadc`). Detalle completo en
+`docs/handoffs/2026-07-09-daily-session-progression-deadlock-handoff.md`.
+
+---
+
+## Qué NO se smokeó
+
+- **Shield en el Shop**: no existe, se retiró en `5c8e0f5d`. No es un bug.
+- **PLAY Save Victory** y **Get Peones**: pasaron el 2026-07-08, sin cambios.
+- **Laberintos**: ya no gastan cupo diario (#191). Un laberinto **fresco** sigue
+  bloqueado al llegar al límite de sesión — decisión de producto abierta.


### PR DESCRIPTION
Docs only. No code.

- **`docs/testing/2026-07-09-re-smoke-checklist.md`** — the three items pass on the 18★ device against preview. Badge claim tx `0x327e80ae…`, rook Owned. Adds the contract note: one claim per (piece, wallet), soulbound, and a second attempt surfaces as a generic "Try again" because `BadgeAlreadyClaimed` is still undecoded. Item 3 lands ⚠️: the mission sheet reads the real pool, the Badge Earned modal does not.
- **`docs/handoffs/2026-07-09-daily-session-progression-deadlock-handoff.md`** — the three stacked defects behind PR #191, why a green suite verified a dead reality, what was verified on device, and the open questions (fresh labyrinth past the limit, UTC vs local reset, `/api/sign-badge` signing without checking stars).
- **`docs/backlog/2026-07-09-piece-unlocked-modal-visual-vocabulary.md`** — the Piece Unlocked modal uses a flat lime shell + brown CTA while the Badge Earned modal it immediately follows uses an art panel + green CTA. Audit `public/art/**` first, consume an existing CTA token family, mock before code.

Wolfcito 🐾 @akawolfcito