### PR TITLE
feat(exercises): gate badge and score success on a verified receipt

### DIFF
--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -109,6 +109,10 @@ import { daysRemaining } from "@/lib/pro/days-remaining";
 import { formatWalletShort } from "@/lib/wallet/format";
 import { ACCEPTED_TOKENS, CELO_TOKEN, erc20Abi, normalizePrice } from "@/lib/contracts/tokens";
 import { waitForReceiptWithTimeout } from "@/lib/contracts/transaction-helpers";
+import { useOnChainWrite } from "@/lib/exercises/use-onchain-write";
+import { useDoneHold } from "@/lib/exercises/use-done-hold";
+import { applyScoreSaveSuccess } from "@/lib/exercises/apply-score-save-success";
+import { applyBadgeClaimSuccess } from "@/lib/exercises/apply-badge-claim-success";
 import { PIECE_IMAGES } from "@/lib/content/editorial";
 import { LottieAnimation } from "@/components/ui/lottie-animation";
 import { getPositionLabel, getValidTargets } from "@/lib/game/board";
@@ -178,7 +182,7 @@ const POINTS_PER_STAR_BIG = BigInt(POINTS_PER_STAR);
  * confirmation reads at the same cadence as other success affordances
  * (Victory NFT mint, badge claim, etc.).
  */
-const SAVE_DONE_HOLD_MS = 1500;
+// SAVE_DONE_HOLD_MS moved to `lib/exercises/use-done-hold` with the timer it governs.
 type CatalogItem = {
   itemId: bigint;
   /** Translator-resolved at memo time from SHOP_ITEM_COPY via the
@@ -310,8 +314,10 @@ export function ExercisesScreen({
   const { disconnect } = useDisconnect();
   const { switchChain } = useSwitchChain();
   const { isMiniPay } = useMiniPay();
-  const { writeContractAsync: writeScoreAsync, isPending: isScoreWriting } = useWriteContract();
-  const { writeContractAsync: writeBadgeAsync, isPending: isBadgeWriting } = useWriteContract();
+  // `isPending` is no longer read: `useOnChainWrite` owns the busy state for
+  // both writes, and it stays busy through confirmation, not just signing.
+  const { writeContractAsync: writeScoreAsync } = useWriteContract();
+  const { writeContractAsync: writeBadgeAsync } = useWriteContract();
   const { writeContractAsync: writeShopAsync, isPending: isShopWriting } = useWriteContract();
   const [selectedPiece, setSelectedPiece] = useState<PieceKey>(initialPiece);
   const [phase, setPhase] = useState<"ready" | "success" | "failure">("ready");
@@ -350,8 +356,8 @@ export function ExercisesScreen({
   const [selectedItemId, setSelectedItemId] = useState<bigint | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [shopTxHash, setShopTxHash] = useState<string | null>(null);
-  const [claimTxHash, setClaimTxHash] = useState<string | null>(null);
-  const [submitTxHash, setSubmitTxHash] = useState<string | null>(null);
+  // claimTxHash / submitTxHash removed: `useOnChainWrite` owns each write's hash
+  // and settles it against a verified receipt.
   const [lastError, setLastError] = useState<string | null>(null);
   const [purchasePhase, setPurchasePhase] = useState<"idle" | "approving" | "buying">("idle");
   // PRO sheet orchestration — owns its own status fetch internally so this
@@ -1002,24 +1008,24 @@ export function ExercisesScreen({
       enabled: Boolean(shopTxHash),
     },
   });
-  const { isLoading: isClaimConfirming } = useWaitForTransactionReceipt({
-    chainId,
-    hash: claimTxHash as `0x${string}` | undefined,
-    query: {
-      enabled: Boolean(claimTxHash),
+  // Badge claim and score save no longer watch the receipt through wagmi:
+  // `useWaitForTransactionReceipt().isSuccess` means "the query resolved", and
+  // viem resolves it for reverted transactions too. Both writes now settle on a
+  // verified receipt via `useOnChainWrite`. The shop watcher above is untouched.
+  const claimWrite = useOnChainWrite();
+  const saveWrite = useOnChainWrite();
+  const doneHold = useDoneHold();
+
+  /** Fails closed: an unverifiable success is not a success. */
+  const confirmReceipt = useCallback(
+    async (hash: `0x${string}`) => {
+      if (!publicClient) {
+        throw new Error("No client available to verify this transaction.");
+      }
+      return waitForReceiptWithTimeout(publicClient, hash);
     },
-  });
-  const {
-    isLoading: isSubmitConfirming,
-    isSuccess: isSubmitSuccess,
-    isError: isSubmitError,
-  } = useWaitForTransactionReceipt({
-    chainId,
-    hash: submitTxHash as `0x${string}` | undefined,
-    query: {
-      enabled: Boolean(submitTxHash),
-    },
-  });
+    [publicClient],
+  );
 
   // `canSendOnChain` keeps its old shape for the claim-badge path (which
   // still requires the badge to have been earned). For the score-save
@@ -1041,8 +1047,8 @@ export function ExercisesScreen({
     () => getScoreboardAddress(chainId),
     [chainId],
   );
-  const isClaimBusy = isBadgeWriting || isClaimConfirming;
-  const isSubmitBusy = isScoreWriting || isSubmitConfirming || isSavingScore;
+  const isClaimBusy = claimWrite.isBusy;
+  const isSubmitBusy = saveWrite.isBusy || isSavingScore;
   const isShopBusy = isShopWriting || isShopConfirming;
 
   // Cluster C — local-first save state. `lastSavedScore` is the last
@@ -1072,55 +1078,12 @@ export function ExercisesScreen({
     lastSavedTxHash,
   });
 
-  // Tx phase tracking for the TxProgressSteps toast. The toast remains
-  // mounted while the tx is in flight AND for `SAVE_DONE_HOLD_MS` after
-  // confirmation (matches the B1 primitive's own done-hold; tokenized as
-  // 3 × `--duration-ceremony` for motion-scale alignment). The surface
-  // owns the unmount boundary so the primitive's internal timer doesn't
-  // conflict with React's re-render cycle.
-  //
-  // The two effects below split cleanly so the done-hold timer is NOT
-  // cleaned up by React's effect-rerun semantics (Cluster C review
-  // patch — premature clear bug fix). One latch ref guarantees the
-  // hold fires once per (txHash, success) pair.
-  const [txDoneAt, setTxDoneAt] = useState<number | null>(null);
-  const pendingSubmitRef = useRef<{
-    piece: typeof selectedPiece;
-    score: number;
-    txHash: string;
-  } | null>(null);
-  const doneHoldStartedForTxRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (!isSubmitSuccess || !submitTxHash) return;
-    if (doneHoldStartedForTxRef.current === submitTxHash) return;
-    doneHoldStartedForTxRef.current = submitTxHash;
-
-    // Persist the save to the ORIGINAL piece (piece-switch corruption
-    // fix). recordSaveFor writes localStorage under pending.piece even
-    // if the user has since switched to a different piece selector.
-    const pending = pendingSubmitRef.current;
-    if (pending && pending.txHash === submitTxHash) {
-      recordSaveFor(pending.piece, pending.score, pending.txHash);
-      pendingSubmitRef.current = null;
-    }
-
-    // Start the 1500ms done-hold. txDoneAt is intentionally NOT in this
-    // effect's deps — setting it inside would re-trigger the effect and
-    // React would clear the timer prematurely.
-    setTxDoneAt(Date.now());
-    const timer = window.setTimeout(() => setTxDoneAt(null), SAVE_DONE_HOLD_MS);
-    return () => window.clearTimeout(timer);
-  }, [isSubmitSuccess, submitTxHash, recordSaveFor]);
-
-  // Reset the done-hold + tx-success latch the moment a NEW submit
-  // starts so subsequent submissions get their own hold window.
-  useEffect(() => {
-    if (isScoreWriting && !submitTxHash) {
-      setTxDoneAt(null);
-      doneHoldStartedForTxRef.current = null;
-    }
-  }, [isScoreWriting, submitTxHash]);
+  // The done-hold keeps the TxProgressSteps toast mounted for a beat after a
+  // save lands. It used to share an effect with `recordSaveFor` and a latch ref,
+  // keyed on `useWaitForTransactionReceipt().isSuccess` — which also fired for
+  // reverted transactions, persisting scores that never landed. The timer, the
+  // latch, and its unmount cleanup now live in `useDoneHold`; the persistence
+  // moved behind a verified receipt in `handleSaveScoreOnChain`.
 
   // 4-phase precedence (failed > done > wait > sign) extracted to
   // `lib/exercises/tx-toast-state` for unit-test coverage. The `failed`
@@ -1128,11 +1091,11 @@ export function ExercisesScreen({
   // surfaces as a sticky failed toast instead of stranding the user on
   // a stale "Waiting…" state until the next submit clears it.
   const txToast = deriveTxToastState({
-    isWriting: isScoreWriting,
-    isConfirming: isSubmitConfirming,
-    isError: isSubmitError,
-    txHash: submitTxHash,
-    doneAt: txDoneAt,
+    isWriting: saveWrite.phase === "signing",
+    isConfirming: saveWrite.phase === "confirming",
+    hasFailed: saveWrite.outcome?.status === "failed",
+    txHash: saveWrite.txHash,
+    doneAt: doneHold.doneAt,
   });
   // Suppress the floating tx-progress toast while the ResultOverlay is
   // mounted. The popup owns the success/failure surface (incl. the
@@ -1573,51 +1536,71 @@ export function ExercisesScreen({
     track("badge_claim_tx", { stage: "start", piece: targetPiece });
 
     try {
-      const signed = await requestSignature("/api/sign-badge", {
-        player: address,
-        levelId: Number(claimLevelId),
+      const outcome = await claimWrite.run({
+        broadcast: async () => {
+          const signed = await requestSignature("/api/sign-badge", {
+            player: address,
+            levelId: Number(claimLevelId),
+          });
+
+          const hash = await writeWithOptionalFeeCurrency(writeBadgeAsync, {
+            address: badgesAddress,
+            abi: badgesAbi,
+            functionName: "claimBadgeSigned" as const,
+            args: [claimLevelId, BigInt(signed.nonce), BigInt(signed.deadline), signed.signature] as const,
+            chainId,
+            account: address,
+          });
+          // The wallet accepted it. The chain has not ruled yet.
+          track("badge_claim_tx", { stage: "broadcast", piece: targetPiece });
+          return hash;
+        },
+        confirm: confirmReceipt,
       });
 
-      const txHash = await writeWithOptionalFeeCurrency(writeBadgeAsync, {
-        address: badgesAddress,
-        abi: badgesAbi,
-        functionName: "claimBadgeSigned" as const,
-        args: [claimLevelId, BigInt(signed.nonce), BigInt(signed.deadline), signed.signature] as const,
-        chainId,
-        account: address,
-      });
+      if (outcome.status === "busy") return;
 
-      hapticSuccess();
-      setClaimTxHash(txHash);
-      track("badge_claim_tx", { stage: "success", piece: targetPiece });
-      setJustClaimed(prev => ({ ...prev, [targetPiece]: true }));
-      void refetchAllBadges();
-      // Queue unlock celebration for the next piece
-      const claimedIndex = PIECE_ORDER.indexOf(targetPiece);
-      const nextUnlock = claimedIndex < PIECE_ORDER.length - 1 ? PIECE_ORDER[claimedIndex + 1] : null;
-      if (nextUnlock) {
-        setUnlockedPiece(nextUnlock);
-        track("modal_open", { id: "piece-unlocked", piece: nextUnlock });
-      }
-      setResultOverlay({
-        variant: "badge",
-        txHash,
-      });
-      console.info("[MiniPayTx] result", { label: "claim-badge", txHash, levelId: Number(claimLevelId) });
-    } catch (error) {
-      if (isUserCancellation(error)) {
+      if (outcome.status === "cancelled") {
         track("badge_claim_tx", { stage: "cancelled", piece: targetPiece });
         return;
       }
-      const message = toErrorMessage(error);
-      setLastError(message);
-      track("badge_claim_tx", { stage: "error", piece: targetPiece, error_kind: classifyTxErrorKind(error) });
-      setResultOverlay({
-        variant: "error",
-        errorMessage: classifyTxError(error, tResult),
-        retryAction: () => void handleClaimBadge(piece),
-      });
-      console.warn("[MiniPayTx] error", { label: "claim-badge", levelId: Number(claimLevelId), error: message });
+
+      if (outcome.status === "failed") {
+        const message = toErrorMessage(outcome.error);
+        setLastError(message);
+        track("badge_claim_tx", { stage: "error", piece: targetPiece, error_kind: outcome.kind });
+        setResultOverlay({
+          variant: "error",
+          errorMessage: classifyTxError(outcome.error, tResult),
+          retryAction: () => void handleClaimBadge(piece),
+        });
+        console.warn("[MiniPayTx] error", { label: "claim-badge", levelId: Number(claimLevelId), error: message });
+        return;
+      }
+
+      // Verified on-chain from here down. `stage: "success"` now means the tx
+      // was mined successfully, not that the wallet accepted the broadcast.
+      track("badge_claim_tx", { stage: "success", piece: targetPiece });
+      void refetchAllBadges();
+
+      const claimedIndex = PIECE_ORDER.indexOf(targetPiece);
+      const nextUnlock = claimedIndex < PIECE_ORDER.length - 1 ? PIECE_ORDER[claimedIndex + 1] : null;
+
+      applyBadgeClaimSuccess(
+        {
+          haptic: hapticSuccess,
+          markClaimed: (claimed) =>
+            setJustClaimed((prev) => ({ ...prev, [claimed as PieceKey]: true })),
+          queueNextPieceUnlock: (next) => {
+            if (!next) return;
+            setUnlockedPiece(next as PieceKey);
+            track("modal_open", { id: "piece-unlocked", piece: next });
+          },
+          showOverlay: (hash) => setResultOverlay({ variant: "badge", txHash: hash }),
+        },
+        { piece: targetPiece, nextPiece: nextUnlock, txHash: outcome.txHash },
+      );
+      console.info("[MiniPayTx] result", { label: "claim-badge", txHash: outcome.txHash, levelId: Number(claimLevelId) });
     } finally {
       setClaimingPiece(null);
     }
@@ -1804,89 +1787,104 @@ export function ExercisesScreen({
     submittingScoreRef.current = true;
 
     setLastError(null);
-    // Clear the previous tx's hash so a retry after revert shows
-    // "Signing…" immediately instead of lingering on "Failed" until the
-    // new hash lands (Cluster C SAVE residue defer #1).
-    setSubmitTxHash(null);
+    // Clear the previous tx's state so a retry after revert shows "Signing…"
+    // immediately instead of lingering on "Failed" until the new hash lands
+    // (Cluster C SAVE residue defer #1).
+    saveWrite.reset();
+    doneHold.reset();
     track("score_submit_tx", { stage: "start", piece: selectedPiece });
 
+    // Captured at broadcast so the save persists under the piece the player was
+    // on when they submitted, even if they switch selectors while it confirms.
+    const submittedPiece = selectedPiece;
+    const submittedScore = Number(score);
+    const submittedTimeMs = Number(timeMs);
+    const submittedLevelId = Number(levelId);
+
     try {
-      const signed = await requestSignature("/api/sign-score", {
-        player: address,
-        levelId: Number(levelId),
-        score: Number(score),
-        timeMs: Number(timeMs),
+      const outcome = await saveWrite.run({
+        broadcast: async () => {
+          const signed = await requestSignature("/api/sign-score", {
+            player: address,
+            levelId: submittedLevelId,
+            score: submittedScore,
+            timeMs: submittedTimeMs,
+          });
+
+          const hash = await writeWithOptionalFeeCurrency(writeScoreAsync, {
+            address: scoreboardAddress,
+            abi: scoreboardAbi,
+            functionName: "submitScoreSigned" as const,
+            args: [levelId, score, timeMs, BigInt(signed.nonce), BigInt(signed.deadline), signed.signature] as const,
+            chainId,
+            account: address,
+          });
+          track("score_submit_tx", { stage: "broadcast", piece: submittedPiece });
+          return hash;
+        },
+        confirm: confirmReceipt,
       });
 
-      const txHash = await writeWithOptionalFeeCurrency(writeScoreAsync, {
-        address: scoreboardAddress,
-        abi: scoreboardAbi,
-        functionName: "submitScoreSigned" as const,
-        args: [levelId, score, timeMs, BigInt(signed.nonce), BigInt(signed.deadline), signed.signature] as const,
-        chainId,
-        account: address,
-      });
+      if (outcome.status === "busy") return;
 
-      hapticSuccess();
-      setSubmitTxHash(txHash);
-      // Capture (piece, score, txHash) at broadcast time so the
-      // receipt-success effect persists the SUBMITTED score under the
-      // CORRECT piece even if the user switches pieces before the
-      // receipt arrives.
-      pendingSubmitRef.current = {
-        piece: selectedPiece,
-        score: Number(score),
-        txHash,
-      };
-      track("score_submit_tx", { stage: "success", piece: selectedPiece });
-      setResultOverlay({
-        variant: "score",
-        txHash,
-      });
-      console.info("[MiniPayTx] result", { label: "submit-score", txHash, levelId: Number(levelId) });
-
-      // Write-through to Supabase (fire-and-forget) — this is what the
-      // combined leaderboard reads as the on-chain `scores` source.
-      void fetch("/api/cache-score", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          player: address,
-          levelId: Number(levelId),
-          score: Number(score),
-          timeMs: Number(timeMs),
-          txHash: txHash,
-        }),
-      }).catch(() => {});
-
-      // Optimistic entry for leaderboard
-      try {
-        sessionStorage.setItem(
-          "chesscito:optimistic-score",
-          JSON.stringify({
-            player: address.toLowerCase(),
-            score: Number(score),
-            levelId: Number(levelId),
-            ts: Date.now(),
-          }),
-        );
-      } catch { /* storage unavailable */ }
-      setLeaderboardRefreshTrigger((n) => n + 1);
-    } catch (error) {
-      if (isUserCancellation(error)) {
-        track("score_submit_tx", { stage: "cancelled", piece: selectedPiece });
+      if (outcome.status === "cancelled") {
+        track("score_submit_tx", { stage: "cancelled", piece: submittedPiece });
         showToast(tFooter("submitCanceled"), 2000);
         return;
       }
-      const message = toErrorMessage(error);
-      setLastError(message);
-      track("score_submit_tx", { stage: "error", piece: selectedPiece, error_kind: classifyTxErrorKind(error) });
-      setResultOverlay({
-        variant: "error",
-        errorMessage: classifyTxError(error, tResult),
-        retryAction: () => void handleSaveScoreOnChain(),
-      });
-      console.warn("[MiniPayTx] error", { label: "submit-score", levelId: Number(levelId), error: message });
+
+      if (outcome.status === "failed") {
+        const message = toErrorMessage(outcome.error);
+        setLastError(message);
+        track("score_submit_tx", { stage: "error", piece: submittedPiece, error_kind: outcome.kind });
+        setResultOverlay({
+          variant: "error",
+          errorMessage: classifyTxError(outcome.error, tResult),
+          retryAction: () => void handleSaveScoreOnChain(),
+        });
+        console.warn("[MiniPayTx] error", { label: "submit-score", levelId: submittedLevelId, error: message });
+        return;
+      }
+
+      // Verified on-chain. Nothing below this line ran for a reverted tx before
+      // — it ran for every broadcast, which is the bug.
+      hapticSuccess();
+      track("score_submit_tx", { stage: "success", piece: submittedPiece });
+
+      applyScoreSaveSuccess(
+        {
+          // The sequencer is piece-agnostic (plain string); the screen owns the
+          // PieceId narrowing.
+          recordSaveFor: (piece, saved, hash) => recordSaveFor(piece as PieceKey, saved, hash),
+          writeOptimisticScore: (entry) => {
+            try {
+              sessionStorage.setItem("chesscito:optimistic-score", JSON.stringify(entry));
+            } catch { /* storage unavailable */ }
+          },
+          // Write-through to Supabase — what the combined leaderboard reads as
+          // the on-chain `scores` source. Still fire-and-forget; its silent
+          // failure handling is a tracked, deferred gap.
+          cacheScore: (payload) => {
+            void fetch("/api/cache-score", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify(payload),
+            }).catch(() => {});
+          },
+          refreshLeaderboard: () => setLeaderboardRefreshTrigger((n) => n + 1),
+          showOverlay: (hash) => setResultOverlay({ variant: "score", txHash: hash }),
+          startDoneHold: doneHold.start,
+        },
+        {
+          piece: submittedPiece,
+          score: submittedScore,
+          timeMs: submittedTimeMs,
+          levelId: submittedLevelId,
+          player: address,
+          txHash: outcome.txHash,
+        },
+      );
+      console.info("[MiniPayTx] result", { label: "submit-score", txHash: outcome.txHash, levelId: submittedLevelId });
     } finally {
       submittingScoreRef.current = false;
     }
@@ -2323,7 +2321,7 @@ export function ExercisesScreen({
           onRetrySave={() => void handleSubmitScore()}
           canSaveOnChain={canSaveOnChain}
           onSaveOnChain={() => void handleSaveScoreOnChain()}
-          isSavingOnChain={isScoreWriting || isSubmitConfirming}
+          isSavingOnChain={saveWrite.isBusy}
           shieldCount={shieldCount}
           streakCount={streakCount}
           lastEarnedStars={lastEarnedStars}
@@ -2450,7 +2448,7 @@ export function ExercisesScreen({
                     key={a}
                     action={a}
                     shieldsAvailable={shieldCount}
-                    isBusy={isBadgeWriting || isClaimConfirming}
+                    isBusy={claimWrite.isBusy}
                     onUseShield={handleUseShield}
                     onClaimBadge={() => void handleClaimBadge()}
                     onRetry={handleRetryApplied}
@@ -2483,7 +2481,7 @@ export function ExercisesScreen({
               <ContextualActionSlot
                 action={contextAction}
                 shieldsAvailable={shieldCount}
-                isBusy={isBadgeWriting || isClaimConfirming}
+                isBusy={claimWrite.isBusy}
                 onUseShield={handleUseShield}
                 onClaimBadge={() => void handleClaimBadge()}
                 // Sprint 5 commit G — route the legacy free Retry
@@ -2833,8 +2831,9 @@ export function ExercisesScreen({
             autoReset.invalidate();
             setSelectedPiece(piece);
             setResultOverlay(null);
-            setClaimTxHash(null);
-            setSubmitTxHash(null);
+            claimWrite.reset();
+            saveWrite.reset();
+            doneHold.reset();
             setShowBadgeEarned(false);
             setShowPieceComplete(false);
             resetBoard();

--- a/apps/web/src/lib/exercises/__tests__/apply-badge-claim-success.test.ts
+++ b/apps/web/src/lib/exercises/__tests__/apply-badge-claim-success.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyBadgeClaimSuccess,
+  type BadgeClaimEffects,
+  type BadgeClaimPayload,
+} from "../apply-badge-claim-success";
+
+const PAYLOAD: BadgeClaimPayload = {
+  piece: "rook",
+  nextPiece: "bishop",
+  txHash: "0xdef",
+};
+
+function makeRecorder() {
+  const calls: string[] = [];
+  const effects: BadgeClaimEffects = {
+    haptic: vi.fn(() => void calls.push("haptic")),
+    markClaimed: vi.fn(() => void calls.push("markClaimed")),
+    queueNextPieceUnlock: vi.fn(() => void calls.push("queueNextPieceUnlock")),
+    showOverlay: vi.fn(() => void calls.push("showOverlay")),
+  };
+  return { calls, effects };
+}
+
+describe("applyBadgeClaimSuccess", () => {
+  it("celebrates, marks the badge owned, queues the unlock, then shows the overlay", () => {
+    const { calls, effects } = makeRecorder();
+    applyBadgeClaimSuccess(effects, PAYLOAD);
+    expect(calls).toEqual([
+      "haptic",
+      "markClaimed",
+      "queueNextPieceUnlock",
+      "showOverlay",
+    ]);
+  });
+
+  it("marks the claimed piece and queues the following one", () => {
+    const { effects } = makeRecorder();
+    applyBadgeClaimSuccess(effects, PAYLOAD);
+    expect(effects.markClaimed).toHaveBeenCalledWith("rook");
+    expect(effects.queueNextPieceUnlock).toHaveBeenCalledWith("bishop");
+  });
+
+  it("queues no unlock when the claimed piece is the last one", () => {
+    const { effects } = makeRecorder();
+    applyBadgeClaimSuccess(effects, { ...PAYLOAD, piece: "king", nextPiece: null });
+    expect(effects.queueNextPieceUnlock).toHaveBeenCalledWith(null);
+    expect(effects.markClaimed).toHaveBeenCalledWith("king");
+  });
+
+  it("passes the txHash to the overlay", () => {
+    const { effects } = makeRecorder();
+    applyBadgeClaimSuccess(effects, PAYLOAD);
+    expect(effects.showOverlay).toHaveBeenCalledWith("0xdef");
+  });
+});

--- a/apps/web/src/lib/exercises/__tests__/apply-score-save-success.test.ts
+++ b/apps/web/src/lib/exercises/__tests__/apply-score-save-success.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyScoreSaveSuccess,
+  type ScoreSaveEffects,
+  type ScoreSavePayload,
+} from "../apply-score-save-success";
+
+const PAYLOAD: ScoreSavePayload = {
+  piece: "rook",
+  score: 2400,
+  timeMs: 18_000,
+  levelId: 1,
+  player: "0x1111111111111111111111111111111111111111",
+  txHash: "0xabc",
+};
+
+/** Records the effect names in call order. The ORDER is the contract here:
+ *  asserting only the final state would pass against a sequencer that wrote
+ *  the remote cache before the local truth. */
+function makeRecorder() {
+  const calls: string[] = [];
+  const effects: ScoreSaveEffects = {
+    recordSaveFor: vi.fn(() => void calls.push("recordSaveFor")),
+    writeOptimisticScore: vi.fn(() => void calls.push("writeOptimisticScore")),
+    cacheScore: vi.fn(() => void calls.push("cacheScore")),
+    refreshLeaderboard: vi.fn(() => void calls.push("refreshLeaderboard")),
+    showOverlay: vi.fn(() => void calls.push("showOverlay")),
+    startDoneHold: vi.fn(() => void calls.push("startDoneHold")),
+  };
+  return { calls, effects };
+}
+
+describe("applyScoreSaveSuccess", () => {
+  it("runs local truth, then the optimistic hint, then the remote write-through, then UI", () => {
+    const { calls, effects } = makeRecorder();
+    applyScoreSaveSuccess(effects, PAYLOAD);
+    expect(calls).toEqual([
+      "recordSaveFor",
+      "writeOptimisticScore",
+      "cacheScore",
+      "refreshLeaderboard",
+      "showOverlay",
+      "startDoneHold",
+    ]);
+  });
+
+  it("persists under the piece captured at broadcast, not a later selection", () => {
+    const { effects } = makeRecorder();
+    applyScoreSaveSuccess(effects, { ...PAYLOAD, piece: "bishop" });
+    expect(effects.recordSaveFor).toHaveBeenCalledWith("bishop", 2400, "0xabc");
+  });
+
+  it("hands /api/cache-score the receipt-backed txHash", () => {
+    const { effects } = makeRecorder();
+    applyScoreSaveSuccess(effects, PAYLOAD);
+    expect(effects.cacheScore).toHaveBeenCalledWith({
+      player: PAYLOAD.player,
+      levelId: PAYLOAD.levelId,
+      score: PAYLOAD.score,
+      timeMs: PAYLOAD.timeMs,
+      txHash: PAYLOAD.txHash,
+    });
+  });
+
+  it("keys the done-hold on the txHash so each save gets its own window", () => {
+    const { effects } = makeRecorder();
+    applyScoreSaveSuccess(effects, PAYLOAD);
+    expect(effects.startDoneHold).toHaveBeenCalledWith("0xabc");
+  });
+});

--- a/apps/web/src/lib/exercises/__tests__/tx-toast-state.test.ts
+++ b/apps/web/src/lib/exercises/__tests__/tx-toast-state.test.ts
@@ -4,18 +4,43 @@ import { deriveTxToastState } from "../tx-toast-state.js";
 const base = {
   isWriting: false,
   isConfirming: false,
-  isError: false,
+  hasFailed: false,
   txHash: null as string | null,
   doneAt: null as number | null,
 };
+
+// `hasFailed` replaces `isError`, which was fed from
+// `useWaitForTransactionReceipt().isError` — a QUERY error. viem resolves the
+// query even for a reverted tx, so this branch never fired on the failure it
+// was written for, despite the comment on it claiming exactly that. It is now
+// fed by the settled outcome of `useOnChainWrite`.
+describe("deriveTxToastState — hasFailed reflects the chain, not the query", () => {
+  it("shows current='failed' when the write settled as failed", () => {
+    expect(deriveTxToastState({ ...base, hasFailed: true, txHash: "0xabc" })).toEqual({
+      show: true,
+      current: "failed",
+    });
+  });
+
+  it("failed outranks a done-hold window", () => {
+    expect(
+      deriveTxToastState({
+        ...base,
+        hasFailed: true,
+        txHash: "0xabc",
+        doneAt: Date.now(),
+      }),
+    ).toEqual({ show: true, current: "failed" });
+  });
+});
 
 describe("deriveTxToastState — idle", () => {
   it("does not show the toast when nothing is happening", () => {
     expect(deriveTxToastState(base)).toEqual({ show: false });
   });
 
-  it("ignores an isError flag with no tx hash (residue from a prior cleared tx)", () => {
-    expect(deriveTxToastState({ ...base, isError: true })).toEqual({ show: false });
+  it("ignores an hasFailed flag with no tx hash (residue from a prior cleared tx)", () => {
+    expect(deriveTxToastState({ ...base, hasFailed: true })).toEqual({ show: false });
   });
 });
 
@@ -61,9 +86,9 @@ describe("deriveTxToastState — done phase", () => {
 });
 
 describe("deriveTxToastState — failed phase (Cluster C SAVE residue defer #1)", () => {
-  it("shows current='failed' when isError is set against a real tx hash (revert)", () => {
+  it("shows current='failed' when hasFailed is set against a real tx hash (revert)", () => {
     expect(
-      deriveTxToastState({ ...base, isError: true, txHash: "0xabc" }),
+      deriveTxToastState({ ...base, hasFailed: true, txHash: "0xabc" }),
     ).toEqual({ show: true, current: "failed" });
   });
 
@@ -73,19 +98,19 @@ describe("deriveTxToastState — failed phase (Cluster C SAVE residue defer #1)"
         ...base,
         isWriting: true,
         isConfirming: true,
-        isError: true,
+        hasFailed: true,
         txHash: "0xabc",
         doneAt: 12345,
       }),
     ).toEqual({ show: true, current: "failed" });
   });
 
-  it("does NOT show failed when isError is true but no tx hash exists (no on-chain attempt)", () => {
-    // Wagmi flips isError on user-rejection BEFORE a hash exists. The
+  it("does NOT show failed when hasFailed is true but no tx hash exists (no on-chain attempt)", () => {
+    // Wagmi flips hasFailed on user-rejection BEFORE a hash exists. The
     // existing error overlay handles that path; the toast should not
     // render a failed state without a real on-chain tx.
     expect(
-      deriveTxToastState({ ...base, isError: true, isWriting: true }),
+      deriveTxToastState({ ...base, hasFailed: true, isWriting: true }),
     ).toEqual({ show: true, current: "sign" });
   });
 });

--- a/apps/web/src/lib/exercises/__tests__/use-done-hold.test.tsx
+++ b/apps/web/src/lib/exercises/__tests__/use-done-hold.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { SAVE_DONE_HOLD_MS, useDoneHold } from "../use-done-hold";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("useDoneHold", () => {
+  it("starts closed", () => {
+    const { result } = renderHook(() => useDoneHold());
+    expect(result.current.doneAt).toBeNull();
+  });
+
+  it("opens the hold window and closes it after SAVE_DONE_HOLD_MS", () => {
+    const { result } = renderHook(() => useDoneHold());
+
+    act(() => result.current.start("0xabc"));
+    expect(result.current.doneAt).not.toBeNull();
+
+    act(() => vi.advanceTimersByTime(SAVE_DONE_HOLD_MS - 1));
+    expect(result.current.doneAt).not.toBeNull();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.doneAt).toBeNull();
+  });
+
+  it("preserves the 1500ms window the effect it replaces used", () => {
+    expect(SAVE_DONE_HOLD_MS).toBe(1500);
+  });
+
+  // This is the latch that `doneHoldStartedForTxRef` used to carry. A repeated
+  // start for the same tx must not restart the window.
+  it("is idempotent per key: a second start for the same tx is a no-op", () => {
+    const { result } = renderHook(() => useDoneHold());
+
+    act(() => result.current.start("0xabc"));
+    const first = result.current.doneAt;
+
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => result.current.start("0xabc"));
+
+    expect(result.current.doneAt).toBe(first);
+    // The original window still expires on its own schedule, un-extended.
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.doneAt).toBeNull();
+  });
+
+  it("a different key opens a fresh window", () => {
+    const { result } = renderHook(() => useDoneHold());
+
+    act(() => result.current.start("0xabc"));
+    act(() => vi.advanceTimersByTime(SAVE_DONE_HOLD_MS));
+    expect(result.current.doneAt).toBeNull();
+
+    act(() => result.current.start("0xdef"));
+    expect(result.current.doneAt).not.toBeNull();
+  });
+
+  it("reset closes the window, clears the timer, and re-arms the same key", () => {
+    const { result } = renderHook(() => useDoneHold());
+
+    act(() => result.current.start("0xabc"));
+    act(() => result.current.reset());
+    expect(result.current.doneAt).toBeNull();
+
+    // The cleared timer must not fire later and null an unrelated window.
+    act(() => result.current.start("0xabc"));
+    expect(result.current.doneAt).not.toBeNull();
+    act(() => vi.advanceTimersByTime(SAVE_DONE_HOLD_MS - 1));
+    expect(result.current.doneAt).not.toBeNull();
+  });
+
+  it("clears its timer on unmount", () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { result, unmount } = renderHook(() => useDoneHold());
+
+    act(() => result.current.start("0xabc"));
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});

--- a/apps/web/src/lib/exercises/__tests__/use-onchain-write.test.tsx
+++ b/apps/web/src/lib/exercises/__tests__/use-onchain-write.test.tsx
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Hash, TransactionReceipt } from "viem";
+
+import {
+  TransactionReceiptUnverifiableError,
+  TransactionRevertedError,
+} from "@/lib/contracts/transaction-helpers";
+import { useOnChainWrite } from "../use-onchain-write";
+
+const HASH = "0xfeed" as Hash;
+const SUCCESS = { transactionHash: HASH, status: "success" } as unknown as TransactionReceipt;
+const REVERTED = { transactionHash: HASH, status: "reverted" } as unknown as TransactionReceipt;
+
+/** A promise we resolve by hand, so the test can observe the phase WHILE the
+ *  step is still in flight. Asserting only after settle would let a hook that
+ *  never enters `confirming` pass. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useOnChainWrite — phase transitions", () => {
+  it("is idle before anything runs", () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.txHash).toBeNull();
+    expect(result.current.outcome).toBeNull();
+    expect(result.current.isBusy).toBe(false);
+  });
+
+  it("is `signing` while broadcast is in flight, before any hash exists", async () => {
+    const broadcast = deferred<Hash>();
+    const { result } = renderHook(() => useOnChainWrite());
+
+    act(() => {
+      void result.current.run({
+        broadcast: () => broadcast.promise,
+        confirm: async () => SUCCESS,
+      });
+    });
+
+    await waitFor(() => expect(result.current.phase).toBe("signing"));
+    expect(result.current.txHash).toBeNull();
+    expect(result.current.isBusy).toBe(true);
+
+    await act(async () => {
+      broadcast.resolve(HASH);
+    });
+  });
+
+  it("is `confirming` after the hash and before the receipt", async () => {
+    const confirm = deferred<TransactionReceipt>();
+    const { result } = renderHook(() => useOnChainWrite());
+
+    act(() => {
+      void result.current.run({
+        broadcast: async () => HASH,
+        confirm: () => confirm.promise,
+      });
+    });
+
+    await waitFor(() => expect(result.current.phase).toBe("confirming"));
+    expect(result.current.txHash).toBe(HASH);
+    expect(result.current.isBusy).toBe(true);
+    expect(result.current.outcome).toBeNull();
+
+    await act(async () => {
+      confirm.resolve(SUCCESS);
+    });
+    await waitFor(() => expect(result.current.phase).toBe("settled"));
+  });
+
+  it("settles success only once the receipt resolves", async () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    let outcome: Awaited<ReturnType<typeof result.current.run>> | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run({
+        broadcast: async () => HASH,
+        confirm: async () => SUCCESS,
+      });
+    });
+
+    expect(outcome).toMatchObject({ status: "success", txHash: HASH, receipt: SUCCESS });
+    expect(result.current.phase).toBe("settled");
+    expect(result.current.isBusy).toBe(false);
+    expect(result.current.outcome).toMatchObject({ status: "success" });
+  });
+});
+
+describe("useOnChainWrite — failure never masquerades as success", () => {
+  it("returns failed/revert on a reverted receipt and keeps the hash", async () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    let outcome: Awaited<ReturnType<typeof result.current.run>> | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run({
+        broadcast: async () => HASH,
+        confirm: async () => {
+          throw new TransactionRevertedError(HASH, REVERTED);
+        },
+      });
+    });
+
+    expect(outcome).toMatchObject({ status: "failed", kind: "revert", txHash: HASH });
+  });
+
+  it("returns failed/unknown on an unverifiable receipt, never `revert`", async () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    let outcome: Awaited<ReturnType<typeof result.current.run>> | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run({
+        broadcast: async () => HASH,
+        confirm: async () => {
+          throw new TransactionReceiptUnverifiableError(HASH, SUCCESS, undefined);
+        },
+      });
+    });
+
+    expect(outcome).toMatchObject({ status: "failed", kind: "unknown", txHash: HASH });
+  });
+
+  it("never throws — a broadcast failure comes back as a failed outcome with a null hash", async () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    let outcome: Awaited<ReturnType<typeof result.current.run>> | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run({
+        broadcast: async () => {
+          throw new Error("rpc exploded");
+        },
+        confirm: async () => SUCCESS,
+      });
+    });
+
+    expect(outcome).toMatchObject({ status: "failed", txHash: null });
+    expect(result.current.phase).toBe("settled");
+  });
+
+  it("reports a wallet rejection as cancelled with a null hash, not as an on-chain failure", async () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    let outcome: Awaited<ReturnType<typeof result.current.run>> | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run({
+        broadcast: async () => {
+          throw new Error("User rejected the request");
+        },
+        confirm: async () => SUCCESS,
+      });
+    });
+
+    expect(outcome).toEqual({ status: "cancelled", txHash: null });
+  });
+
+  it("keeps the hash when the user cancels AFTER the broadcast landed", async () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    let outcome: Awaited<ReturnType<typeof result.current.run>> | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run({
+        broadcast: async () => HASH,
+        confirm: async () => {
+          throw new Error("User rejected the request");
+        },
+      });
+    });
+
+    expect(outcome).toEqual({ status: "cancelled", txHash: HASH });
+  });
+});
+
+describe("useOnChainWrite — concurrency and lifecycle", () => {
+  it("a second run while busy does not broadcast again", async () => {
+    const broadcast = vi.fn(async () => HASH);
+    const confirm = deferred<TransactionReceipt>();
+    const { result } = renderHook(() => useOnChainWrite());
+
+    act(() => {
+      void result.current.run({ broadcast, confirm: () => confirm.promise });
+    });
+    await waitFor(() => expect(result.current.phase).toBe("confirming"));
+
+    let second: Awaited<ReturnType<typeof result.current.run>> | undefined;
+    await act(async () => {
+      second = await result.current.run({ broadcast, confirm: async () => SUCCESS });
+    });
+
+    // `busy` is its own outcome, not a TxErrorKind: nothing failed on chain,
+    // and it must never reach telemetry as an error.
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(second).toEqual({ status: "busy" });
+    expect(result.current.outcome).toBeNull();
+
+    await act(async () => {
+      confirm.resolve(SUCCESS);
+    });
+  });
+
+  it("does not update state after unmount", async () => {
+    const confirm = deferred<TransactionReceipt>();
+    const { result, unmount } = renderHook(() => useOnChainWrite());
+
+    act(() => {
+      void result.current.run({
+        broadcast: async () => HASH,
+        confirm: () => confirm.promise,
+      });
+    });
+    await waitFor(() => expect(result.current.phase).toBe("confirming"));
+
+    unmount();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await act(async () => {
+      confirm.resolve(SUCCESS);
+    });
+
+    // React logs "state update on an unmounted component" through console.error.
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("reset returns the hook to idle", async () => {
+    const { result } = renderHook(() => useOnChainWrite());
+    await act(async () => {
+      await result.current.run({ broadcast: async () => HASH, confirm: async () => SUCCESS });
+    });
+    expect(result.current.phase).toBe("settled");
+
+    act(() => result.current.reset());
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.txHash).toBeNull();
+    expect(result.current.outcome).toBeNull();
+  });
+});

--- a/apps/web/src/lib/exercises/apply-badge-claim-success.ts
+++ b/apps/web/src/lib/exercises/apply-badge-claim-success.ts
@@ -1,0 +1,33 @@
+/**
+ * The effect sequence a CONFIRMED badge claim is allowed to run.
+ *
+ * The claim handler used to fire all of this the moment `writeContractAsync`
+ * returned a hash. A tx that mined and reverted produced the full celebration
+ * and left `justClaimed` true for a badge the player does not own.
+ *
+ * Nothing in here may be called before `receipt.status === "success"`.
+ */
+
+export type BadgeClaimPayload = {
+  piece: string;
+  /** The piece unlocked by this claim, or null when the claimed piece is last. */
+  nextPiece: string | null;
+  txHash: string;
+};
+
+export type BadgeClaimEffects = {
+  haptic: () => void;
+  markClaimed: (piece: string) => void;
+  queueNextPieceUnlock: (next: string | null) => void;
+  showOverlay: (txHash: string) => void;
+};
+
+export function applyBadgeClaimSuccess(
+  effects: BadgeClaimEffects,
+  payload: BadgeClaimPayload,
+): void {
+  effects.haptic();
+  effects.markClaimed(payload.piece);
+  effects.queueNextPieceUnlock(payload.nextPiece);
+  effects.showOverlay(payload.txHash);
+}

--- a/apps/web/src/lib/exercises/apply-score-save-success.ts
+++ b/apps/web/src/lib/exercises/apply-score-save-success.ts
@@ -1,0 +1,70 @@
+/**
+ * The effect sequence that a CONFIRMED on-chain score save is allowed to run.
+ *
+ * Extracted from `<ExercisesScreen>` so the ORDER is assertable. Previously
+ * these effects were spread across a broadcast-time handler and a
+ * `useWaitForTransactionReceipt().isSuccess` effect — and `isSuccess` means
+ * "the query resolved", not "the tx succeeded". A reverted save therefore
+ * persisted locally and wrote through to the Supabase leaderboard.
+ *
+ * Nothing in here may be called before `receipt.status === "success"`.
+ */
+
+export type ScoreSavePayload = {
+  /** Captured at broadcast, not read at receipt time: the player may have
+   *  switched the piece selector while the tx was in flight. */
+  piece: string;
+  score: number;
+  timeMs: number;
+  levelId: number;
+  player: string;
+  txHash: string;
+};
+
+export type CacheScorePayload = {
+  player: string;
+  levelId: number;
+  score: number;
+  timeMs: number;
+  txHash: string;
+};
+
+export type OptimisticScore = {
+  player: string;
+  score: number;
+  levelId: number;
+  ts: number;
+};
+
+export type ScoreSaveEffects = {
+  recordSaveFor: (piece: string, score: number, txHash: string) => void;
+  writeOptimisticScore: (entry: OptimisticScore) => void;
+  /** Fire-and-forget POST to /api/cache-score. Its silent-failure handling is
+   *  a known, deferred gap — but it must not run before the receipt. */
+  cacheScore: (payload: CacheScorePayload) => void;
+  refreshLeaderboard: () => void;
+  showOverlay: (txHash: string) => void;
+  startDoneHold: (txHash: string) => void;
+};
+
+/** Local truth, then the optimistic hint, then the remote write-through, then
+ *  the UI. The order is the contract: the leaderboard must never learn about a
+ *  score this device has not yet committed to. */
+export function applyScoreSaveSuccess(
+  effects: ScoreSaveEffects,
+  payload: ScoreSavePayload,
+): void {
+  const { piece, score, timeMs, levelId, player, txHash } = payload;
+
+  effects.recordSaveFor(piece, score, txHash);
+  effects.writeOptimisticScore({
+    player: player.toLowerCase(),
+    score,
+    levelId,
+    ts: Date.now(),
+  });
+  effects.cacheScore({ player, levelId, score, timeMs, txHash });
+  effects.refreshLeaderboard();
+  effects.showOverlay(txHash);
+  effects.startDoneHold(txHash);
+}

--- a/apps/web/src/lib/exercises/tx-toast-state.ts
+++ b/apps/web/src/lib/exercises/tx-toast-state.ts
@@ -11,12 +11,17 @@
  */
 
 export type TxToastInputs = {
-  /** Wagmi `useWriteContract().isPending` — request being signed. */
+  /** `useOnChainWrite().phase === "signing"` — request being signed. */
   isWriting: boolean;
-  /** Wagmi `useWaitForTransactionReceipt().isLoading` — receipt pending. */
+  /** `useOnChainWrite().phase === "confirming"` — receipt pending. */
   isConfirming: boolean;
-  /** Wagmi `useWaitForTransactionReceipt().isError` — chain revert / RPC error. */
-  isError: boolean;
+  /** The write settled as `failed`.
+   *
+   *  Was `useWaitForTransactionReceipt().isError`, documented here as
+   *  "chain revert / RPC error". It was only ever the RPC error: viem resolves
+   *  the receipt query for a reverted tx, so this branch never fired on the
+   *  revert it was written for. Now fed by the settled outcome. */
+  hasFailed: boolean;
   /** Broadcast tx hash, set once the wallet returns from `writeContract`. */
   txHash: string | null;
   /** Epoch ms when the done-hold window started; null outside the hold. */
@@ -33,7 +38,7 @@ export function deriveTxToastState(inputs: TxToastInputs): TxToastState {
   // Failed wins outright — a chain revert is terminal. The toast stays
   // mounted with `current="failed"` until either a new submit starts
   // (which clears `txHash` upstream) or the surface unmounts.
-  if (inputs.isError && hasTxHash) {
+  if (inputs.hasFailed && hasTxHash) {
     return { show: true, current: "failed" };
   }
 

--- a/apps/web/src/lib/exercises/use-done-hold.ts
+++ b/apps/web/src/lib/exercises/use-done-hold.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Matches the window the replaced effect used (3 × --duration-ceremony). */
+export const SAVE_DONE_HOLD_MS = 1500;
+
+export type UseDoneHoldReturn = {
+  /** Epoch ms when the window opened; null outside the hold. */
+  doneAt: number | null;
+  /** Idempotent per key — a repeat start for the same tx does not restart the
+   *  window. This carries the `doneHoldStartedForTxRef` latch. */
+  start: (key: string) => void;
+  /** Closes the window and clears the pending timer, so a stale timeout cannot
+   *  null out a later window. Call when a NEW write begins. */
+  reset: () => void;
+};
+
+/**
+ * The post-confirmation hold that keeps `<TxProgressSteps>` mounted for a beat
+ * after a save lands.
+ *
+ * Lifted out of `<ExercisesScreen>`, where it shared an effect with
+ * `recordSaveFor` and a latch ref. That effect was keyed on
+ * `useWaitForTransactionReceipt().isSuccess`, so it also ran for reverted
+ * transactions. Separating the timer from the persistence let the persistence
+ * move behind a real receipt check without losing the hold.
+ */
+export function useDoneHold(holdMs: number = SAVE_DONE_HOLD_MS): UseDoneHoldReturn {
+  const [doneAt, setDoneAt] = useState<number | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const startedForKeyRef = useRef<string | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const start = useCallback(
+    (key: string) => {
+      if (startedForKeyRef.current === key) return;
+      startedForKeyRef.current = key;
+
+      clearTimer();
+      setDoneAt(Date.now());
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = null;
+        setDoneAt(null);
+      }, holdMs);
+    },
+    [clearTimer, holdMs],
+  );
+
+  const reset = useCallback(() => {
+    clearTimer();
+    startedForKeyRef.current = null;
+    setDoneAt(null);
+  }, [clearTimer]);
+
+  return { doneAt, start, reset };
+}

--- a/apps/web/src/lib/exercises/use-onchain-write.ts
+++ b/apps/web/src/lib/exercises/use-onchain-write.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Hash, TransactionReceipt } from "viem";
+
+import { classifyTxErrorKind, isUserCancellation, type TxErrorKind } from "@/lib/errors";
+
+/** `idle → signing → confirming → settled`. `settled` covers every terminal
+ *  outcome: success, cancellation, and failure alike. */
+export type OnChainWritePhase = "idle" | "signing" | "confirming" | "settled";
+
+export type OnChainWriteOutcome =
+  | { status: "success"; txHash: Hash; receipt: TransactionReceipt }
+  /** The wallet never broadcast (hash null), or the player walked away after it
+   *  did (hash kept). Never surfaced as an on-chain failure. */
+  | { status: "cancelled"; txHash: Hash | null }
+  | { status: "failed"; kind: TxErrorKind; error: unknown; txHash: Hash | null };
+
+/** Returned when `run` is called while a write is already in flight. Not a
+ *  TxErrorKind: nothing failed, and it must never reach telemetry as an error. */
+export type OnChainWriteBusy = { status: "busy" };
+
+export type OnChainWriteRequest = {
+  /** Sign and broadcast. Resolves with the tx hash. */
+  broadcast: () => Promise<Hash>;
+  /** Await the receipt. MUST reject on a revert or an unreadable receipt —
+   *  `waitForReceiptWithTimeout` does. A `confirm` that resolves on a reverted
+   *  receipt reintroduces the exact bug this module exists to close. */
+  confirm: (hash: Hash) => Promise<TransactionReceipt>;
+};
+
+export type UseOnChainWriteReturn = {
+  phase: OnChainWritePhase;
+  txHash: Hash | null;
+  outcome: OnChainWriteOutcome | null;
+  isBusy: boolean;
+  run: (req: OnChainWriteRequest) => Promise<OnChainWriteOutcome | OnChainWriteBusy>;
+  reset: () => void;
+};
+
+/**
+ * Drives a player-facing on-chain write from signature to settled verdict.
+ *
+ * `run` never throws: callers branch on a discriminated outcome, so a success
+ * path cannot be reached by forgetting a `try`. Success is only ever reported
+ * after `confirm` resolves, which is what makes the celebration honest.
+ */
+export function useOnChainWrite(): UseOnChainWriteReturn {
+  const [phase, setPhase] = useState<OnChainWritePhase>("idle");
+  const [txHash, setTxHash] = useState<Hash | null>(null);
+  const [outcome, setOutcome] = useState<OnChainWriteOutcome | null>(null);
+
+  const isMountedRef = useRef(true);
+  // Guards re-entry synchronously. React state lands a render too late to stop
+  // a double tap from broadcasting twice.
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const commit = useCallback((next: OnChainWriteOutcome) => {
+    if (!isMountedRef.current) return;
+    setOutcome(next);
+    setPhase("settled");
+  }, []);
+
+  const run = useCallback(
+    async (req: OnChainWriteRequest): Promise<OnChainWriteOutcome | OnChainWriteBusy> => {
+      if (inFlightRef.current) return { status: "busy" };
+      inFlightRef.current = true;
+
+      let hash: Hash | null = null;
+      try {
+        if (isMountedRef.current) {
+          setOutcome(null);
+          setTxHash(null);
+          setPhase("signing");
+        }
+
+        hash = await req.broadcast();
+        if (isMountedRef.current) {
+          setTxHash(hash);
+          setPhase("confirming");
+        }
+
+        const receipt = await req.confirm(hash);
+        const success: OnChainWriteOutcome = { status: "success", txHash: hash, receipt };
+        commit(success);
+        return success;
+      } catch (error) {
+        // A rejection is a cancellation wherever it happens: before the wallet
+        // broadcast (hash null) or while waiting on the receipt (hash kept).
+        const settled: OnChainWriteOutcome = isUserCancellation(error)
+          ? { status: "cancelled", txHash: hash }
+          : { status: "failed", kind: classifyTxErrorKind(error), error, txHash: hash };
+        commit(settled);
+        return settled;
+      } finally {
+        inFlightRef.current = false;
+      }
+    },
+    [commit],
+  );
+
+  const reset = useCallback(() => {
+    setPhase("idle");
+    setTxHash(null);
+    setOutcome(null);
+  }, []);
+
+  return {
+    phase,
+    txHash,
+    outcome,
+    isBusy: phase === "signing" || phase === "confirming",
+    run,
+    reset,
+  };
+}

--- a/docs/handoffs/_next-session-prompt.md
+++ b/docs/handoffs/_next-session-prompt.md
@@ -19,7 +19,25 @@ en mainnet.
 
 ---
 
-## Camino recomendado (en orden, de barato a caro)
+## ⚠️ Ruta vigente (2026-07-09, modo cierre y estabilización)
+
+El camino de abajo quedó **obsoleto**. Los custom errors YA NO son el siguiente
+paso: el síntoma que los motivaba era una misclasificación (#197), y debajo
+apareció algo peor — badge y score declaran éxito sobre el hash, no sobre el
+receipt (#199 cerró el helper; falta el lado del jugador).
+
+1. **`docs/specs/receipt-status-learn-handlers.md`** — bloque activo. Seam
+   testable + handlers de LEARN + estado `confirming`.
+2. **Probe en device del `raw` de MiniPay** — sin esto, decodificar custom errors
+   es una apuesta (`docs/reviews/2026-07-09-custom-errors-plan-redteam.md`).
+3. **Smoke test del flujo crítico** en mainnet.
+4. **Checkpoint de estabilidad.**
+
+Regla activa: si un hallazgo no bloquea el bloque, se **difiere**, no se abre.
+
+---
+
+## Camino anterior (histórico, no seguir)
 
 1. ~~**Refrescar el baseline VR `hub-shop-sheet-open`**~~ — **HECHO** (`28b2f75`).
    Eran dos fallos apilados. El segundo, no previsto: un


### PR DESCRIPTION
Cierra `docs/specs/receipt-status-learn-handlers.md` (spec 2 de 2). Consume el
helper fail-closed de #199.

## El bug

- **Badge**: `hapticSuccess()`, `justClaimed`, el modal `piece-unlocked` y el
  overlay se disparaban en cuanto `writeContractAsync` devolvía el hash. La
  cadena todavía no había fallado.
- **Score**: sí esperaba el receipt, pero consumía
  `useWaitForTransactionReceipt().isSuccess`, que significa **"la query
  resolvió"**. viem la resuelve también para una tx revertida. Un save revertido
  persistía en localStorage y **escribía en el leaderboard de Supabase**.

## El cambio

Ambos writes pasan por `useOnChainWrite`: `idle → signing → confirming → settled`.
Devuelve un outcome discriminado y **nunca lanza**, así que no se puede llegar al
camino de éxito olvidando un `try`. El `confirm` inyectado es
`waitForReceiptWithTimeout`, que desde #199 rechaza revert y receipt ilegible.

Los efectos de éxito viven en **dos secuenciadores puros**, y ahí el orden es
afirmable:

```
recordSaveFor → writeOptimisticScore → cacheScore → refreshLeaderboard → showOverlay → startDoneHold
```

Afirmar solo el estado final habría pasado contra un secuenciador que le cuenta
al leaderboard un score que este dispositivo todavía no commiteó.

## El effect de `:1094` hacía tres cosas

| Responsabilidad | Destino |
| --- | --- |
| `recordSaveFor` | detrás del receipt verificado |
| latch `doneHoldStartedForTxRef` | es el `key` de `useDoneHold.start()` |
| done-hold de 1500 ms + cleanup | encapsulado en `useDoneHold` |

No desapareció nada. `SAVE_DONE_HOLD_MS === 1500` tiene su propio test.

## La rama muerta del toast

`deriveTxToastState` recibía `useWaitForTransactionReceipt().isError` — un error
**de query**. Su branch `failed` nunca disparó en un revert, al revés de lo que
afirmaban sus comentarios. Ahora se llama `hasFailed` y lo alimenta el outcome.

Tercera aparición de `feedback_tests_green_against_dead_shape` en esta sesión.

## ⚠️ La telemetría cambia de significado

`stage: "success"` pasa de **"broadcast aceptado por la wallet"** a
**"transacción minada exitosamente"**. Se agrega `stage: "broadcast"` para el
momento viejo.

Las tasas de éxito de `badge_claim_tx` y `score_submit_tx` **van a caer**, y no
es una regresión: es la diferencia entre lo que se creía y lo que pasaba. Sumado
al re-bucketeo de `error_kind` de #197, son dos discontinuidades seguidas. No se
abrió trabajo de analytics.

## Criterios de cierre

| Criterio | Estado |
| --- | --- |
| Badge no celebra ni marca `justClaimed` sin receipt exitoso | ✅ |
| Score no persiste local ni en `/api/cache-score` sin receipt exitoso | ✅ |
| UI en estado explícito `confirming` mientras espera | ✅ |
| Revert o receipt no verificable → error, nunca éxito | ✅ |
| Latch y done-hold de 1500 ms preservados | ✅ |
| Los tests prueban el **orden**, no solo el estado final | ✅ |
| `exercises-screen.tsx` solo cambia para crear el seam y cablear | ✅ |

Tests de orden y de fase, con promesas diferidas para observar `signing` y
`confirming` **mientras corren**: un hook que nunca entrara en `confirming`
pasaría si solo se mirara el estado final.

## Verificación

- Unit: **4820 passed, 0 failed**, en **399 test files** (antes 4791 / 395)
- `pnpm exec tsc --noEmit`: limpio
- `pnpm lint`: limpio (2 warnings preexistentes, en otros archivos)
- VR: **52 passed** (env limpio)
- `git diff --check`: limpio

## Riesgos diferidos, registrados y no abiertos

1. `/api/cache-score` sigue fire-and-forget con `.catch(() => {})`. Ahora corre
   después del receipt, así que la ventana de fallo silencioso es mayor:
   cambiamos "score falso en el leaderboard" por "score real ausente".
2. Ningún refactor general de `ExercisesScreen`.
3. Reconciliación asimétrica si el jugador cierra la app en `confirming`: el
   badge se auto-cura al montar, el score no.

Wolfcito 🐾 @akawolfcito
