### PR TITLE
docs: close the 2026-07-09 session, retarget the continuation prompt

### DIFF
--- a/docs/backlog/2026-07-09-pending-work-triage.md
+++ b/docs/backlog/2026-07-09-pending-work-triage.md
@@ -1,0 +1,90 @@
+# Triage de pendientes — 2026-07-09
+
+Auditado **contra el código**, no contra las listas. Dos entradas del backlog ya
+estaban cerradas y nadie lo había anotado; un baseline VR está rojo ahora mismo.
+
+---
+
+## 0. Ya está hecho — corregir los docs
+
+| Item | Estado real | Evidencia |
+| --- | --- | --- |
+| 🔴 "CTA dorado Save proof casi inalcanzable" (`2026-07-08-lote2-smoke-findings`) | **ARREGLADO** en #183 | `canSaveOnChain` ya no comparte `scorePendingNew`; usa `deriveCanSaveOnChain()` gateado por ausencia de recibo real (`exercises-screen.tsx:1066`) |
+| Backlog LEARN **#4 Post-Focus Free Practice** | **ARREGLADO** en #191 | `isExerciseReplayable()` deja rejugar todo lo completado y el drawer ya los muestra (`exercise-drawer.tsx:120`) |
+
+El doc de smoke findings todavía los describe como abiertos. Eso es deriva de
+documentación: el próximo que lo lea va a trabajar sobre un bug que no existe.
+
+---
+
+## 1. Barato y cerrable hoy (< 1h cada uno)
+
+**a. Baseline VR `hub-shop-sheet-open` — está ROJO.** Verificado corriéndolo.
+Espera 3 SKUs retirados (`5c8e0f5d`, `6bf6c344`). Es limpieza, no decisión de
+producto. Refrescar con `--update-snapshots=all` y abrir el PNG para confirmar
+que el diff es solo los SKUs que ya no existen.
+
+**b. Backlog PLAY #7 — icono de Coach en el HUB.** El asset ya existe en los tres
+formatos (`public/art/new-icons-chesscito/training.{png,webp,avif}`). Es un swap
+de ruta. Toca UI → baseline VR en el mismo PR.
+
+---
+
+## 2. Barato-medio (1–3h)
+
+**c. Decodificar los custom errors.** Verificado: **nadie** decodifica revert
+data en `apps/web/src` (cero hits de `decodeErrorResult` /
+`ContractFunctionRevertedError`). Hoy `BadgeAlreadyClaimed`, `CooldownActive`
+(`0xc1ab61a1`) y `DailyLimitReached` (`0xeba8fe8a`) salen los tres como un
+"Try again" genérico que no dice nada. Un util + un mapa selector→copy, y las
+ABIs salen de artifacts, nunca a mano ([[feedback_verifier_abi_lesson]]).
+Es el que más dolor de QA quita por hora invertida.
+
+**d. Backlog PLAY #8 — quitar la confirmación redundante de LUZ.** Tocar Coach
+Review lanza análisis directo; LUZ conserva personalidad en loading y resultado.
+Borrar una pantalla intermedia.
+
+---
+
+## 3. Medio (medio día), necesitan ojo de diseño
+
+- **#9 Coach Analysis Loading Overlay** + **#10 Save Match Success Celebration** —
+  ambos son "cerrar el loop emocional después de una acción". Se pueden agrupar.
+- **#2 Post-Claim Gift Overlay** — mismo patrón: mostrar QUÉ ganó y para qué sirve.
+- **Modal `Piece Unlocked` fuera del vocabulario visual** —
+  `2026-07-09-piece-unlocked-modal-visual-vocabulary.md`. Requiere GOAL → Sally →
+  mock → código.
+- **#11 PLAY Dock 4 slots** — simetría del dock. Ojo en device + baseline VR.
+- **#5 Shop Active State** — con Season Pass activo el Shop solo muestra un modal.
+  Hay una pregunta de producto adentro (¿merece slot en el dock?).
+
+## 4. Investigación primero, no código
+
+- **#1 "Claim 3 Shields"** — nadie sabe a qué pertenece (Welcome Pack, Season Pass
+  bonus, rescue gift), si duplica los 3 shields de onboarding, ni por qué al
+  tocarlo lanza el 21-Day Mind Challenge. **No cambiar lógica hasta entenderlo.**
+  Es el único pendiente con comportamiento inexplicado; puede esconder un bug.
+
+## 5. Grande — no abrir sin decidirlo
+
+- **Server-verified progress** — el único anti-cheat real. `/api/sign-badge` y
+  `/api/sign-score` sellan lo que el cliente afirma. Feature, no un `if`.
+- **Belt System** ([[project_belt_system_design]], #189) — incluye
+  `BADGE_THRESHOLD` → proporción. La ventana "antes de que se minteen muchos
+  badges" sigue abierta: hay exactamente uno.
+- **Lote 2.5** Tactical Day Gift + Proof of Consistency (#3).
+- Issues de GitHub: #104 Treasure hunt (P1), #101 Prize pool v2 (P2, falta método
+  en el contrato), #67 Exercise world map (P2).
+
+---
+
+## Orden recomendado
+
+1. **(a)** VR rojo — 10 min, quita ruido de CI.
+2. **(c)** Custom errors — el mejor ratio dolor/hora, y hoy mismo te mordió tres veces.
+3. **(b)** Icono de Coach — trivial, el asset ya está.
+4. **(d)** Confirmación de LUZ — borrar una pantalla.
+5. **(#1)** Investigar "Claim 3 Shields" antes de que se vuelva deuda silenciosa.
+
+Después de eso, la conversación es Belt System vs server-verified progress, y
+esa sí es una decisión de producto.

--- a/docs/handoffs/2026-07-09-session-close-handoff.md
+++ b/docs/handoffs/2026-07-09-session-close-handoff.md
@@ -1,0 +1,75 @@
+# Session close — 2026-07-09
+
+**`main` = `daf4de36`.** Suite **4760 passing / 395 files**. Cuatro PRs mergeados.
+
+La sesión empezó como un re-smoke y terminó destapando tres bugs que compartían
+la misma firma: **algo verde verificaba una realidad muerta.**
+
+---
+
+## Qué se cerró
+
+| PR | Qué |
+| --- | --- |
+| [#191](https://github.com/akawolfcito/chesscito/pull/191) `0f44eadc` | Deadlock de progresión de la sesión diaria |
+| [#192](https://github.com/akawolfcito/chesscito/pull/192) `1cede56d` | Checklist de re-smoke + handoff + backlog del modal |
+| [#193](https://github.com/akawolfcito/chesscito/pull/193) `04de19fa` | Los techos de estrellas leen el pool real |
+| [#194](https://github.com/akawolfcito/chesscito/pull/194) `daf4de36` | Handoff del techo de estrellas |
+
+**El re-smoke de LEARN pasó completo en device.** Badge de la torre minteado en
+mainnet ([`0x327e80ae…`](https://celoscan.io/tx/0x327e80aee165a4aa2486458038ad252a453fb9432ed16732c6a67dec9c96ff4b)),
+torre **Owned**, save proof sin 400.
+
+Detalle en:
+- `docs/handoffs/2026-07-09-daily-session-progression-deadlock-handoff.md`
+- `docs/handoffs/2026-07-09-star-ceiling-real-pool-handoff.md`
+- `docs/testing/2026-07-09-re-smoke-checklist.md`
+
+## El patrón de la sesión
+
+Tres fallos, una sola causa de fondo: una señal verde custodiando algo que ya no
+existía.
+
+1. **El test aislaba el predicado, nunca la composición.** `shouldFreezeScoring`
+   estaba probado solo; nadie probaba `congelado → 0★ → gate del drawer`.
+2. **Un comentario congeló el dato de hoy como garantía de mañana.**
+   `EXERCISES_PER_PIECE = 5` decía "today every piece returns 5". Los pools
+   crecieron a 10 y nada falló.
+3. **El umbral de píxeles se tragó el texto que debía custodiar.**
+   `maxDiffPixelRatio: 0.01` dejó pasar cuatro baselines dibujando `12/15`.
+
+Codificado en [[feedback_deprecated_constant_outlives_migration]] y en la
+corrección a [[feedback_vr_baseline_discipline]].
+
+## Decisión de diseño tomada (no implementada)
+
+Si `sign-badge` verifica estrellas, el umbral **proporcional evaluado en vivo se
+rompe**: agregar ejercicios sube el techo y des-califica retroactivamente a quien
+ya había cruzado la barra. La respuesta es **calificación monótona**: cuando el
+jugador cruza por primera vez, el servidor escribe un bit permanente
+`qualified(player, piece)` y `sign-badge` consulta el bit, no el catálogo vivo.
+Encaja con la semántica del contrato, donde `hasClaimedBadge` ya es permanente.
+
+Guardar el mapa disperso `exerciseId → estrellas`, nunca un `totalStars`: es la
+única forma que sobrevive a que crezca o se reordene el catálogo.
+
+---
+
+## Estado del backlog
+
+Auditado contra el código en `docs/backlog/2026-07-09-pending-work-triage.md`.
+Dos items del backlog **ya estaban hechos** y nadie lo había anotado (el CTA
+dorado, arreglado en #183; Post-Focus Free Practice, arreglado en #191).
+
+**Rojo ahora mismo:** el baseline VR `hub-shop-sheet-open`. Verificado
+corriéndolo, no inferido.
+
+## Preguntas abiertas
+
+- **¿Un laberinto fresco debe poder jugarse pasado el límite diario?** Ya no gasta
+  cupo, pero `isLabReplayable()` lo trata como contenido nuevo. Ahora es decisión
+  de producto, no consecuencia del código.
+- **¿El reset diario debe ser UTC o local?** En UTC-5 el día entra a las 19:00,
+  en plena sesión de noche. Local rompe la rotación determinista entre devices.
+- **`/api/sign-badge` firma sin verificar estrellas.** Hay un badge en mainnet que
+  ya ejercitó ese camino.

--- a/docs/handoffs/_next-session-prompt.md
+++ b/docs/handoffs/_next-session-prompt.md
@@ -1,59 +1,77 @@
-# Next session prompt — post 2026-05-30 em-dash sweep cluster
+# Next session prompt — post 2026-07-09 LEARN re-smoke
 
-Paste this in the next session to bootstrap context. Or just say "continuemos" — the agent should detect this file and follow its instructions.
+Di **"continuemos"** y el agente debe leer este archivo y seguirlo.
 
 ---
 
-**State at start of next session:** main = `974afd07`. Three handoffs from 2026-05-30 are committed; the em-dash sweep is the most recent.
+**Estado al arrancar:** `main` = `daf4de36`. Suite **4760 passing / 395 files**.
+El re-smoke de LEARN pasó completo en device; el badge de la torre está minteado
+en mainnet.
 
-**Read first:**
-- `docs/handoffs/2026-05-30-em-dash-sweep-handoff.md` — full session log, what's swept, what's left, why.
-- Earlier same-day handoffs (in chronological order):
-  - `docs/handoffs/2026-05-30-coach-bugs-shop-vitrine-account-inventory-handoff.md`
-  - `docs/handoffs/2026-05-30-playercolor-callouts-vr-refresh-handoff.md`
-  - `docs/handoffs/2026-05-30-shop-cleanup-vr-settle-pro-days-handoff.md`
-- Memory updates this thread: `feedback_anti_ai_prose` (rule was already there; now backed by a regression test that prevents drift).
+**Leer primero:**
+- `docs/handoffs/2026-07-09-session-close-handoff.md` — resumen de la sesión.
+- `docs/backlog/2026-07-09-pending-work-triage.md` — pendientes **auditados contra
+  el código**, con costo estimado y orden recomendado.
 
-**Choose your path:**
+**Antes de tocar nada:** `preview.chesscito.com` necesita un redeploy con
+`04de19fa` o posterior para que el modal muestre `12/30`.
+`NEXT_PUBLIC_CHESSCITO_SESSION_LIMIT` es build-time.
 
-1. **Pre-flight + VR baseline refresh** (post-reboot, ~1h-1.5h)
-   This is the unblocker for everything else. Per `memory/project_disk_telemetry.md`:
-   - `df -h /` + `bash scripts/disk-telemetry.sh save baseline_pre`. Need <30GB free + swap >2GB cleared.
-   - `cd apps/web && pnpm test:e2e:visual` — targets: hub-shop-sheet-open settle fix (`1fec59c8`), Cluster C visor states, shop+vitrine deltas, the 14-baseline backlog from `_bmad-output/implementation-artifacts/deferred-work.md`.
-   - If any baseline drifted from the morning's chunks, refresh in a dedicated `test(vr): refresh baselines` commit with rationale per file.
+---
 
-2. **Em-dash sweep chunks 8+** (~1-2h after VR is green)
-   42 em-dashes remain in editorial.ts + i18n. Each next chunk should be one VR baseline's worth of strings, so the baseline refresh stays atomic with the sweep. Order of attack (by baseline-scope, smallest first):
-   - **vr9-arena-end-state-** (7 baselines) — `"Checkmate — You Win!"`, `"Checkmate — AI Wins"`, `"Stalemate — Draw"`. 3 EN + 2 ES.
-   - **hub-clean** — `proInactiveAriaLabel`, `activeLabel`, `inFlightLabel`, `"Unlock PRO — full experience"`. ~6 EN + 4 ES.
-   - **landing tagline + share-card meta** — `"Train your mind with pre-chess challenges — a Celo MiniPay game"` + the FIDE Master ES line (HARD RULE: don't weaken to imply medical benefit).
-   - **Misc visible hints** — `prizePoolSoonHint`, `analysisPendingHint`, `shieldsStatusEmpty`, `firstStepHint`, etc. ~10 strings; likely no VR coverage but verify each.
-   Each chunk: lower per-file ceilings in `anti-ai-prose.test.ts` to match the post-sweep count.
+## Camino recomendado (en orden, de barato a caro)
 
-3. **MiniPay smoke + production promote** (~30-45 min)
-   Verify the full chain on device after Path 1 completes:
-   - Save Victory from visor end-to-end (not return 400).
-   - sessionStorage scoping: SAVE in game A → lock/unlock → game B → Save tile present.
-   - Shop cards: per-tone pastel + visible icon overhang past left edge.
-   - AccountSheet: Shields + Founder + Manage PRO rows render with correct status + tap targets.
-   If pass → promote to chesscito.com via Vercel UI.
+1. **Refrescar el baseline VR `hub-shop-sheet-open`** (~10 min)
+   Está **rojo**, verificado. Espera 3 SKUs retirados (`5c8e0f5d`, `6bf6c344`).
+   Usar `--update-snapshots=all` (el flag pelado no reescribe lo que cae bajo el
+   umbral) y **abrir el PNG** para confirmar que el diff son solo esos SKUs.
 
-4. **Phase 2 of shop oscuridad — in-context callouts** (~3-4h, gated on user signal)
-   Don't ship reflexively. Confirm users still report oscuridad after Phase 1 lands in production.
+2. **Decodificar los custom errors** (~1-2h) — mejor ratio dolor/hora
+   Verificado: cero hits de `decodeErrorResult` / `ContractFunctionRevertedError`
+   en `apps/web/src`. Hoy `BadgeAlreadyClaimed`, `CooldownActive` (`0xc1ab61a1`) y
+   `DailyLimitReached` (`0xeba8fe8a`) salen los tres como "Try again".
+   Las ABIs salen de `artifacts/`, **nunca a mano**.
 
-5. **Persist `playerColor` in GameRecord** (~1-2h)
-   Removes the parity-based fallback in the visor. Touches `/api/games` POST + GameRecord type + arena POST body.
+3. **Icono de Coach en el HUB** (~30 min) — backlog PLAY #7
+   El asset ya existe en los tres formatos:
+   `public/art/new-icons-chesscito/training.{png,webp,avif}`. Es un swap de ruta.
+   Toca UI → baseline VR en el mismo PR.
 
-6. **Triage the ~39 pre-existing vitest env failures** (~30-60 min)
-   All match `TypeError: window.localStorage.clear is not a function`. Doesn't block shipping but degrades CI signal.
+4. **Quitar la confirmación redundante de LUZ** (~1h) — backlog PLAY #8
 
-**What NOT to touch yet:**
-- Visor structure is locked from Cluster C.
-- The cream-amber-only-on-MOVES rule still holds: data tables get frames, floating affordances don't.
-- Do NOT add a "you'll lose mint chance" warning in resign flow.
-- Do NOT propose a context provider refactor for `TrophiesBody` + `TrophiesHeroBand` unless profiling confirms the duplicate `/api/my-victories` is hurting.
-- Do NOT add em-dashes to user-facing copy. The ceiling test will fail the build.
+5. **Investigar "Claim 3 Shields"** — backlog LEARN #1. **Investigación, no
+   código.** Nadie sabe a qué sistema pertenece ni por qué lanza el 21-Day Mind
+   Challenge. Es el único pendiente con comportamiento inexplicado.
 
-**If user says "ship it":** option 1 + 3 + post-promote smoke.
-**If user says "continuemos":** read this file + the em-dash handoff, then ask which path. Default to option 1 (VR pre-flight) unless the user redirects.
-**If user says "what's pending":** read deferred ledgers in the four 2026-05-30 handoffs.
+Después de eso la conversación es **Belt System vs server-verified progress**, y
+esa es decisión de producto, no de ingeniería.
+
+---
+
+## Reglas que esta sesión ganó a golpes
+
+- **Verde no significa verificado.** Un test que aísla un predicado no prueba la
+  composición. Un baseline VR con `maxDiffPixelRatio: 0.01` no guarda texto.
+- **Una constante derivada de contenido debe ser función del contenido.** Nunca un
+  literal. Si dice `@deprecated ... migración diferida a Sprint N`, bórrala en el
+  PR que migra al último consumidor y deja que `tsc` enumere el resto.
+- **VR:** refrescar con `--update-snapshots=all`, luego leer el PNG.
+
+## Qué NO tocar todavía
+
+- **No abrir el Belt System** hasta que cierren MiniPay/slides. Único item con
+  reloj: `BADGE_THRESHOLD` → proporción, y **la ventana sigue abierta** (hay
+  exactamente un badge minteado).
+- **Nunca construir recovery para el Daily-Streak.** El shield protege el COMBO,
+  no el Daily.
+- **No implementar server-verified progress con umbral proporcional evaluado en
+  vivo** — des-califica retroactivamente. Ver la decisión de diseño en el
+  session-close handoff: bit monótono `qualified(player, piece)`.
+- **No subir el `MAX_STARS`** ni ningún techo a un literal otra vez.
+
+## Si el usuario dice…
+
+- **"continuemos"** → leer este archivo + el triage, y arrancar por el punto 1
+  salvo que redirija.
+- **"qué falta"** → `docs/backlog/2026-07-09-pending-work-triage.md`.
+- **"ship it"** → redeploy de preview y confirmar `12/30` en device antes de nada.


### PR DESCRIPTION
Docs only.

- **`docs/handoffs/2026-07-09-session-close-handoff.md`** — the four PRs, the shared root pattern (a green signal guarding something that no longer existed), and the badge server-verification design decision.
- **`docs/backlog/2026-07-09-pending-work-triage.md`** — pendings audited **against the code**, not the lists. Two items were already fixed and nobody had recorded it: the "golden Save-proof CTA unreachable" 🔴 (fixed in #183 — `canSaveOnChain` no longer shares `scorePendingNew`) and LEARN #4 Post-Focus Free Practice (fixed in #191). `hub-shop-sheet-open` is red **right now**, verified by running it.
- **`docs/handoffs/_next-session-prompt.md`** — still pointed at the 2026-05-30 em-dash sweep. Retargeted so "continuemos" resumes here, cheapest work first.

The design decision worth keeping: a live-evaluated proportional badge threshold **retroactively un-qualifies** players when the pool grows. A player one star from the badge wakes up 21 stars away because you shipped content. The answer is a monotonic `qualified(player, piece)` bit written on first crossing, read at sign time instead of the live catalog.

Wolfcito 🐾 @akawolfcito