### PR TITLE
fix(errors): stop reading "400" inside call args as an HTTP 400

### DIFF
--- a/apps/web/src/lib/__tests__/errors.test.ts
+++ b/apps/web/src/lib/__tests__/errors.test.ts
@@ -14,3 +14,71 @@ describe("classifyTxErrorKind — ERC2612 permit reverts", () => {
     expect(classifyTxErrorKind(err)).toBe("revert");
   });
 });
+
+/** Captured verbatim from `simulateContract` against the mainnet Scoreboard
+ *  (`0x1681aAA1…`) on 2026-07-09. viem echoes the call args into the message,
+ *  so any score / timeMs / deadline / nonce containing the digits "400" used
+ *  to hijack the `signingUnavailable` branch, which is evaluated before the
+ *  `revert` branch. The fixture is real output, not a paraphrase — a
+ *  hand-written approximation is exactly what let this survive. */
+const REAL_REVERT_MESSAGE = [
+  'The contract function "submitScoreSigned" reverted with the following signature:',
+  "0xcd21db4f",
+  "",
+  'Unable to decode signature "0xcd21db4f" as it was not found on the provided ABI.',
+  "Make sure you are using the correct ABI and that the error exists on it.",
+  "You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0xcd21db4f.",
+  " ",
+  "Contract Call:",
+  "  address:   0x1681aAA176d5f46e45789A8b18C8E990f663959a",
+  "  function:  submitScoreSigned(uint256 levelId, uint256 score, uint256 timeMs, uint256 nonce, uint256 deadline, bytes signature)",
+  "  args:                       (1, 2400, 18000, 7, 1783000000, 0x1111)",
+].join("\n");
+
+describe("classifyTxErrorKind — revert vs signingUnavailable disambiguation", () => {
+  it("classifies a real on-chain revert as revert even when its args contain 400", () => {
+    expect(classifyTxErrorKind(new Error(REAL_REVERT_MESSAGE))).toBe("revert");
+  });
+
+  it.each([
+    ["score", "args: (1, 2400, 18000, 7, 1783000000)"],
+    ["timeMs", "args: (1, 90, 400123, 7, 1783000000)"],
+    ["deadline", "args: (1, 90, 18000, 7, 1784001234)"],
+    ["nonce", "args: (1, 90, 18000, 400, 1783000000)"],
+  ])("does not read a %s containing 400 as a signing failure", (_field, args) => {
+    const err = new Error(`execution reverted\n  ${args}`);
+    expect(classifyTxErrorKind(err)).toBe("revert");
+  });
+
+  it("still classifies a real signing-endpoint env failure as signingUnavailable", () => {
+    const err = new Error("Missing required env: DRAGON");
+    expect(classifyTxErrorKind(err)).toBe("signingUnavailable");
+  });
+
+  it("classifies the requestSignature fallback message as signingUnavailable", () => {
+    // `requestSignature` throws this when /api/sign-* returns a body with no
+    // `error` field. It reached `unknown` before, so the player saw
+    // "Something went wrong" for a server-side outage.
+    const err = new Error("Could not fetch signature");
+    expect(classifyTxErrorKind(err)).toBe("signingUnavailable");
+  });
+
+  it("classifies the sign-badge route fallback as signingUnavailable", () => {
+    const err = new Error("Could not sign badge claim");
+    expect(classifyTxErrorKind(err)).toBe("signingUnavailable");
+  });
+
+  it("still classifies an explicit HTTP 4xx from a signing call as signingUnavailable", () => {
+    expect(classifyTxErrorKind(new Error("HTTP 400"))).toBe("signingUnavailable");
+    expect(classifyTxErrorKind(new Error("sign-victory failed: HTTP 403"))).toBe(
+      "signingUnavailable",
+    );
+  });
+
+  it("does not read a bare 400 inside an address or hash as HTTP 4xx", () => {
+    const err = new Error(
+      "execution reverted\n  address: 0x400aAA176d5f46e45789A8b18C8E990f663959a",
+    );
+    expect(classifyTxErrorKind(err)).toBe("revert");
+  });
+});

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -28,6 +28,10 @@ export type TxErrorKind =
   | "revert"
   | "unknown";
 
+/** A 4xx/5xx from a signing call, anchored to the literal "http" so it
+ *  cannot match the digits of a contract address, tx hash, or call arg. */
+const HTTP_STATUS_RE = /\bhttp[\s_-]?[45]\d{2}\b/;
+
 export function classifyTxErrorKind(error: unknown): TxErrorKind {
   const msg = error instanceof Error ? error.message : String(error);
   const lower = msg.toLowerCase();
@@ -44,6 +48,16 @@ export function classifyTxErrorKind(error: unknown): TxErrorKind {
   if (lower.includes("badgealreadyclaimed") || lower.includes("already claimed")) {
     return "badgeAlreadyClaimed";
   }
+  // An on-chain revert is self-identifying, so it settles the question
+  // before any of the fuzzy substring checks below get a vote. This
+  // ordering is load-bearing: viem echoes the call args into the
+  // message ("args: (1, 2400, 18000, ...)"), and the signing branch
+  // used to test for the bare substring "400". Every revert whose
+  // score, timeMs, nonce or unix deadline happened to contain those
+  // three digits was reported to the player as "Signing service
+  // unavailable" — a server outage that never happened.
+  if (lower.includes("revert") || lower.includes("execution reverted")) return "revert";
+
   // Server signing endpoint missing config or unavailable. Most often
   // surfaced in local dev when the operator forgot the encrypted
   // signer envs (DRAGON / TORRE_PRINCESA), but also catches prod
@@ -54,6 +68,10 @@ export function classifyTxErrorKind(error: unknown): TxErrorKind {
   // the GCM auth-tag mismatch surfaced by Node's crypto when the
   // TORRE_PRINCESA key doesn't decrypt the DRAGON ciphertext (rotated
   // key, copied wrong env, mismatched envs from prod/dev).
+  //
+  // HTTP_STATUS_RE requires the literal "http" prefix. `requestSignature`
+  // throws the server's `error` string rather than the status code, so
+  // the fallback messages it can produce are matched by name below.
   if (
     lower.includes("missing required env") ||
     lower.includes("sign-badge") ||
@@ -61,12 +79,13 @@ export function classifyTxErrorKind(error: unknown): TxErrorKind {
     lower.includes("sign-victory") ||
     lower.includes("unsupported state") ||
     lower.includes("authenticate data") ||
-    lower.includes("400") ||
+    lower.includes("could not fetch signature") ||
+    lower.includes("could not sign") ||
+    HTTP_STATUS_RE.test(lower) ||
     lower.includes("signing")
   ) {
     return "signingUnavailable";
   }
-  if (lower.includes("revert") || lower.includes("execution reverted")) return "revert";
   return "unknown";
 }
 

--- a/docs/reviews/2026-07-09-custom-errors-plan-redteam.md
+++ b/docs/reviews/2026-07-09-custom-errors-plan-redteam.md
@@ -1,0 +1,180 @@
+# Red-team del plan "decodificar custom errors" — 2026-07-09
+
+Auditado contra el código y contra Celo Mainnet, no contra el backlog.
+**Veredicto: el plan resuelve un problema real, pero no el que produce el síntoma
+reportado, y su valor depende de un supuesto que nadie verificó.**
+
+---
+
+## F1 🔴 El síntoma "Try again" no lo causa la falta de decodificación
+
+`classifyTxErrorKind` (`lib/errors.ts:57`) evalúa la rama `signingUnavailable`
+**antes** que la rama `revert`, y esa rama incluye:
+
+```ts
+lower.includes("400")
+```
+
+`"400"` es un substring, no un status code. El mensaje de viem para un revert
+incluye los args de la llamada. Probado contra el Scoreboard de mainnet
+(`0x1681aAA1…`), con `score = 2400`:
+
+```
+The contract function "submitScoreSigned" reverted with the following signature:
+0xcd21db4f
+  args: (1, 2400, 18000, 7, 1783000000, 0x1111…)
+```
+
+Branches evaluadas sobre ese mensaje real:
+
+| rama | resultado |
+| --- | --- |
+| insufficientFunds | false |
+| network | false |
+| badgeAlreadyClaimed | false |
+| **signingUnavailable** (`includes("400")`) | **true** ← gana |
+| revert | true (nunca se alcanza) |
+
+Copy resultante: **"Signing service unavailable. Try again in a moment."**
+Ese es el "Try again" del smoke. No es un revert genérico: es una
+**misclasificación**.
+
+Cualquier `score`, `timeMs`, `deadline`, `nonce`, `txHash` o dirección que
+contenga la subcadena `400` cae acá. Un deadline unix de 10 dígitos la contiene
+con frecuencia alta. La clasificación es efectivamente aleatoria.
+
+`isUserCancellation` tiene la misma clase de defecto: `lower.includes("cancelled")`
+matchea cualquier mensaje que mencione la palabra.
+
+**Implicación:** se puede arreglar el síntoma **hoy**, sin generador, sin ABIs y
+sin decodificar nada. Es un cambio de una línea con test. El plan lo daba por
+sentado y lo enterraba bajo 1-2h de infra.
+
+---
+
+## F2 🔴 Ni el claim de badge ni el save de score esperan el receipt
+
+`exercises-screen.tsx:1581` y `:1840` llaman `writeContractAsync` y declaran
+éxito **sobre el hash**, no sobre el receipt:
+
+```ts
+const txHash = await writeWithOptionalFeeCurrency(writeBadgeAsync, {...});
+track("badge_claim_tx", { stage: "success", ... });
+setResultOverlay({ variant: "badge", txHash });
+```
+
+Nadie chequea `receipt.status` en ninguna superficie de jugador (los únicos
+`status !== "success"` viven en rutas de API y en `dev/`).
+
+Dos consecuencias:
+
+1. **Bug independiente, más grave que el que vinimos a arreglar:** si la tx se
+   mina y revierte, el jugador ve la celebración del badge y `justClaimed` queda
+   en `true`. El error nunca se muestra porque nunca se lanza.
+2. Los custom errors **solo** pueden llegar si la wallet rechaza en estimación,
+   antes de firmar. Es decir: el camino que el plan quiere decorar es el único
+   camino donde el plan sirve, y no es el único camino que falla.
+
+---
+
+## F3 🟠 Nadie verificó que MiniPay devuelva la revert data
+
+Todo el plan asume que el error que llega al `catch` contiene
+`ContractFunctionRevertedError` con `raw`. Eso está **probado con
+`publicClient.simulateContract`** (probe local, Forno), no con la wallet.
+
+La app no simula: `writeContract` va directo a `eth_sendTransaction` del
+provider inyectado. Si MiniPay estima internamente y devuelve un `Error` con
+texto plano, `raw` es `undefined` y **el decoder muere silenciosamente**,
+cayendo al mismo fallback de strings.
+
+**No se puede resolver desde este repo.** Necesita un probe en device: un
+`console.warn` del `raw` en el catch, corrido contra preview.
+Construir el generador antes de responder esto es apostar 1-2h a una moneda.
+
+---
+
+## F4 🟠 `BadgeAlreadyClaimed` probablemente no es alcanzable
+
+Es el primero de la lista del backlog, pero la UI ya gatea el claim con la
+lectura `hasClaimed`, y los badges son one-per-(piece, wallet). Para llegar al
+revert hace falta una carrera (dos taps, dos tabs, o un estado stale).
+Antes de gastar copy en él conviene confirmar que alguna vez dispara.
+
+Costo de equivocarse: bajo. Pero encabeza la lista y no debería.
+
+---
+
+## F5 🟡 Mi propia afirmación sobre `signatureExpired` era falsa
+
+Dije que la copy existía pero era inalcanzable por no tener `TxErrorKind`.
+Es alcanzable: `use-mint-victory.ts:711` la usa vía `/expired/i.test(raw)`.
+
+Lo cierto es **peor y más sutil**: ese regex está muerto para el caso on-chain.
+Con la ABI actual (sin errors) el mensaje de viem contiene el selector
+`0xcd21db4f`, nunca la palabra "expired" — lo verifiqué arriba. Así que ese
+branch solo matchea texto de respuestas 4xx del servidor. La copy existe, el
+camino existe, y aun así el `SignatureExpired` on-chain no la alcanza.
+
+---
+
+## F6 🟡 El plan proponía editar `messages/en.ts` a mano
+
+`messages/en.ts` es **derivado** de `editorial.ts` (`import * as editorial`), y
+su header lo prohíbe explícitamente. La paridad i18n acá es
+`editorial.ts` + `messages/es.ts`. El plan citaba la regla de memoria correcta y
+la aplicaba mal a este repo.
+
+---
+
+## F7 🟡 Decodificar contra una ABI unión puede misatribuir el error
+
+Un selector de 4 bytes es un espacio chico. Un revert de un ERC20 (`approve`),
+de un proxy, o de cualquier contrato ajeno puede decodificar por coincidencia
+como un error de Chesscito y mostrar copy falsa con confianza total.
+
+Mitigación: decodificar **con la ABI del contrato que se llamó**, no con la
+unión, o exigir que el nombre esté en un allowlist explícito y que los args
+decodifiquen con la aridad esperada.
+
+Aparte: existen `Shop.sol` **y** `ShopUpgradeable.sol` en artifacts. El
+desplegado es `ShopUpgradeable`. Un generador que barra el directorio los toma
+a los dos.
+
+---
+
+## F8 🟡 La estrategia de test repetía el pecado de la casa
+
+Proponía construir `new ContractFunctionRevertedError({ abi, data })` a mano.
+Eso afirma **la forma que yo creo** que viem produce, y pasa en verde aunque la
+realidad sea otra. Es literalmente `feedback_tests_green_against_dead_shape`.
+
+Alternativa honesta y barata: manejar la stack real de viem con un transport
+`custom()` que lance un error RPC canónico (`{ code: 3, data: "0xc1ab61a1…" }`)
+y dejar que viem arme la cadena de errores. El test entonces verifica el
+contrato con viem, no con mi memoria de viem.
+
+---
+
+## F9 🟢 Nota de telemetría
+
+`error_kind` cambia de cardinalidad y, sobre todo, **arreglar F1 re-bucketea el
+histórico**: parte de lo que hoy cuenta como `signingUnavailable` era revert.
+Cualquier comparación antes/después de este PR es inválida.
+
+---
+
+## Orden revisado
+
+| # | Acción | Costo | Depende de |
+| --- | --- | --- | --- |
+| 0 | Probe en device: loguear `raw` del revert en el catch, correr contra preview | 20 min | — |
+| 1 | **Arreglar F1**: sacar `includes("400")`, endurecer las ramas de substring | 30 min | — |
+| 2 | Decidir F2: chequear `receipt.status` en claim y save | spec aparte | producto |
+| 3 | Generador de error-ABIs + decoder + copy | 1-2h | **0** |
+
+**Recomendación:** hacer **1** ahora — es barato, está probado, y por sí solo
+convierte "Signing service unavailable" en un mensaje honesto. Correr **0** en
+el próximo device test. **No** construir el generador hasta que 0 responda.
+
+**F2 es el hallazgo más caro de esta revisión y no estaba en el backlog.**


### PR DESCRIPTION
Primer paso del cluster de custom errors. **No decodifica nada todavía** — y
resulta que el síntoma reportado no necesitaba decodificación.

## El hallazgo

`classifyTxErrorKind` chequeaba el substring `"400"` para detectar un 4xx de
`/api/sign-*`, y evaluaba esa rama **antes** que la de revert. viem imprime los
args de la llamada dentro del mensaje de error.

Probado contra el Scoreboard de mainnet (`0x1681aAA1…`), `submitScoreSigned` con
`score = 2400`:

```
The contract function "submitScoreSigned" reverted with the following signature:
0xcd21db4f
  args: (1, 2400, 18000, 7, 1783000000, 0x1111…)
```

| rama | resultado |
| --- | --- |
| insufficientFunds | false |
| network | false |
| badgeAlreadyClaimed | false |
| **signingUnavailable** (`includes("400")`) | **true** ← ganaba |
| revert | true (inalcanzable) |

Copy mostrada: *"Signing service unavailable. **Try again** in a moment."*
Ese es el "Try again" genérico que reportó el smoke. No era un revert sin
decodificar: era una **misclasificación**. Cualquier `score`, `timeMs`, `nonce` o
deadline unix de 10 dígitos que contuviera `400` caía ahí.

## Y nunca sirvió para lo que fue escrito

`requestSignature` lanza el string `error` del servidor, no el status code. Sus
fallbacks reales (`"Could not fetch signature"`, `"Could not sign badge claim"`)
no contienen `400` ni `sign-badge`, así que caían en `unknown` → *"Something went
wrong"* para una caída del signer. Ahora se matchean por nombre.

## El cambio

- La detección de revert corre primero. Un revert se identifica solo; no le pido
  opinión a las heurísticas de substring.
- `"400"` pasa a `/\bhttp[\s_-]?[45]\d{2}\b/`, anclado al literal `http`, así no
  puede matchear los dígitos de una dirección, un hash o un arg.
- Se agregan los dos fallbacks del path de firma.

Sin claves de copy nuevas → sin cambios de i18n, sin cambios de baseline VR.

## Sobre el test

El fixture es el mensaje de viem **capturado textual de mainnet**, no una
paráfrasis. Un mensaje inventado a mano es exactamente lo que permitió que esto
sobreviviera: `feedback_tests_green_against_dead_shape`.

## Verificación

- Unit: **4770 passed / 395 files** (antes 4760; +10 nuevos)
- VR: **52 passed** (env limpio)
- `tsc --noEmit`: limpio

## Lo que sigue (ver `docs/reviews/2026-07-09-custom-errors-plan-redteam.md`)

- 🔴 **Ni el claim de badge ni el save de score esperan el receipt.** Declaran
  éxito sobre el hash. Si la tx se mina y revierte, el jugador ve la celebración.
  Bug independiente, no está en el backlog, y decide cuánto vale decodificar.
- 🟠 Nadie verificó que MiniPay devuelva revert data al dapp. Sin eso, el decoder
  muere en silencio. Necesita un probe en device antes de construir el generador.

Wolfcito 🐾 @akawolfcito
