### PR TITLE
feat(contracts): fail closed on reverted and unreadable tx receipts

### DIFF
--- a/apps/web/src/lib/__tests__/errors.test.ts
+++ b/apps/web/src/lib/__tests__/errors.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { classifyTxErrorKind } from "../errors";
+import type { Hash, TransactionReceipt } from "viem";
+import {
+  classifyTxErrorKind,
+  isReceiptUnverifiable,
+  isTransactionReverted,
+} from "../errors";
+import {
+  TransactionReceiptUnverifiableError,
+  TransactionRevertedError,
+} from "../contracts/transaction-helpers";
 
 describe("classifyTxErrorKind — ERC2612 permit reverts", () => {
   it("classifies ERC2612ExpiredSignature as revert", () => {
@@ -80,5 +89,80 @@ describe("classifyTxErrorKind — revert vs signingUnavailable disambiguation", 
       "execution reverted\n  address: 0x400aAA176d5f46e45789A8b18C8E990f663959a",
     );
     expect(classifyTxErrorKind(err)).toBe("revert");
+  });
+});
+
+describe("classifyTxErrorKind — TransactionRevertedError is typed, not parsed", () => {
+  const HASH = "0x4001beef" as Hash;
+  const receipt = { status: "reverted" } as unknown as TransactionReceipt;
+
+  it("classifies a TransactionRevertedError as revert", () => {
+    expect(classifyTxErrorKind(new TransactionRevertedError(HASH, receipt))).toBe("revert");
+  });
+
+  // The whole point of the typed error: classification must not depend on the
+  // prose of `message`. A revert whose message happens to read like an HTTP
+  // 4xx must still classify as a revert, because we know what it IS.
+  it("wins over the string heuristics even when the message reads like an HTTP 400", () => {
+    const err = new TransactionRevertedError(HASH, receipt);
+    Object.defineProperty(err, "message", { value: "HTTP 400 signing failed" });
+    expect(classifyTxErrorKind(err)).toBe("revert");
+  });
+
+  it("recognises a cross-realm duck-typed revert by name", () => {
+    // Same escape hatch `isTransactionTimeout` already relies on (errors.ts:11)
+    // for errors that cross a bundle/realm boundary and lose `instanceof`.
+    const err = Object.assign(new Error("HTTP 400"), {
+      name: "TransactionRevertedError",
+    });
+    expect(isTransactionReverted(err)).toBe(true);
+    expect(classifyTxErrorKind(err)).toBe("revert");
+  });
+
+  it("does not treat a plain Error as reverted", () => {
+    expect(isTransactionReverted(new Error("boom"))).toBe(false);
+  });
+
+  // A typed revert must not be demoted to `cancelled` because its prose happens
+  // to contain a cancellation keyword. `isUserCancellation` is a substring
+  // scan; the typed check has to run ahead of it.
+  it("wins over the cancellation heuristic", () => {
+    const err = new TransactionRevertedError(HASH, receipt);
+    Object.defineProperty(err, "message", { value: "User rejected the request" });
+    expect(classifyTxErrorKind(err)).toBe("revert");
+  });
+
+  it("still classifies a plain wallet rejection as cancelled", () => {
+    // Untyped: the heuristic remains the only signal, and must stay silent.
+    expect(classifyTxErrorKind(new Error("User rejected the request"))).toBe("cancelled");
+  });
+});
+
+describe("classifyTxErrorKind — an unverifiable receipt is not a revert", () => {
+  const HASH = "0xdeadbeef" as Hash;
+  const receipt = { transactionHash: HASH } as unknown as TransactionReceipt;
+
+  it("classifies TransactionReceiptUnverifiableError as unknown, never revert", () => {
+    const err = new TransactionReceiptUnverifiableError(HASH, receipt, undefined);
+    expect(classifyTxErrorKind(err)).toBe("unknown");
+    expect(classifyTxErrorKind(err)).not.toBe("revert");
+  });
+
+  it("is not reported as a revert by isTransactionReverted", () => {
+    const err = new TransactionReceiptUnverifiableError(HASH, receipt, "pending");
+    expect(isTransactionReverted(err)).toBe(false);
+    expect(isReceiptUnverifiable(err)).toBe(true);
+  });
+
+  it("recognises a cross-realm duck-typed unverifiable receipt by name", () => {
+    const err = Object.assign(new Error("HTTP 400"), {
+      name: "TransactionReceiptUnverifiableError",
+    });
+    expect(isReceiptUnverifiable(err)).toBe(true);
+    expect(classifyTxErrorKind(err)).toBe("unknown");
+  });
+
+  it("does not treat a plain Error as unverifiable", () => {
+    expect(isReceiptUnverifiable(new Error("boom"))).toBe(false);
   });
 });

--- a/apps/web/src/lib/coach/__tests__/use-mint-victory.test.ts
+++ b/apps/web/src/lib/coach/__tests__/use-mint-victory.test.ts
@@ -181,6 +181,54 @@ describe("useMintVictory", () => {
     expect(sendMint).toHaveBeenCalledTimes(1);
   });
 
+  // A mined-but-reverted mint used to reach `success`: the receipt was cast to
+  // `{ logs }`, so `status` was never read, the VictoryMinted event was simply
+  // absent, and `tokenId: null` degraded the share link to a CeloScan URL while
+  // the player saw a celebration.
+  it("reverted mint receipt never reaches the success phase", async () => {
+    const txHash = ("0x" + "cd".repeat(32)) as `0x${string}`;
+    const sendApprove = vi.fn().mockResolvedValue(("0x" + "01".repeat(32)) as `0x${string}`);
+    const sendMint = vi.fn().mockResolvedValue(txHash);
+    const waitReceipt = vi.fn().mockResolvedValue({ status: "reverted", logs: [] });
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          nonce: "42",
+          deadline: String(Math.floor(Date.now() / 1000) + 300),
+          signature: ("0x" + "ab".repeat(65)) as `0x${string}`,
+        }),
+      })
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    const { result } = renderHook(() =>
+      useMintVictory({
+        gameId: "550e8400-e29b-41d4-a716-446655440000",
+        walletAddress: "0x1111111111111111111111111111111111111111",
+        difficulty: "easy",
+        result: "win",
+        totalMoves: 12,
+        elapsedMs: 60_000,
+        injected: {
+          address: "0x1111111111111111111111111111111111111111",
+          chainId: 42220,
+          sendApprove,
+          sendMint,
+          waitReceipt,
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.phase).not.toBe("claiming"));
+    expect(result.current.phase).not.toBe("success");
+    expect(result.current.errorKind).toBe("revert");
+  });
+
   it("sig rejection → cancelled phase + claimingRef released", async () => {
     const sendSig = vi.fn().mockRejectedValue(new Error("user rejected"));
 
@@ -356,7 +404,7 @@ describe("useMintVictory", () => {
     // (which would crash because wagmi mock returns null for publicClient).
     const sendApprove = vi.fn().mockResolvedValue(("0x" + "00".repeat(32)) as `0x${string}`);
     const sendMint = vi.fn().mockResolvedValue(txHash);
-    const waitReceipt = vi.fn().mockResolvedValue({ logs: [] });
+    const waitReceipt = vi.fn().mockResolvedValue({ status: "success", logs: [] });
 
     // Two sequential successful sign-victory fetches
     const makeSignResponse = () => ({
@@ -428,7 +476,7 @@ describe("useMintVictory", () => {
       const sendMintWithPermit = vi.fn().mockResolvedValue(txHash);
       const sendApprove = vi.fn();
       const sendMint = vi.fn();
-      const waitReceipt = vi.fn().mockResolvedValue({ logs: [] });
+      const waitReceipt = vi.fn().mockResolvedValue({ status: "success", logs: [] });
 
       mockFetch
         .mockResolvedValueOnce({
@@ -483,7 +531,7 @@ describe("useMintVictory", () => {
       const sendMintWithPermit = vi.fn();
       const sendApprove = vi.fn().mockResolvedValue(("0x" + "01".repeat(32)) as `0x${string}`);
       const sendMint = vi.fn().mockResolvedValue(txHash);
-      const waitReceipt = vi.fn().mockResolvedValue({ logs: [] });
+      const waitReceipt = vi.fn().mockResolvedValue({ status: "success", logs: [] });
 
       mockFetch
         .mockResolvedValueOnce({
@@ -582,7 +630,7 @@ describe("useMintVictory", () => {
       const sendMintWithPermit = vi.fn();
       const sendApprove = vi.fn().mockResolvedValue(("0x" + "01".repeat(32)) as `0x${string}`);
       const sendMint = vi.fn().mockResolvedValue(txHash);
-      const waitReceipt = vi.fn().mockResolvedValue({ logs: [] });
+      const waitReceipt = vi.fn().mockResolvedValue({ status: "success", logs: [] });
 
       mockFetch
         .mockResolvedValueOnce({
@@ -650,7 +698,7 @@ describe("useMintVictory", () => {
       const sendMintWithPermit = vi.fn().mockResolvedValue(("0x" + "cc".repeat(32)) as `0x${string}`);
       const sendApprove = vi.fn();
       const sendMint = vi.fn();
-      const waitReceipt = vi.fn().mockResolvedValue({ logs: [] });
+      const waitReceipt = vi.fn().mockResolvedValue({ status: "success", logs: [] });
 
       mockFetch
         .mockResolvedValueOnce({

--- a/apps/web/src/lib/coach/use-mint-victory.ts
+++ b/apps/web/src/lib/coach/use-mint-victory.ts
@@ -16,6 +16,7 @@ import {
   useWriteContract,
 } from "wagmi";
 import { decodeEventLog } from "viem";
+import type { TransactionReceipt } from "viem";
 import { useTranslations } from "next-intl";
 import { getConfiguredChainId, getVictoryNFTAddress } from "@/lib/contracts/chains";
 import { VICTORY_CLAIM_COPY } from "@/lib/content/editorial";
@@ -28,7 +29,10 @@ import {
   normalizePrice,
 } from "@/lib/contracts/tokens";
 import { selectMaxBalanceToken } from "@/lib/contracts/select-payment-token";
-import { waitForReceiptWithTimeout } from "@/lib/contracts/transaction-helpers";
+import {
+  assertReceiptSuccess,
+  waitForReceiptWithTimeout,
+} from "@/lib/contracts/transaction-helpers";
 import { isVictoryPermitMintEnabled } from "@/lib/feature-flags";
 import { permitTokenAbi } from "@/lib/contracts/permit-abi";
 import { permitSignatureToVRS } from "@/lib/contracts/permit-signature";
@@ -598,10 +602,16 @@ export function useMintVictory(input: MintVictoryInput): MintVictoryState {
         });
       }
 
-      type ReceiptLike = { logs: Array<{ data: `0x${string}`; topics: readonly `0x${string}`[] }> };
-      let receipt: ReceiptLike;
+      // The receipt is typed in full, not narrowed to `{ logs }`. That cast is
+      // what hid `status` and let a reverted mint reach the success phase with
+      // an empty log set and `tokenId: null`. Both branches converge on
+      // assertReceiptSuccess so they cannot disagree about what a success is.
+      let receipt: TransactionReceipt;
       if (inp.injected?.waitReceipt) {
-        receipt = (await inp.injected.waitReceipt(claimHash)) as ReceiptLike;
+        receipt = assertReceiptSuccess(
+          claimHash,
+          (await inp.injected.waitReceipt(claimHash)) as TransactionReceipt,
+        );
       } else {
         receipt = await waitForReceiptWithTimeout(publicClient!, claimHash);
       }

--- a/apps/web/src/lib/contracts/__tests__/transaction-helpers.test.ts
+++ b/apps/web/src/lib/contracts/__tests__/transaction-helpers.test.ts
@@ -4,7 +4,10 @@ import type { Hash, PublicClient, TransactionReceipt } from "viem";
 
 import {
   DEFAULT_TX_TIMEOUT_MS,
+  TransactionReceiptUnverifiableError,
+  TransactionRevertedError,
   TransactionTimeoutError,
+  assertReceiptSuccess,
   waitForReceiptWithTimeout,
 } from "../transaction-helpers";
 
@@ -16,7 +19,18 @@ function makeClient(impl: () => Promise<TransactionReceipt>) {
   } as unknown as PublicClient;
 }
 
-const fakeReceipt = { transactionHash: HASH } as unknown as TransactionReceipt;
+/** A receipt always carries `status`. The previous fixture omitted it, which
+ *  is why every assertion here passed against a helper that never read it. */
+const fakeReceipt = {
+  transactionHash: HASH,
+  status: "success",
+} as unknown as TransactionReceipt;
+
+const revertedReceipt = {
+  transactionHash: HASH,
+  status: "reverted",
+  gasUsed: 21_000n,
+} as unknown as TransactionReceipt;
 
 describe("waitForReceiptWithTimeout", () => {
   it("resolves with the receipt when viem returns successfully", async () => {
@@ -66,5 +80,101 @@ describe("waitForReceiptWithTimeout", () => {
     expect(err.timeoutMs).toBe(12_345);
     expect(err.message).toContain(HASH);
     expect(err.message).toContain("12345");
+  });
+
+  // viem resolves `waitForTransactionReceipt` with the receipt and never
+  // inspects `status` (viem@2.46.3, _esm/actions/public/waitForTransactionReceipt.js
+  // — emit.resolve(receipt)). A mined-but-reverted tx therefore looked
+  // identical to a successful one to every caller of this helper.
+  it("rejects with TransactionRevertedError when the tx mined but reverted", async () => {
+    const client = makeClient(async () => revertedReceipt);
+    await expect(waitForReceiptWithTimeout(client, HASH)).rejects.toBeInstanceOf(
+      TransactionRevertedError,
+    );
+  });
+
+  it("never resolves successfully on a reverted receipt", async () => {
+    const client = makeClient(async () => revertedReceipt);
+    const outcome = await waitForReceiptWithTimeout(client, HASH).then(
+      () => "resolved" as const,
+      () => "rejected" as const,
+    );
+    expect(outcome).toBe("rejected");
+  });
+
+  it("still resolves with the receipt when the tx succeeded", async () => {
+    const client = makeClient(async () => fakeReceipt);
+    await expect(waitForReceiptWithTimeout(client, HASH)).resolves.toBe(fakeReceipt);
+  });
+});
+
+describe("assertReceiptSuccess", () => {
+  it("returns the receipt when status is success", () => {
+    expect(assertReceiptSuccess(HASH, fakeReceipt)).toBe(fakeReceipt);
+  });
+
+  // Asserting the constructor alone is not enough: `toThrow(undefined)` matches
+  // ANY throw, so before `assertReceiptSuccess` existed these two passed on the
+  // TypeError from calling a missing function. Pin the type AND the message.
+  it("throws TransactionRevertedError when status is reverted", () => {
+    expect(() => assertReceiptSuccess(HASH, revertedReceipt)).toThrow(
+      TransactionRevertedError,
+    );
+    expect(() => assertReceiptSuccess(HASH, revertedReceipt)).toThrow(
+      `Transaction reverted on-chain: ${HASH}`,
+    );
+  });
+
+  // Fail closed, but do not lie about WHY. "The chain rejected this" and "we
+  // could not read the chain's answer" are different states; collapsing them
+  // would make a reverted tx and an unreadable receipt indistinguishable in
+  // telemetry and in copy.
+  it("throws TransactionReceiptUnverifiableError — not a revert — when status is absent", () => {
+    const shapeless = { transactionHash: HASH } as unknown as TransactionReceipt;
+    expect(() => assertReceiptSuccess(HASH, shapeless)).toThrow(
+      TransactionReceiptUnverifiableError,
+    );
+    expect(() => assertReceiptSuccess(HASH, shapeless)).not.toThrow(
+      TransactionRevertedError,
+    );
+    expect(() => assertReceiptSuccess(HASH, shapeless)).toThrow(
+      `Unverifiable receipt status for ${HASH}: undefined`,
+    );
+  });
+
+  it("throws TransactionReceiptUnverifiableError on an unrecognized status", () => {
+    const weird = { transactionHash: HASH, status: "pending" } as unknown as TransactionReceipt;
+    try {
+      assertReceiptSuccess(HASH, weird);
+      expect.unreachable("assertReceiptSuccess should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionReceiptUnverifiableError);
+      const unverifiable = err as TransactionReceiptUnverifiableError;
+      expect(unverifiable.receivedStatus).toBe("pending");
+      expect(unverifiable.hash).toBe(HASH);
+    }
+  });
+
+  it("waitForReceiptWithTimeout rejects an unverifiable receipt too", async () => {
+    const shapeless = { transactionHash: HASH } as unknown as TransactionReceipt;
+    const client = makeClient(async () => shapeless);
+    await expect(waitForReceiptWithTimeout(client, HASH)).rejects.toBeInstanceOf(
+      TransactionReceiptUnverifiableError,
+    );
+  });
+
+  it("carries the hash and the full receipt on the error", () => {
+    try {
+      assertReceiptSuccess(HASH, revertedReceipt);
+      expect.unreachable("assertReceiptSuccess should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransactionRevertedError);
+      const reverted = err as TransactionRevertedError;
+      expect(reverted.name).toBe("TransactionRevertedError");
+      expect(reverted.hash).toBe(HASH);
+      expect(reverted.receipt).toBe(revertedReceipt);
+      expect(reverted.receipt.gasUsed).toBe(21_000n);
+      expect(reverted.message).toContain(HASH);
+    }
   });
 });

--- a/apps/web/src/lib/contracts/transaction-helpers.ts
+++ b/apps/web/src/lib/contracts/transaction-helpers.ts
@@ -15,6 +15,55 @@ export class TransactionTimeoutError extends Error {
   }
 }
 
+/** A transaction that was mined and reverted. Distinct from a timeout: the
+ *  chain reached a verdict, and the verdict was no. Carries the full receipt
+ *  so callers can read `gasUsed` / `logs` / `blockNumber` for diagnostics. */
+export class TransactionRevertedError extends Error {
+  readonly hash: Hash;
+  readonly receipt: TransactionReceipt;
+
+  constructor(hash: Hash, receipt: TransactionReceipt) {
+    super(`Transaction reverted on-chain: ${hash}`);
+    this.name = "TransactionRevertedError";
+    this.hash = hash;
+    this.receipt = receipt;
+  }
+}
+
+/** A receipt whose `status` we cannot read. NOT a revert: the chain never told
+ *  us it rejected the tx, we simply have no verdict. Kept distinct so telemetry
+ *  never reports "the chain said no" when the truth is "we don't know". */
+export class TransactionReceiptUnverifiableError extends Error {
+  readonly hash: Hash;
+  readonly receipt: TransactionReceipt;
+  readonly receivedStatus: unknown;
+
+  constructor(hash: Hash, receipt: TransactionReceipt, receivedStatus: unknown) {
+    super(`Unverifiable receipt status for ${hash}: ${String(receivedStatus)}`);
+    this.name = "TransactionReceiptUnverifiableError";
+    this.hash = hash;
+    this.receipt = receipt;
+    this.receivedStatus = receivedStatus;
+  }
+}
+
+/** Gate every receipt through here before treating it as a success.
+ *
+ *  Pure, so it works on a receipt from any source — viem, or a wallet-provided
+ *  override. viem's `waitForTransactionReceipt` resolves with reverted receipts
+ *  without inspecting `status` (viem@2.46.3), which is why this check cannot
+ *  live in the caller's happy path.
+ *
+ *  Fails closed three ways, not two: success, revert, and "no verdict". */
+export function assertReceiptSuccess(
+  hash: Hash,
+  receipt: TransactionReceipt,
+): TransactionReceipt {
+  if (receipt?.status === "success") return receipt;
+  if (receipt?.status === "reverted") throw new TransactionRevertedError(hash, receipt);
+  throw new TransactionReceiptUnverifiableError(hash, receipt, receipt?.status);
+}
+
 type WaitOpts = {
   timeoutMs?: number;
   confirmations?: number;
@@ -27,11 +76,12 @@ export async function waitForReceiptWithTimeout(
 ): Promise<TransactionReceipt> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TX_TIMEOUT_MS;
   try {
-    return await client.waitForTransactionReceipt({
+    const receipt = await client.waitForTransactionReceipt({
       hash,
       timeout: timeoutMs,
       confirmations: opts.confirmations,
     });
+    return assertReceiptSuccess(hash, receipt);
   } catch (err) {
     if (
       err instanceof WaitForTransactionReceiptTimeoutError ||

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -1,4 +1,8 @@
-import { TransactionTimeoutError } from "@/lib/contracts/transaction-helpers";
+import {
+  TransactionReceiptUnverifiableError,
+  TransactionRevertedError,
+  TransactionTimeoutError,
+} from "@/lib/contracts/transaction-helpers";
 
 export function isUserCancellation(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
@@ -12,6 +16,21 @@ export function isTransactionTimeout(error: unknown): boolean {
   if (error instanceof Error && error.name === "WaitForTransactionReceiptTimeoutError") return true;
   const msg = error instanceof Error ? error.message : String(error);
   return /transaction timed out/i.test(msg);
+}
+
+/** A mined-and-reverted transaction. Recognized by type, never by prose —
+ *  the `name` fallback mirrors `isTransactionTimeout` and covers errors that
+ *  cross a bundle/realm boundary and lose `instanceof`. */
+export function isTransactionReverted(error: unknown): boolean {
+  if (error instanceof TransactionRevertedError) return true;
+  return error instanceof Error && error.name === "TransactionRevertedError";
+}
+
+/** A receipt with no readable `status`. Distinct from a revert: the chain gave
+ *  no verdict, so we must not claim it gave one. */
+export function isReceiptUnverifiable(error: unknown): boolean {
+  if (error instanceof TransactionReceiptUnverifiableError) return true;
+  return error instanceof Error && error.name === "TransactionReceiptUnverifiableError";
 }
 
 /** Locale-agnostic identifier for the kind of tx error. Stable across
@@ -35,6 +54,16 @@ const HTTP_STATUS_RE = /\bhttp[\s_-]?[45]\d{2}\b/;
 export function classifyTxErrorKind(error: unknown): TxErrorKind {
   const msg = error instanceof Error ? error.message : String(error);
   const lower = msg.toLowerCase();
+
+  // Typed outcomes are decided before a single character of prose is read.
+  // These errors carry a receipt: we KNOW what happened. Letting the string
+  // heuristics run first would let a revert whose message mentions "cancelled"
+  // or "400" be silently reclassified — the failure mode this whole module
+  // exists to prevent.
+  if (isTransactionReverted(error)) return "revert";
+  // No verdict from the chain is not a verdict of failure. It must never
+  // report as `revert`, and it must never render as success.
+  if (isReceiptUnverifiable(error)) return "unknown";
 
   if (isUserCancellation(error)) return "cancelled";
   // Timeout takes priority over generic network so the player learns

--- a/apps/web/src/lib/shop/__tests__/use-shop-sheet-state.test.tsx
+++ b/apps/web/src/lib/shop/__tests__/use-shop-sheet-state.test.tsx
@@ -264,6 +264,49 @@ describe("useShopSheetState — open/close", () => {
   });
 });
 
+// This suite mocks `waitForReceiptWithTimeout` wholesale (see the vi.mock
+// above), so it cannot observe the helper's new fail-closed behaviour — it can
+// only prove the call site propagates the rejection. The helper's own guarantee
+// is asserted in lib/contracts/__tests__/transaction-helpers.test.ts.
+describe("useShopSheetState — a reverted approve never reaches buyItem", () => {
+  it("aborts the purchase, shows no success, and never fires onPurchaseSuccess", async () => {
+    setReadContractsState({ catalog: makeOnChainItems(), balances: makeBalances() });
+
+    const onPurchaseSuccess = vi.fn();
+    // Approve broadcasts fine; the chain rejects it.
+    writeContractAsyncMock.mockResolvedValueOnce("0xapprove");
+    waitForReceiptMock.mockRejectedValueOnce(
+      Object.assign(new Error("Transaction reverted on-chain: 0xapprove"), {
+        name: "TransactionRevertedError",
+      }),
+    );
+
+    const { result } = renderHook(() => useShopSheetState({ onPurchaseSuccess }));
+
+    act(() => {
+      result.current.sheetProps.onSelectItem(1n);
+    });
+    act(() => {
+      result.current.confirmProps.onConfirm();
+    });
+
+    await waitFor(() => {
+      expect(result.current.confirmProps.purchasePhase).toBe("idle");
+    });
+
+    // Exactly one write: the approve. `buyItem` was never broadcast.
+    expect(writeContractAsyncMock).toHaveBeenCalledTimes(1);
+    const functionNames = writeContractAsyncMock.mock.calls.map(
+      (call) => (call[0] as { functionName?: string })?.functionName,
+    );
+    expect(functionNames).not.toContain("buyItem");
+
+    expect(result.current.sheetProps.successBanner).toBeNull();
+    expect(onPurchaseSuccess).not.toHaveBeenCalled();
+    expect(hapticSuccessMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("useShopSheetState — handleSelectItem", () => {
   it("opens confirm sheet with the selected item + payment token", () => {
     setReadContractsState({ catalog: makeOnChainItems(), balances: makeBalances() });

--- a/docs/specs/receipt-status-helper.md
+++ b/docs/specs/receipt-status-helper.md
@@ -47,35 +47,53 @@ import type { Hash, PublicClient, TransactionReceipt } from "viem";
 export class TransactionRevertedError extends Error {
   readonly hash: Hash;
   readonly receipt: TransactionReceipt;
-  constructor(hash: Hash, receipt: TransactionReceipt) {
-    super(`Transaction reverted on-chain: ${hash}`);
-    this.name = "TransactionRevertedError";
-    this.hash = hash;
-    this.receipt = receipt;
-  }
 }
 
-/** Resuelve SOLO con `receipt.status === "success"`.
- *  @throws TransactionRevertedError  si se minó y revirtió
+/** Distinto de un revert: la cadena no dio veredicto. No colapsar los dos —
+ *  "la cadena dijo que no" y "no pude leer la respuesta" no son el mismo hecho,
+ *  ni en la copy ni en la telemetría. */
+export class TransactionReceiptUnverifiableError extends Error {
+  readonly hash: Hash;
+  readonly receipt: TransactionReceipt;
+  readonly receivedStatus: unknown;
+}
+
+/** PURA. Vale para un receipt de cualquier origen.
+ *  @returns el receipt si `status === "success"`
+ *  @throws TransactionRevertedError              si `status === "reverted"`
+ *  @throws TransactionReceiptUnverifiableError   si el status falta o no se reconoce */
+export function assertReceiptSuccess(
+  hash: Hash,
+  receipt: TransactionReceipt,
+): TransactionReceipt;
+
+/** Resuelve SOLO con `receipt.status === "success"`. Delega en assertReceiptSuccess.
  *  @throws TransactionTimeoutError   si no se minó dentro de timeoutMs */
 export async function waitForReceiptWithTimeout(
   client: PublicClient,
   hash: Hash,
   opts?: { timeoutMs?: number; confirmations?: number },
 ): Promise<TransactionReceipt>;
-
-/** Verifica el status de un hash cuyo receipt vino de una fuente no confiable
- *  (p.ej. `injected.waitReceipt` de MiniPay). Lee del nodo, no de la wallet. */
-export async function assertReceiptSuccess(
-  client: PublicClient,
-  hash: Hash,
-): Promise<TransactionReceipt>;
 ```
+
+> **Corrección al plan original.** El spec pedía
+> `assertReceiptSuccess(client, hash)`, con una lectura extra al nodo, para no
+> confiar en el receipt de MiniPay. Al implementarlo se comprobó que
+> `inp.injected` de `use-mint-victory` **solo existe en tests** (`injected:` no
+> aparece en ningún call site de producción): es un doble, no la wallet. Sin una
+> fuente no confiable que justificarla, la lectura extra es I/O sin motivo. La
+> versión pura cubre ambas ramas y las obliga a coincidir.
 
 ```ts
 // lib/errors.ts
 export function isTransactionReverted(error: unknown): boolean;
+export function isReceiptUnverifiable(error: unknown): boolean;
 ```
+
+Ambos se evalúan **antes que toda heurística de strings, incluida la de
+cancelación**: un revert cuyo mensaje contenga "cancelled" o "400" no debe
+reclasificarse. `TransactionRevertedError` → `"revert"`;
+`TransactionReceiptUnverifiableError` → `"unknown"`, nunca `"revert"`.
 
 `classifyTxErrorKind` mapea `TransactionRevertedError` → `"revert"`.
 El kind y la copy (`RESULT_OVERLAY_COPY.error.revert`) ya existen: **cero claves
@@ -94,9 +112,9 @@ nuevas, cero i18n, cero baselines VR**.
    `isTransactionTimeout` en `:11`).
 5. `classifyTxErrorKind(new TransactionRevertedError(...))` devuelve `"revert"`,
    y lo hace **antes** que las heurísticas de substring.
-6. Dado el path de victory con `injected.waitReceipt`, tras obtener el receipt de
-   la wallet se llama `assertReceiptSuccess(publicClient, claimHash)`. Si el
-   status no es `success`, lanza y `claimPhase` nunca pasa a `"success"`.
+6. Dado el path de victory con `injected.waitReceipt`, el receipt obtenido pasa
+   por `assertReceiptSuccess(claimHash, receipt)`. Si el status no es `success`,
+   lanza y `claimPhase` nunca pasa a `"success"`.
 7. Dado el path de victory sin `injected`, el helper ya lanza. Ambas ramas se
    comportan igual.
 8. Dado un `approve` revertido (shop o victory), la promesa lanza y el flujo
@@ -104,14 +122,9 @@ nuevas, cero i18n, cero baselines VR**.
 
 ## Edge cases
 
-- **`publicClient` ausente en el path inyectado de victory.** Hoy `publicClient!`
-  se usa con non-null assertion en `:606`. Si es `undefined` y hay `injected`,
-  `assertReceiptSuccess` no puede correr. → **fail closed**: lanzar. Un éxito no
-  verificable no se muestra como éxito.
-- **`assertReceiptSuccess` corre justo después de que la wallet ya vio el receipt**,
-  así que el nodo debería tenerlo. Aun así puede devolver
-  `TransactionReceiptNotFoundError` por lag de RPC. → reintentar vía
-  `waitForTransactionReceipt` con timeout corto en vez de `getTransactionReceipt`.
+- **Status ausente o desconocido.** Fail closed, pero **no** como revert:
+  `TransactionReceiptUnverifiableError` → kind `"unknown"`. Un receipt que no
+  podemos leer no autoriza a decir que la cadena rechazó la tx.
 - **Tx reemplazada** (speed-up desde la wallet): viem lanza. Sin cobertura previa;
   no la agregamos acá, pero queda anotada.
 - Un `approve` que revierte es hoy invisible; después será un error. Es un cambio
@@ -122,8 +135,13 @@ nuevas, cero i18n, cero baselines VR**.
 - [ ] `waitForReceiptWithTimeout` lanza `TransactionRevertedError` con `status: "reverted"`.
 - [ ] `waitForReceiptWithTimeout` devuelve el receipt con `status: "success"`.
 - [ ] El timeout sigue lanzando `TransactionTimeoutError` (test de regresión).
+- [ ] `assertReceiptSuccess` lanza `TransactionReceiptUnverifiableError` (y NO
+      `TransactionRevertedError`) con status ausente o desconocido.
 - [ ] `isTransactionReverted` reconoce instancia y duck-type por `name`.
-- [ ] `classifyTxErrorKind(TransactionRevertedError)` → `"revert"`.
+- [ ] `classifyTxErrorKind(TransactionRevertedError)` → `"revert"`, aun cuando el
+      mensaje diga "User rejected" o "HTTP 400".
+- [ ] `classifyTxErrorKind(TransactionReceiptUnverifiableError)` → `"unknown"`.
+- [ ] Un `Error` plano con "User rejected" sigue clasificando `"cancelled"`.
 - [ ] `use-mint-victory`: receipt revertido por el path inyectado ⇒ `claimPhase`
       NO es `"success"`, `onClaimTelemetry` emite `stage: "error"`.
 - [ ] `use-mint-victory`: receipt revertido por el path web ⇒ idem.


### PR DESCRIPTION
Implementa `docs/specs/receipt-status-helper.md` (spec 1 de 2). Vía `/tdd`:
SDD → RED → GREEN → EDD.

**No toca `exercises-screen.tsx`, ni badge, ni score, ni su UX.** Eso es el spec 2.

## El bug

`viem@2.46.3/_esm/actions/public/waitForTransactionReceipt.js` resuelve con
`emit.resolve(receipt)` y **nunca inspecciona `status`**. Todo consumidor de
`waitForReceiptWithTimeout` trataba una tx minada-y-revertida como un éxito.

En victory era peor: el receipt se casteaba a `{ logs }`, así que `status` ni
existía en el tipo. Un mint revertido llegaba a `claimPhase: "success"` con
`tokenId: null` y un link a CeloScan en vez de la Victory NFT.

El test que lo demuestra, en RED:

```
AssertionError: expected 'success' not to be 'success'
  reverted mint receipt never reaches the success phase
```

## El cambio

- `waitForReceiptWithTimeout` resuelve **solo** con `status === "success"`.
- `assertReceiptSuccess(hash, receipt)` es **pura**, y las dos ramas de victory
  (inyectada y web) la comparten, así que no pueden discrepar sobre qué es un éxito.
- **`reverted` y `unverifiable` quedan separados.** `TransactionRevertedError`
  significa que la cadena dio un veredicto; `TransactionReceiptUnverifiableError`,
  que no dio ninguno. Clasifican como `"revert"` y `"unknown"`. Colapsarlos haría
  que la telemetría dijera "la cadena rechazó esto" cuando la verdad es "no sé".
- Ambos se detectan **por tipo, antes de leer una sola letra del mensaje**, y por
  delante de la heurística de cancelación. `isUserCancellation` es un scan de
  substrings: un revert cuyo mensaje contenga `cancelled` (o `400`, ver #197) se
  reclasificaría en silencio.

## Corrección al spec

El spec pedía `assertReceiptSuccess(client, hash)`, con una lectura extra al nodo,
para no confiar en el receipt de MiniPay. Al implementarlo se comprobó que
`inp.injected` de `use-mint-victory` **solo existe en tests** — `injected:` no
aparece en ningún call site de producción. Es un doble, no la wallet.

Sin una fuente no confiable que la justifique, esa lectura es I/O sin motivo. El
spec queda corregido en este mismo commit.

## Fixtures corregidos, no acomodados

| Archivo | Antes | Por qué importaba |
| --- | --- | --- |
| `transaction-helpers.test.ts:19` | `{ transactionHash }` | Sin `status`. Todas las aserciones del archivo pasaban contra un helper que nunca lo leía. |
| `use-mint-victory.test.ts` | `{ logs: [] }` × 5 | Seguían verdes antes del cambio: nunca dependieron de `status`. |
| 2 tests nuevos míos | `toThrow(undefined)` | Matcheaban el `TypeError` de llamar una función inexistente. Ahora fijan tipo **y** mensaje. |

Un receipt real siempre trae `status`. Los fixtures estaban incompletos.

## Nota sobre el verde de shop

`use-shop-sheet-state.test.tsx:169` mockea `waitForReceiptWithTimeout` entero, así
que su test prueba que el call site propaga el rechazo, **no** la garantía del
helper. Esa garantía vive en `transaction-helpers.test.ts`. Está anotado sobre el
`describe` para que nadie lea de más en ese verde.

## Verificación

- Unit: **4791 passed, 0 failed**, en **395 test files** (antes 4770)
- `pnpm exec tsc --noEmit`: limpio
- `git diff --check`: limpio
- Sin claves de copy nuevas → sin i18n, sin baselines VR

## Sigue

`docs/specs/receipt-status-learn-handlers.md` — el seam testable y los handlers de
LEARN, que son donde el jugador realmente ve la celebración falsa.

Wolfcito 🐾 @akawolfcito
