### PR TITLE
docs(spec): receipt-status verification, split per its red-team

### DIFF
--- a/docs/specs/receipt-status-helper.md
+++ b/docs/specs/receipt-status-helper.md
@@ -1,0 +1,151 @@
+# Spec — receipt-status-helper (1 de 2)
+
+**Date**: 2026-07-09
+**Status**: ready for /tdd
+**Parent**: `receipt-status-verification.md` (partido tras su red-team)
+**Blocks**: `receipt-status-learn-handlers.md`
+
+## Problem
+
+`waitForReceiptWithTimeout` (`lib/contracts/transaction-helpers.ts:23`) devuelve
+cualquier receipt, incluido el de una tx revertida. Verificado en
+`viem@2.46.3/_esm/actions/public/waitForTransactionReceipt.js`: resuelve con
+`emit.resolve(receipt)` y nunca inspecciona `status`.
+
+Ningún consumidor compensa esa laguna:
+
+| Consumidor | Qué hace con el receipt | Si revierte |
+| --- | --- | --- |
+| `use-shop-sheet-state.ts:461` (approve) | lo ignora y sigue al `buyItem` | gasta gas en un `buyItem` condenado |
+| `use-mint-victory.ts:517` (approve) | igual | igual |
+| `use-mint-victory.ts:606` (claim) | lo castea a `{ logs }` y busca `VictoryMinted` | `logs` vacío → `tokenId: null` → `claimPhase: "success"` |
+
+Y una asimetría que el red-team marcó como bloqueante: victory elige entre
+`inp.injected.waitReceipt(hash)` (MiniPay) y el helper (web) en `:601-607`.
+Arreglar solo el helper haría que **el path web falle honestamente y el path
+MiniPay siga celebrando**. MiniPay es el target de distribución.
+
+## Goal
+
+`waitForReceiptWithTimeout` resuelve únicamente con receipts exitosos, y los tres
+consumidores actuales convergen en esa garantía, incluido el path inyectado de
+victory.
+
+## Non-goals
+
+- Badge claim y score save. Ninguno de los dos usa este helper (usan el hook
+  `useWaitForTransactionReceipt`). Van en el spec 2.
+- Decodificar custom errors.
+- Cambiar copy, UI o baselines VR.
+
+## Contracts (SDD)
+
+```ts
+// lib/contracts/transaction-helpers.ts
+import type { Hash, PublicClient, TransactionReceipt } from "viem";
+
+export class TransactionRevertedError extends Error {
+  readonly hash: Hash;
+  readonly receipt: TransactionReceipt;
+  constructor(hash: Hash, receipt: TransactionReceipt) {
+    super(`Transaction reverted on-chain: ${hash}`);
+    this.name = "TransactionRevertedError";
+    this.hash = hash;
+    this.receipt = receipt;
+  }
+}
+
+/** Resuelve SOLO con `receipt.status === "success"`.
+ *  @throws TransactionRevertedError  si se minó y revirtió
+ *  @throws TransactionTimeoutError   si no se minó dentro de timeoutMs */
+export async function waitForReceiptWithTimeout(
+  client: PublicClient,
+  hash: Hash,
+  opts?: { timeoutMs?: number; confirmations?: number },
+): Promise<TransactionReceipt>;
+
+/** Verifica el status de un hash cuyo receipt vino de una fuente no confiable
+ *  (p.ej. `injected.waitReceipt` de MiniPay). Lee del nodo, no de la wallet. */
+export async function assertReceiptSuccess(
+  client: PublicClient,
+  hash: Hash,
+): Promise<TransactionReceipt>;
+```
+
+```ts
+// lib/errors.ts
+export function isTransactionReverted(error: unknown): boolean;
+```
+
+`classifyTxErrorKind` mapea `TransactionRevertedError` → `"revert"`.
+El kind y la copy (`RESULT_OVERLAY_COPY.error.revert`) ya existen: **cero claves
+nuevas, cero i18n, cero baselines VR**.
+
+`confirmations`: se mantiene el default de viem (1). Decidido, no es pregunta abierta.
+
+## Behavior
+
+1. Dado un receipt con `status: "success"`, `waitForReceiptWithTimeout` lo devuelve.
+2. Dado un receipt con `status: "reverted"`, lanza `TransactionRevertedError` con
+   el `hash` y el `receipt` adjuntos.
+3. Dado un timeout, sigue lanzando `TransactionTimeoutError` (sin cambios).
+4. `isTransactionReverted` reconoce la instancia y también un `Error` cuyo `name`
+   sea `"TransactionRevertedError"` (cruce de realms, igual que hace hoy
+   `isTransactionTimeout` en `:11`).
+5. `classifyTxErrorKind(new TransactionRevertedError(...))` devuelve `"revert"`,
+   y lo hace **antes** que las heurísticas de substring.
+6. Dado el path de victory con `injected.waitReceipt`, tras obtener el receipt de
+   la wallet se llama `assertReceiptSuccess(publicClient, claimHash)`. Si el
+   status no es `success`, lanza y `claimPhase` nunca pasa a `"success"`.
+7. Dado el path de victory sin `injected`, el helper ya lanza. Ambas ramas se
+   comportan igual.
+8. Dado un `approve` revertido (shop o victory), la promesa lanza y el flujo
+   nunca alcanza el `buyItem` / `claim`.
+
+## Edge cases
+
+- **`publicClient` ausente en el path inyectado de victory.** Hoy `publicClient!`
+  se usa con non-null assertion en `:606`. Si es `undefined` y hay `injected`,
+  `assertReceiptSuccess` no puede correr. → **fail closed**: lanzar. Un éxito no
+  verificable no se muestra como éxito.
+- **`assertReceiptSuccess` corre justo después de que la wallet ya vio el receipt**,
+  así que el nodo debería tenerlo. Aun así puede devolver
+  `TransactionReceiptNotFoundError` por lag de RPC. → reintentar vía
+  `waitForTransactionReceipt` con timeout corto en vez de `getTransactionReceipt`.
+- **Tx reemplazada** (speed-up desde la wallet): viem lanza. Sin cobertura previa;
+  no la agregamos acá, pero queda anotada.
+- Un `approve` que revierte es hoy invisible; después será un error. Es un cambio
+  de comportamiento **deseado** y observable en telemetría.
+
+## Acceptance criteria
+
+- [ ] `waitForReceiptWithTimeout` lanza `TransactionRevertedError` con `status: "reverted"`.
+- [ ] `waitForReceiptWithTimeout` devuelve el receipt con `status: "success"`.
+- [ ] El timeout sigue lanzando `TransactionTimeoutError` (test de regresión).
+- [ ] `isTransactionReverted` reconoce instancia y duck-type por `name`.
+- [ ] `classifyTxErrorKind(TransactionRevertedError)` → `"revert"`.
+- [ ] `use-mint-victory`: receipt revertido por el path inyectado ⇒ `claimPhase`
+      NO es `"success"`, `onClaimTelemetry` emite `stage: "error"`.
+- [ ] `use-mint-victory`: receipt revertido por el path web ⇒ idem.
+- [ ] `use-mint-victory`: receipt exitoso ⇒ comportamiento idéntico al de hoy
+      (test de regresión sobre `tokenId` y `shareLinkUrl`).
+- [ ] Shop: `approve` revertido ⇒ `buyItem` nunca se llama.
+- [ ] Suite completa verde. Sin claves de copy nuevas.
+
+**Todos los criterios son verificables hoy.** Los harnesses existen:
+`lib/contracts/__tests__/transaction-helpers.test.ts`,
+`lib/coach/__tests__/use-mint-victory.test.ts`,
+`lib/shop/__tests__/use-shop-sheet-state.test.tsx`, `lib/__tests__/errors.test.ts`.
+
+## Out of scope / future
+
+- `deriveTxToastState` (`lib/exercises/tx-toast-state.ts:36`) tiene un branch
+  `failed` alimentado por `isError`, documentado en `:18` como
+  *"chain revert / RPC error"*. **Solo es RPC error.** El comentario de
+  `exercises-screen.tsx:1127` afirma que "chain revert now surfaces as a sticky
+  failed toast": es falso. Se corrige en el spec 2, que es quien controla ese
+  input. Tercera aparición de `feedback_tests_green_against_dead_shape`.
+
+## Open questions
+
+Ninguna. Este spec es implementable tal cual.

--- a/docs/specs/receipt-status-learn-handlers.md
+++ b/docs/specs/receipt-status-learn-handlers.md
@@ -1,0 +1,187 @@
+# Spec — receipt-status-learn-handlers (2 de 2)
+
+**Date**: 2026-07-09
+**Status**: draft — bloqueado por `receipt-status-helper.md`
+**Parent**: `receipt-status-verification.md` (partido tras su red-team)
+
+## Problem
+
+Los dos writes on-chain de LEARN declaran éxito sobre el hash, no sobre el
+resultado.
+
+- **Badge claim** (`exercises-screen.tsx:1581-1606`): tras `writeContractAsync`
+  corre `hapticSuccess()`, `justClaimed[piece] = true`, el modal `piece-unlocked`
+  y el overlay `variant: "badge"`. Nunca lee un receipt.
+- **Score save** (`:1821-1846`): espera el receipt con
+  `useWaitForTransactionReceipt` (`:1016`) pero consume `isSuccess`, que en wagmi
+  significa "la query resolvió", no `status === "success"`. El effect de `:1094`
+  corre igual y `recordSaveFor` persiste el score de una tx revertida.
+- `/api/cache-score` se llama al broadcast (`:1850`). El leaderboard combinado de
+  Supabase lee esa tabla como fuente `scores` on-chain.
+- `chesscito:optimistic-score` (`:1864`), lo mismo.
+- `deriveTxToastState` recibe `isError` (`:1133`), que es error de query, no
+  revert. Su branch `failed` **nunca dispara** en un revert, contra lo que
+  afirman los comentarios de `:1127` y `tx-toast-state.ts:18`.
+
+## Goal
+
+Ningún efecto de éxito (celebración, persistencia local, write-through a Supabase,
+telemetría `stage: "success"`, toast de éxito) ocurre antes de que el nodo
+confirme `receipt.status === "success"`.
+
+## Non-goals
+
+- Shop buy y victory mint (spec 1 los deja consistentes a nivel helper; el
+  `buyItem` de shop sigue sin esperar receipt y **queda como follow-up explícito**).
+- Decodificar custom errors.
+- Anti-cheat. Verificar el receipt confirma que la cadena aceptó la tx, no que el
+  score sea legítimo: `/api/sign-badge:23` sigue firmando cualquier `levelId`.
+  **No mezclar los dos en el PR ni en el handoff.**
+
+## Pre-requisito: el seam testable (P0 del red-team)
+
+`<ExercisesScreen>` tiene ~2.900 líneas y **no tiene harness**. Sin extraerlo, 7
+de 9 criterios no son falsables y se implementa contra `tsc` y buena fe, que es
+como se shipeó el bug de `badge-sheet` con la suite en verde.
+
+**Tarea 0, no negociable:** extraer los dos handlers a hooks con harness propio.
+
+```ts
+// lib/exercises/use-onchain-write.ts
+export type OnChainWritePhase = "idle" | "signing" | "confirming" | "settled";
+
+export type OnChainWriteResult =
+  | { status: "success"; txHash: `0x${string}` }
+  | { status: "reverted"; txHash: `0x${string}`; error: TransactionRevertedError }
+  | { status: "timeout"; txHash: `0x${string}` }
+  | { status: "cancelled" }
+  | { status: "failed"; error: unknown };
+
+export function useOnChainWrite(): {
+  phase: OnChainWritePhase;
+  /** Firma, broadcastea, y espera el receipt. Nunca resuelve "success"
+   *  sin `receipt.status === "success"`. */
+  run: (req: WriteRequest) => Promise<OnChainWriteResult>;
+};
+```
+
+El hook devuelve un resultado **discriminado**, no lanza: el call site decide qué
+celebrar. Los efectos de éxito viven en un solo `if (result.status === "success")`.
+
+## Contracts (SDD)
+
+Consume del spec 1: `waitForReceiptWithTimeout`, `TransactionRevertedError`,
+`isTransactionReverted`, y el mapeo a kind `"revert"`.
+
+```ts
+// lib/exercises/tx-toast-state.ts — corrección del input mentiroso
+export type TxToastInputs = {
+  isWriting: boolean;
+  isConfirming: boolean;
+  /** `true` SOLO si la tx se minó y revirtió, o el envío falló.
+   *  Antes recibía `useWaitForTransactionReceipt().isError`, que es un
+   *  error de query y nunca refleja un revert. */
+  hasFailed: boolean;
+  txHash: string | null;
+  doneAt: number | null;
+};
+```
+
+## Behavior
+
+1. Broadcast (badge o score): la fase pasa a `confirming`, la telemetría emite
+   `stage: "broadcast"`, y **ningún** efecto de éxito corre.
+2. Badge + receipt `success`: `hapticSuccess()`, `justClaimed[piece] = true`,
+   modal `piece-unlocked` de la siguiente pieza, overlay `variant: "badge"`,
+   telemetría `stage: "success"`.
+3. Badge + receipt `reverted`: overlay `variant: "error"` con `error.revert` y
+   `retryAction`; telemetría `stage: "error", error_kind: "revert"`. Cero mutación
+   de estado local.
+4. Score + receipt `success`, en este orden: `recordSaveFor(piece, score, txHash)`
+   → `chesscito:optimistic-score` → `/api/cache-score` → refresh del leaderboard
+   → overlay `variant: "score"` → done-hold.
+5. Score + receipt `reverted`: overlay de error. El score **no** se persiste en
+   localStorage, ni en sessionStorage, ni en Supabase.
+6. Timeout (120s sin minar): kind `"timeout"`, copy existente. El estado no se
+   muta; la tx puede confirmar después.
+7. La pieza usada al persistir es la capturada al broadcast, no `selectedPiece` al
+   momento del receipt. El handler **no debe re-leer `selectedPiece` tras el await**.
+   (Hoy lo resuelve `pendingSubmitRef`; con el hook lo resuelve el closure.)
+8. Desmontaje durante `confirming`: ningún `setState` corre tras el await.
+9. Los CTA de Claim y Save están deshabilitados durante `confirming`.
+
+## Las tres responsabilidades del effect de `:1094` (P0 del red-team)
+
+No es un borrado. El effect hace tres cosas y cada una necesita destino:
+
+| Responsabilidad | Hoy | Después |
+| --- | --- | --- |
+| `recordSaveFor(pending.piece, ...)` | effect on `isSubmitSuccess` | dentro de `if (result.status === "success")` |
+| Latch `doneHoldStartedForTxRef` | evita re-disparo del effect | innecesario: el handler corre una vez |
+| Done-hold 1500ms (`setTxDoneAt`) | efecto visual del toast | **se preserva**, disparado en el mismo branch |
+
+Consumidores enumerados (el red-team pedía la lista):
+`isClaimConfirming` → `:1044` `isClaimBusy`, `:2453` y `:2486` (`isBusy` de los CTA).
+`isSubmitConfirming` → `:1045` `isSubmitBusy`, `:1132` `txToast`, `:2326` `isSavingOnChain`.
+`txDoneAt` → `:1135` `txToast.doneAt`.
+
+Ninguno se elimina: todos pasan a leer `phase === "confirming"`.
+
+## Edge cases
+
+- **Doble tap** en Claim durante `confirming`: cubierto por (9); test explícito.
+- **`publicClient` ausente** (wrong chain): fail closed, overlay de error. Verificar
+  antes que `usePublicClient({ chainId })` no sea `undefined` en el path normal de
+  MiniPay, o convertimos un flujo que funciona en uno que falla.
+- **UX del peor caso** (P1 del red-team): el jugador pasa de 0s de espera a hasta
+  120s de spinner, en un WebView que puede pausar timers al ir a background.
+  → **umbral de UI a los 20s**: el overlay degrada a "sigue confirmando, revisá
+  más tarde" y ofrece cerrar, **sin cancelar** la espera real de 120s.
+- **App cerrada durante `confirming`** — divergencia asimétrica: el badge se
+  auto-cura (los `useReadContracts` de badges leen la cadena al montar); el score
+  **no** (`recordSaveFor` escribe localStorage y nadie reconcilia). Ver preguntas.
+- **`/api/cache-score` falla** tras un receipt exitoso: hoy es fire-and-forget con
+  `.catch(() => {})` (`:1860`). Cambiamos "score falso en el leaderboard" por
+  "score real ausente". Elegir explícitamente: reintento con backoff, o aceptar y
+  dejar que el cron `/api/cron/sync` reconcilie.
+
+## Acceptance criteria
+
+- [ ] Los handlers viven en hooks con harness propio; los criterios de abajo se
+      prueban contra ellos, no contra `<ExercisesScreen>`.
+- [ ] Badge + revert: `justClaimed` sin mutar, `piece-unlocked` no se abre,
+      overlay de error, `stage: "error"`.
+- [ ] Badge + success: comportamiento idéntico al actual (regresión).
+- [ ] Score + revert: `recordSaveFor` no se llama, `/api/cache-score` no se llama,
+      `chesscito:optimistic-score` no se escribe.
+- [ ] Score + success: los tres corren, en el orden de (4).
+- [ ] `deriveTxToastState` con `hasFailed: true` produce el toast `failed`
+      (y existe un test que lo alcanza vía un revert, no vía un error de query).
+- [ ] Sin `setState` tras desmontaje.
+- [ ] CTA deshabilitado durante `confirming`.
+- [ ] El done-hold de 1500ms sigue ocurriendo tras un save exitoso.
+- [ ] Baseline VR para el estado `confirming` si la UI cambia.
+- [ ] Smoke en device (mainnet): un claim exitoso celebra igual, con ~5s de
+      confirmación visible.
+
+## Out of scope / future
+
+- **Shop `buyItem`** (`use-shop-sheet-state.ts:466-484`): setea `successBanner` y
+  dispara `fireOnPurchaseSuccess` (que muta shields en el host) sobre el hash, sin
+  esperar su receipt. Mismo bug, superficie de dinero. Follow-up inmediato.
+- Reconciliación del score al volver a la app.
+
+## Open questions
+
+1. **Score divergente**: ¿reconciliamos leyendo el Scoreboard al montar, o
+   aceptamos la divergencia y confiamos en el cron?
+2. **`/api/cache-score` fallido tras receipt exitoso**: ¿reintento o cron?
+3. ¿El estado `confirming` es una variante nueva del `ResultOverlay` o reusa el
+   toast existente? Decide si hace falta baseline VR.
+
+## Nota de telemetría (P1 del red-team)
+
+Cambiar `stage: "success"` de "broadcast" a "minada y exitosa" redefine el funnel.
+La tasa de éxito de `badge_claim_tx` **va a caer** y se va a leer como una
+regresión de este PR. Sumado al re-bucketeo de `error_kind` del PR #197, son dos
+discontinuidades seguidas. Anotarlo en el handoff.

--- a/docs/specs/receipt-status-verification-redteam.md
+++ b/docs/specs/receipt-status-verification-redteam.md
@@ -1,0 +1,169 @@
+# Red Team Review — receipt-status-verification
+
+**Date**: 2026-07-09
+**Reviewer mindset**: hostile QA + senior engineer
+
+La premisa del spec se verificó contra el código, no se asumió:
+`viem@2.46.3/_esm/actions/public/waitForTransactionReceipt.js` resuelve con el
+receipt (`emit.resolve(receipt)`, líneas 79/106/131/188) y **nunca inspecciona
+`status`**. Por lo tanto `useWaitForTransactionReceipt().isSuccess` es `true`
+para una tx revertida. El bug es real.
+
+Lo que sigue es lo que el spec **no** resuelve.
+
+## Findings
+
+### P0 — Must address before implementation
+
+- **[testabilidad] Los acceptance criteria no son falsables hoy.** El spec pide
+  aseverar el comportamiento de los handlers de `<ExercisesScreen>`, un componente
+  de ~2.900 líneas **sin harness de test** — hecho ya registrado como deuda
+  abierta (`MEMORY.md`: "Extract a testable seam for ExercisesScreen"). Sin
+  extraer los dos handlers a un hook (`useOnChainWrite` / `useBadgeClaim` /
+  `useScoreSave`), no hay TDD posible: se implementa contra `tsc` y buena fe.
+  — **Por qué bloquea:** es exactamente cómo se shipeó el bug de `badge-sheet`
+  con la suite en verde (`feedback_tests_green_against_dead_shape`). El spec pide
+  9 criterios y no puede probar 7. El costo del seam no está estimado en el spec.
+
+- **[scope leak] Cambiar `waitForReceiptWithTimeout` toca dos call sites que el
+  spec declara fuera de alcance**, en el mismo PR: shop approve
+  (`use-shop-sheet-state.ts:461`) y victory (`use-mint-victory.ts:606`). El spec
+  lo llama "deseable" y no define ni un test para ellos.
+  — **Por qué bloquea:** "fuera de alcance" y "hereda el cambio de contrato" son
+  incompatibles. O entran con cobertura, o el helper recibe el chequeo detrás de
+  un parámetro y los call sites migran uno por uno.
+
+- **[incoherencia] En victory, solo UNA de las dos ramas quedaría verificada.**
+  `use-mint-victory.ts:601-607` elige entre `injected.waitReceipt(hash)` (MiniPay)
+  y `waitForReceiptWithTimeout(...)` (web). Si el chequeo vive en el helper, el
+  path web empieza a lanzar en reverts y **el path MiniPay sigue celebrando**.
+  El mismo botón, dos verdades, y MiniPay es el target de distribución.
+  — **Por qué bloquea:** produce una inconsistencia peor que el bug actual,
+  porque ahora es no determinista según el entorno.
+
+- **[borrado con efectos colaterales] El effect de `:1094-1114` hace TRES cosas**,
+  no una: (1) `recordSaveFor`, (2) el latch `doneHoldStartedForTxRef`, (3) el
+  done-hold de 1500ms (`setTxDoneAt` + timer, con un comentario explícito sobre
+  por qué `txDoneAt` no está en las deps). El spec dice "se borra" y relega el
+  done-hold a "hay que verificar".
+  — **Por qué bloquea:** borrarlo elimina silenciosamente la ventana de UI de
+  éxito. Eso es un cambio visual sin baseline VR y sin criterio de aceptación.
+
+### P1 — Should address
+
+- **[UX] Un solo timeout para dos propósitos distintos.** El spec reusa
+  `DEFAULT_TX_TIMEOUT_MS = 120_000` como límite de la fase `confirming`. Hoy el
+  jugador espera 0s; con esto puede mirar un spinner **dos minutos** antes de ver
+  nada. En un WebView de MiniPay que puede pausar timers al ir a background, ese
+  peor caso no es teórico.
+  — Riesgo: cambiar una mentira rápida por una verdad insoportable. Hace falta un
+  umbral de UI (~15-20s) que degrade a "sigue confirmando, revisá más tarde" sin
+  cancelar la espera real.
+
+- **[telemetría] Redefinir `stage: "success"` rompe el funnel histórico en
+  silencio.** Hoy significa "broadcast"; pasaría a significar "minada y exitosa".
+  La tasa de éxito de `badge_claim_tx` va a **caer** y va a leerse como una
+  regresión introducida por este PR.
+  — Riesgo: nadie va a poder comparar antes/después. Sumado a que el fix del
+  `"400"` (#197) ya re-bucketeó `error_kind`, son dos discontinuidades seguidas.
+
+- **[copy] Este spec hace visible el revert por primera vez, con la peor copy
+  disponible.** `error.revert` dice "Transaction failed. This action may not be
+  available right now." La causa real más probable de un claim revertido es
+  `BadgeAlreadyClaimed`, que **tiene copy dedicada** ("You already own this
+  badge!") y que no se va a mostrar porque el decoder está diferido.
+  — Riesgo: shipear la verificación sin el decoder convierte un falso éxito en un
+  error genérico y desconcertante. Argumenta por hacer los dos juntos, o por
+  aceptar conscientemente el intermedio.
+
+- **[fire-and-forget] Mover `/api/cache-score` después del receipt agranda su
+  ventana de fallo silencioso.** Ya tiene `.catch(() => {})` (`:1860`). Con el
+  chequeo, la tx está confirmada on-chain y Supabase puede quedarse sin el score,
+  sin ninguna señal. El leaderboard combinado lee esa tabla.
+  — Riesgo: cambiamos "score falso en el leaderboard" por "score real ausente".
+  Ambos son divergencia; el spec no elige explícitamente.
+
+- **[guard] `isClaimConfirming` tiene consumidores no enumerados.** El spec dice
+  "reemplazar por la fase" sin listar quién lo lee. Enumerar antes de tocar.
+
+### P2 — Nice to clarify
+
+- **[divergencia] Open question 1 es asimétrica y el spec no lo nota.** Si el
+  jugador cierra la app en `confirming`: el badge **se auto-cura** (los
+  `useReadContracts` de badges leen la cadena al montar), el score **no**
+  (`recordSaveFor` escribe localStorage y nadie reconcilia). Son dos problemas
+  distintos disfrazados de uno.
+
+- **[contrato] `confirmations`** queda como pregunta abierta pero afecta la
+  latencia percibida directamente. Decidir (1, el default de viem) y borrar la
+  pregunta. Celo no tiene reorgs relevantes a esta escala.
+
+- **[fail-closed] "Si no hay `publicClient`, error"** es la decisión correcta,
+  pero hay que confirmar que `usePublicClient({ chainId })` no devuelve
+  `undefined` en el path normal de MiniPay antes de convertir un flujo que
+  funciona en uno que falla.
+
+- **[naming]** `TransactionRevertedError` junto a `TransactionTimeoutError`:
+  consistente. Sin objeción.
+
+## Categories audited
+
+### Contract gaps
+`TransactionRevertedError` expone `receipt`, lo cual es correcto (permite leer
+`gasUsed`, `logs`). No hay `any`. Falta: el tipo de la fase
+(`OnChainWritePhase`) se declara pero el spec nunca dice **dónde vive** — si es
+estado local de `<ExercisesScreen>` (2.900 líneas, sin harness) o del hook
+extraído. Es la misma herida del P0 de testabilidad.
+
+### Behavioral ambiguity
+Behavior 7 dice "el estado no se muta: la tx puede confirmar más tarde", pero no
+define qué ve el jugador si efectivamente confirma después. ¿Se entera alguna vez?
+
+Behavior 9 traslada la invariante piece-switch del `pendingSubmitRef` al closure.
+Correcto **solo si** el handler no re-lee `selectedPiece` tras el await. No está
+escrito como restricción.
+
+### Hidden assumptions
+- Que `publicClient` existe y apunta a la chain correcta.
+- Que MiniPay no mata el WebView durante los ~5s.
+- Que la wallet devuelve un hash de una tx que efectivamente se broadcasteó.
+
+### Backward compatibility
+El cambio de postcondición de `waitForReceiptWithTimeout` es **breaking para sus
+consumidores actuales**, y todos están fuera del alcance declarado. Ver P0.
+
+### Security & data
+Ninguna superficie nueva. Nota: este spec **no** es anti-cheat. Verificar el
+receipt confirma que la cadena aceptó la tx, no que el score fuera legítimo:
+`/api/sign-badge` sigue firmando cualquier `levelId` sin mirar estrellas
+(`route.ts:23`). No confundir los dos en el PR ni en el handoff.
+
+### Test coverage gaps
+7 de 9 criterios apuntan a comportamiento dentro de `<ExercisesScreen>`. Sin
+harness, no son verificables. Los 2 restantes (el helper y el clasificador) sí lo
+son hoy, y son los únicos que este spec puede probar tal como está escrito.
+
+### Operational readiness
+No hay plan de rollback. El cambio es puramente client-side y va por deploy, así
+que el rollback es un revert + redeploy. Aceptable, pero conviene declararlo,
+porque el blast radius incluye shop y victory vía el helper compartido.
+
+## Verdict
+
+**NEEDS REVISION** — 4 P0.
+
+Para pasar a `/tdd`, el spec debe:
+
+1. Absorber el costo del **seam testable** (extraer los handlers a un hook), o
+   bajar los acceptance criteria a lo que realmente se puede probar y decirlo.
+2. Decidir el alcance del helper: o entra con shop + victory y sus tests, o el
+   chequeo va detrás de un parámetro y se migra call site por call site.
+3. Resolver la **asimetría de victory** (`injected.waitReceipt` vs helper) antes
+   de tocar el helper, aunque victory quede fuera del PR.
+4. Tratar el effect de `:1094` como tres responsabilidades y decir qué pasa con
+   el done-hold, con criterio de aceptación y baseline VR si cambia.
+
+Recomendación de ruta: **partir el spec en dos**. `receipt-status-helper`
+(helper + clasificador + tests, verificable hoy, sin tocar UI) y
+`receipt-status-learn-handlers` (seam + handlers + UX de `confirming`), que
+depende del primero.

--- a/docs/specs/receipt-status-verification.md
+++ b/docs/specs/receipt-status-verification.md
@@ -1,8 +1,17 @@
 # Spec — receipt-status-verification
 
 **Date**: 2026-07-09
-**Status**: draft
+**Status**: ⚠️ SPLIT — no implementar este archivo
 **Scope**: LEARN only — badge claim + score save. Shop buy and victory mint are documented follow-ups.
+
+> Su red-team (`receipt-status-verification-redteam.md`) devolvió **NEEDS
+> REVISION** con 4 P0. Este documento se conserva como registro del problema y
+> de la iteración. El trabajo implementable vive partido en:
+>
+> 1. **`receipt-status-helper.md`** — helper + clasificador + los tres consumidores
+>    actuales. Sin UI. Todos sus criterios son verificables hoy. **Empezar acá.**
+> 2. **`receipt-status-learn-handlers.md`** — seam testable + handlers de LEARN +
+>    UX de `confirming`. Depende del anterior.
 
 ## Problem
 

--- a/docs/specs/receipt-status-verification.md
+++ b/docs/specs/receipt-status-verification.md
@@ -1,0 +1,224 @@
+# Spec — receipt-status-verification
+
+**Date**: 2026-07-09
+**Status**: draft
+**Scope**: LEARN only — badge claim + score save. Shop buy and victory mint are documented follow-ups.
+
+## Problem
+
+Los dos writes on-chain de LEARN declaran éxito sobre el **hash de la transacción**,
+no sobre su resultado. Una tx que se mina y revierte es indistinguible de una que
+tuvo éxito.
+
+- **Badge claim** (`exercises-screen.tsx:1581-1606`): tras `writeContractAsync`
+  se dispara `hapticSuccess()`, `justClaimed[piece] = true`, el modal
+  `piece-unlocked` de la siguiente pieza, y el overlay `variant: "badge"`. Nunca
+  se lee un receipt. Si la tx revierte, el jugador ve la celebración y cree que
+  tiene el badge.
+- **Score save** (`exercises-screen.tsx:1821-1846`): sí espera el receipt vía
+  `useWaitForTransactionReceipt` (`:1016`), pero consume `isSuccess`, que en
+  wagmi significa **"la query resolvió"**, no `receipt.status === "success"`.
+  viem devuelve el receipt de una tx revertida sin lanzar. Por lo tanto el
+  effect de `:1095` corre igual y `recordSaveFor` **persiste el score** de una
+  tx revertida.
+- Peor: `/api/cache-score` se llama al broadcast (`:1850`), antes de cualquier
+  receipt. El leaderboard combinado de Supabase lee esa tabla como la fuente
+  `scores` on-chain. Un revert deja un score falso en el leaderboard.
+- `sessionStorage["chesscito:optimistic-score"]` (`:1864`) tiene el mismo defecto.
+
+El precedente correcto ya existe **server-side**: `/api/verify-pro/route.ts:60` y
+`/api/verify-payment/route.ts:193` chequean `receipt.status !== "success"`.
+Ninguna superficie de jugador lo hace.
+
+Este bug precede y domina al de los custom errors: si el revert ocurre después de
+firmar, no hay error que decodificar porque nadie lanza nada.
+
+## Goal
+
+Ningún estado de éxito (overlay, celebración, persistencia local, write-through a
+Supabase, telemetría `stage: "success"`) se produce hasta que el nodo confirme
+`receipt.status === "success"` para esa tx.
+
+## Non-goals
+
+- Shop buy (`use-shop-sheet-state.ts:466`) y victory mint (`use-mint-victory.ts:606`).
+  Documentados en "Out of scope" con su hallazgo. Victory además usa
+  `injected.waitReceipt`, tipado como `unknown` y casteado a `{ logs }`.
+- Decodificar custom errors. Ortogonal, ver `docs/reviews/2026-07-09-custom-errors-plan-redteam.md`.
+- Recuperar/reintentar automáticamente una tx revertida.
+- Anti-cheat / server-verified progress.
+
+## Contracts (SDD)
+
+### 1. Nuevo error, hermano de `TransactionTimeoutError`
+
+```ts
+// lib/contracts/transaction-helpers.ts
+import type { Hash, TransactionReceipt } from "viem";
+
+export class TransactionRevertedError extends Error {
+  readonly hash: Hash;
+  readonly receipt: TransactionReceipt;
+
+  constructor(hash: Hash, receipt: TransactionReceipt) {
+    super(`Transaction reverted on-chain: ${hash}`);
+    this.name = "TransactionRevertedError";
+    this.hash = hash;
+    this.receipt = receipt;
+  }
+}
+```
+
+### 2. El helper compartido se vuelve fail-closed
+
+```ts
+/** Resuelve SOLO con un receipt cuyo `status === "success"`.
+ *  Lanza TransactionRevertedError si la tx se minó y revirtió.
+ *  Lanza TransactionTimeoutError si no se minó dentro de timeoutMs. */
+export async function waitForReceiptWithTimeout(
+  client: PublicClient,
+  hash: Hash,
+  opts?: { timeoutMs?: number; confirmations?: number },
+): Promise<TransactionReceipt>;
+```
+
+El cambio de contrato es el **postcondition**: hoy devuelve cualquier receipt;
+después devuelve solo receipts exitosos. Los call sites existentes (shop approve,
+victory) heredan el fail-closed sin editarlos — deseable, un `approve` revertido
+no debe continuar hacia el `buyItem`.
+
+### 3. Clasificación
+
+```ts
+// lib/errors.ts
+export function isTransactionReverted(error: unknown): boolean;
+```
+
+`classifyTxErrorKind` mapea `TransactionRevertedError` → `"revert"` (kind y copy
+ya existen: `RESULT_OVERLAY_COPY.error.revert`). **No** se agregan claves de copy,
+por lo tanto no hay trabajo de i18n ni de baselines VR.
+
+### 4. Fases del handler
+
+```ts
+type OnChainWritePhase = "idle" | "signing" | "confirming" | "settled";
+```
+
+`signing` = esperando a la wallet. `confirming` = hash conocido, esperando receipt.
+
+## Behavior
+
+1. Dado un claim de badge, cuando `writeContractAsync` resuelve con un hash,
+   entonces la fase pasa a `confirming` y **no** se muestra celebración,
+   **no** se setea `justClaimed`, **no** se abre `piece-unlocked`, y la telemetría
+   emite `stage: "broadcast"` (no `"success"`).
+2. Dado un claim en `confirming`, cuando el receipt llega con `status: "success"`,
+   entonces se dispara `hapticSuccess()`, `justClaimed[piece] = true`, el modal
+   `piece-unlocked` de la siguiente pieza, el overlay `variant: "badge"`, y
+   telemetría `stage: "success"`.
+3. Dado un claim en `confirming`, cuando el receipt llega con `status: "reverted"`,
+   entonces se muestra el overlay `variant: "error"` con la copy `error.revert`,
+   con `retryAction`, y telemetría `stage: "error", error_kind: "revert"`.
+   Ningún estado local se muta.
+4. Dado un save de score, cuando `writeContractAsync` resuelve con un hash,
+   entonces la fase pasa a `confirming` y **no** se llama `/api/cache-score`,
+   **no** se escribe `chesscito:optimistic-score`, **no** se llama `recordSaveFor`.
+5. Dado un save en `confirming`, cuando el receipt confirma `status: "success"`,
+   entonces se llama `recordSaveFor(piece, score)`, se hace el write-through a
+   `/api/cache-score`, se escribe el optimistic-score, se refresca el leaderboard,
+   y el overlay muestra `variant: "score"`.
+6. Dado un save en `confirming`, cuando el receipt revierte, entonces overlay
+   `variant: "error"` con `error.revert` y retry. **El score no se persiste en
+   ningún lado**: ni local, ni Supabase, ni sessionStorage.
+7. Dado cualquiera de los dos en `confirming`, cuando pasan `DEFAULT_TX_TIMEOUT_MS`
+   (120s) sin receipt, entonces `TransactionTimeoutError` → kind `"timeout"` →
+   copy existente ("Check your wallet or try again"). El estado no se muta: la tx
+   puede confirmar más tarde.
+8. Dado un handler en `confirming`, cuando el componente se desmonta, entonces
+   ningún `setState` corre tras el await (guard `isMountedRef`).
+9. La pieza usada al persistir es la capturada **al broadcast**, no la
+   `selectedPiece` del momento del receipt. (Invariante que hoy resuelve
+   `pendingSubmitRef`; con el handler imperativo lo resuelve el closure.)
+
+## Consecuencia de diseño (no obvia)
+
+Ni badge ni score usan `waitForReceiptWithTimeout` hoy: usan el hook
+`useWaitForTransactionReceipt` (`:1005`, `:1016`). Poner el chequeo en el helper
+**no los cubre**. Ambos handlers deben volverse imperativos:
+
+```ts
+const txHash = await writeWithOptionalFeeCurrency(...);
+setPhase("confirming");
+track("badge_claim_tx", { stage: "broadcast", piece });
+await waitForReceiptWithTimeout(publicClient, txHash);   // lanza si revierte
+if (!isMountedRef.current) return;
+// ...todo el éxito, acá
+```
+
+Los hooks quedan solo para el spinner (`isClaimConfirming`) o se eliminan. El
+effect de `:1095` (`isSubmitSuccess` → `recordSaveFor`) se borra, y con él
+`pendingSubmitRef` y `doneHoldStartedForTxRef` pierden su razón de ser: hay que
+verificar si el "done hold" del overlay depende de ellos antes de sacarlos.
+
+## Edge cases
+
+- **Doble tap** en Claim mientras `confirming`: el CTA debe estar deshabilitado.
+  Hoy el guard es `isClaimConfirming` del hook; hay que reemplazarlo por la fase.
+- **`publicClient` ausente**: `usePublicClient({ chainId })` puede devolver
+  `undefined` en wrong-chain. Hoy shop lanza `"Missing public client"`. Definir:
+  si no hay client, ¿fallamos closed (error) o degradamos a optimista? → **fail
+  closed**, mostrar error. Un éxito no verificable no se muestra como éxito.
+- **Tx reemplazada** (speed-up / cancel desde la wallet): viem lanza
+  `TransactionNotFoundError` o resuelve con el reemplazo. Sin cobertura hoy.
+- **MiniPay en background**: el WebView puede pausar timers durante los ~5s.
+  El timeout de 120s absorbe esto, pero conviene medirlo en device.
+- **Receipt con `status: "success"` pero sin el evento esperado**: fuera de
+  alcance acá (es el bug de victory: `logs` vacío → `tokenId: null` → éxito).
+- **El jugador cierra la app en `confirming`**: la tx confirma sola on-chain, el
+  estado local nunca se escribe. Al volver, `useReadContracts` de badges lee la
+  verdad. Para score, `recordSaveFor` nunca corre → divergencia local vs chain.
+  **Pregunta abierta.**
+- **Quota de sesión**: si el save consumió un slot de la sesión diaria al
+  broadcast, un revert lo pierde. Verificar dónde se decrementa.
+
+## Acceptance criteria
+
+- [ ] `waitForReceiptWithTimeout` lanza `TransactionRevertedError` cuando el
+      receipt trae `status: "reverted"`, y devuelve el receipt cuando es `"success"`.
+- [ ] `classifyTxErrorKind(new TransactionRevertedError(...))` devuelve `"revert"`.
+- [ ] Badge claim con receipt revertido: no setea `justClaimed`, no abre
+      `piece-unlocked`, muestra overlay de error, emite `stage: "error"`.
+- [ ] Badge claim con receipt exitoso: mantiene exactamente el comportamiento de hoy.
+- [ ] Score save con receipt revertido: `recordSaveFor` no se llama,
+      `/api/cache-score` no se llama, `chesscito:optimistic-score` no se escribe.
+- [ ] Score save con receipt exitoso: los tres se llaman, en ese orden.
+- [ ] Ningún `setState` tras el await si el componente se desmontó.
+- [ ] El CTA de Claim/Save está deshabilitado durante `confirming`.
+- [ ] Suite completa verde; sin claves de copy nuevas; sin baselines VR nuevos.
+- [ ] Smoke en device (mainnet): un claim exitoso sigue celebrando, y el
+      overlay de confirmación aparece durante ~5s.
+
+## Out of scope / future
+
+- **Shop buy** (`use-shop-sheet-state.ts:466-484`): setea `successBanner` y
+  dispara `fireOnPurchaseSuccess` (que muta shields en el host) sobre el hash
+  del `buyItem`, sin esperar su receipt. Hereda el fix del helper solo si se
+  agrega el `await`.
+- **Victory mint** (`use-mint-victory.ts:601-644`): tipa el receipt como
+  `{ logs }`, nunca lee `status`. Un revert deja `logs` vacío → `tokenId: null`
+  → `setClaimPhase("success")` con link a celoscan. Decisión ya tomada para
+  cuando se aborde: **no confiar en `injected.waitReceipt`**, re-verificar
+  `status` con `publicClient.getTransactionReceipt(hash)`.
+- Reconciliación al volver a la app tras cerrar en `confirming`.
+
+## Open questions
+
+1. **Score divergente**: si el jugador cierra la app en `confirming` y la tx
+   confirma, el score existe on-chain pero no en local ni en Supabase. ¿Se
+   reconcilia al montar (leer el scoreboard) o se acepta la divergencia?
+2. **Quota de sesión diaria**: ¿dónde se decrementa el slot, al broadcast o al
+   éxito? Un revert no debería consumirlo.
+3. **`confirmations`**: ¿esperamos 1 confirmación o `undefined` (default de viem)?
+   Celo tiene finalidad rápida; 1 debería bastar.
+4. ¿El overlay `confirming` es una variante nueva del `ResultOverlay` o reusamos
+   el spinner existente? Toca UI → baseline VR en el mismo PR si es nuevo.


### PR DESCRIPTION
Spec-only. **Sin código.** Sale de `/spec` (spec + revisión adversarial) sobre el
hallazgo P0 del red-team de custom errors.

## El bug

Badge claim y score save declaran éxito sobre el **hash**, no sobre el resultado.

Verificado en `viem@2.46.3/_esm/actions/public/waitForTransactionReceipt.js`:
resuelve con `emit.resolve(receipt)` y **nunca inspecciona `status`**. Por lo
tanto `useWaitForTransactionReceipt().isSuccess` es `true` para una tx revertida.

- Un claim revertido muestra la celebración del badge y setea `justClaimed`.
- Un save revertido persiste el score en localStorage **y lo escribe en el
  leaderboard de Supabase** (`/api/cache-score` se llama al broadcast, `:1850`).

El precedente correcto ya existe server-side (`/api/verify-pro/route.ts:60`).
Ninguna superficie de jugador lo hace.

## El red-team devolvió NEEDS REVISION (4 P0)

Contra mi propio spec:

1. **7 de 9 acceptance criteria no eran falsables.** `<ExercisesScreen>` tiene
   ~2.900 líneas y no tiene harness — deuda ya registrada en memoria.
2. **El cambio al helper tocaba shop y victory**, declarados fuera de alcance.
3. **En victory solo una de dos ramas quedaba verificada.** `injected.waitReceipt`
   (MiniPay) vs el helper (web): el path web habría empezado a fallar honestamente
   mientras MiniPay seguía celebrando. MiniPay es el target de distribución.
4. **El effect de `:1094` hace tres cosas**, no una: persiste el score, mantiene un
   latch, y corre el done-hold de 1500ms. "Se borra" lo eliminaba en silencio.

## El split

| Spec | Contenido | Estado |
| --- | --- | --- |
| `receipt-status-helper.md` | helper + clasificador + los 3 call sites actuales. Sin UI, sin copy, sin VR. | **ready for /tdd** |
| `receipt-status-learn-handlers.md` | seam testable + handlers de LEARN + UX de `confirming`. | draft, bloqueado por el anterior |
| `receipt-status-verification.md` | el original + su red-team, como registro. | ⚠️ SPLIT, no implementar |

Todos los criterios del spec 1 son verificables **hoy**: los harnesses existen
(`transaction-helpers.test.ts`, `use-mint-victory.test.ts`,
`use-shop-sheet-state.test.tsx`, `errors.test.ts`).

## Hallazgo extra, encontrado enumerando consumidores

`deriveTxToastState` recibe `useWaitForTransactionReceipt().isError`, que es un
**error de query**. Su branch `failed` nunca dispara en un revert. Los comentarios
de `exercises-screen.tsx:1127` (*"chain revert now surfaces as a sticky failed
toast"*) y de `tx-toast-state.ts:18` (*"chain revert / RPC error"*) son falsos.

Tercera aparición de `feedback_tests_green_against_dead_shape` en esta sesión.

## Nota importante

Esto **no es anti-cheat**. Verificar el receipt confirma que la cadena aceptó la
tx, no que el score fuera legítimo: `/api/sign-badge:23` sigue firmando cualquier
`levelId` sin mirar estrellas. No confundir los dos.

Wolfcito 🐾 @akawolfcito
