### PR TITLE
test(dev): probe what MiniPay preserves of a tx error

### DIFF
--- a/apps/web/src/app/dev/tx-error-probe/page.tsx
+++ b/apps/web/src/app/dev/tx-error-probe/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+
+import { WalletProvider } from "@/components/wallet-provider";
+import { TxErrorProbeClient } from "./tx-error-probe-client";
+
+// TEMPORARY — delete this directory and `lib/debug/serialize-tx-error.ts`
+// once the question below is answered.
+//
+// Internal dev surface to answer ONE question with evidence: what does MiniPay
+// preserve of an error on its way back to the dapp? Specifically, does a
+// contract revert arrive with its 4-byte revert data intact?
+//
+// It matters because `apps/web/src` decodes no revert data today, and building
+// a decoder + an ABI generator is 1-2h of work that is worthless if MiniPay
+// hands us a plain string. See docs/reviews/2026-07-09-custom-errors-plan-redteam.md.
+//
+// This probe decodes nothing and changes no production code. It only reports.
+//
+// Never shipped to production — 404s there. Lives outside `[locale]`, so it
+// does NOT inherit the app's WalletProvider from the locale layout.
+export const dynamic = "force-dynamic";
+
+export default function TxErrorProbeDevPage() {
+  if (process.env.VERCEL_ENV === "production") notFound();
+  return (
+    <WalletProvider>
+      <TxErrorProbeClient />
+    </WalletProvider>
+  );
+}

--- a/apps/web/src/app/dev/tx-error-probe/tx-error-probe-client.tsx
+++ b/apps/web/src/app/dev/tx-error-probe/tx-error-probe-client.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useAccount, useChainId, usePublicClient, useWriteContract } from "wagmi";
+
+import { useConnectWallet } from "@/lib/wallet/use-connect-wallet";
+import { badgesAbi } from "@/lib/contracts/badges";
+import { erc20Abi } from "@/lib/contracts/tokens";
+import {
+  getBadgesAddress,
+  getMiniPayFeeCurrency,
+  getShopAddress,
+  getUsdcAddress,
+} from "@/lib/contracts/chains";
+import {
+  findRevertData,
+  serializeTxError,
+  type SerializedTxErrorChain,
+} from "@/lib/debug/serialize-tx-error";
+
+type Scenario = "cancel" | "pre-broadcast" | "revert" | "success";
+
+type Report = {
+  scenario: Scenario;
+  at: string;
+  /** Did the wallet return a hash? This is the load-bearing distinction: a
+   *  rejection at estimation never broadcasts, a mined revert does. */
+  txHash: string | null;
+  receiptStatus: string | null;
+  revertData: string | null;
+  error: SerializedTxErrorChain | null;
+  env: {
+    origin: string;
+    chainId: number;
+    userAgent: string;
+    isMiniPay: boolean;
+  };
+};
+
+function readEnv(chainId: number) {
+  const eth = (globalThis as { ethereum?: { isMiniPay?: boolean } }).ethereum;
+  return {
+    origin: typeof window === "undefined" ? "" : window.location.origin,
+    chainId,
+    userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
+    isMiniPay: Boolean(eth?.isMiniPay),
+  };
+}
+
+export function TxErrorProbeClient() {
+  const { address, isConnected } = useAccount();
+  const chainId = useChainId();
+  const publicClient = usePublicClient({ chainId });
+  const { writeContractAsync } = useWriteContract();
+  const { connectWallet } = useConnectWallet();
+
+  const [levelId, setLevelId] = useState("1");
+  const [running, setRunning] = useState<Scenario | null>(null);
+  const [reports, setReports] = useState<Report[]>([]);
+
+  const badgesAddress = getBadgesAddress(chainId);
+  const usdcAddress = getUsdcAddress(chainId);
+  const shopAddress = getShopAddress(chainId);
+  const feeCurrency = getMiniPayFeeCurrency(chainId);
+
+  const record = useCallback((report: Report) => {
+    setReports((prev) => [report, ...prev]);
+  }, []);
+
+  /** MiniPay wallets hold no CELO; every write must offer a fee currency, then
+   *  retry without it for web wallets that reject the extra field. */
+  const write = useCallback(
+    async (request: Parameters<typeof writeContractAsync>[0]) => {
+      try {
+        const withFee = feeCurrency
+          ? ({ ...request, feeCurrency } as unknown as Parameters<typeof writeContractAsync>[0])
+          : request;
+        return await writeContractAsync(withFee);
+      } catch (error) {
+        if (!feeCurrency) throw error;
+        return writeContractAsync(request);
+      }
+    },
+    [writeContractAsync, feeCurrency],
+  );
+
+  const run = useCallback(
+    async (scenario: Scenario) => {
+      if (!address) return;
+      setRunning(scenario);
+
+      let txHash: string | null = null;
+      let receiptStatus: string | null = null;
+
+      try {
+        if (scenario === "pre-broadcast") {
+          // A signing failure that never reaches the wallet. Malformed body →
+          // the route 400s → requestSignature throws. No tx, no gas.
+          const response = await fetch("/api/sign-badge", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({}),
+          });
+          const payload = (await response.json()) as { error?: string };
+          throw new Error(payload.error ?? `sign-badge failed: ${response.status}`);
+        }
+
+        if (scenario === "revert") {
+          // Claim a badge this wallet ALREADY owns. /api/sign-badge signs any
+          // levelId without checking ownership, so the signature is valid and
+          // the contract is the one that says no: BadgeAlreadyClaimed.
+          // This is the only scenario that can produce real revert data.
+          if (!badgesAddress) throw new Error("No badges address for this chain");
+          const response = await fetch("/api/sign-badge", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ player: address, levelId: Number(levelId) }),
+          });
+          const signed = (await response.json()) as {
+            nonce: string;
+            deadline: string;
+            signature: `0x${string}`;
+            error?: string;
+          };
+          if (signed.error) throw new Error(signed.error);
+
+          txHash = await write({
+            address: badgesAddress,
+            abi: badgesAbi,
+            functionName: "claimBadgeSigned" as const,
+            args: [
+              BigInt(levelId),
+              BigInt(signed.nonce),
+              BigInt(signed.deadline),
+              signed.signature,
+            ] as const,
+            chainId,
+            account: address,
+          });
+        }
+
+        if (scenario === "cancel" || scenario === "success") {
+          // Harmless control write: approve(shop, 0). Real broadcast, real
+          // receipt, zero economic effect. Reject it in the wallet for
+          // `cancel`; accept it for `success`.
+          if (!usdcAddress || !shopAddress) throw new Error("No USDC/shop address for this chain");
+          txHash = await write({
+            address: usdcAddress,
+            abi: erc20Abi,
+            functionName: "approve" as const,
+            args: [shopAddress, 0n] as const,
+            chainId,
+            account: address,
+          });
+        }
+
+        // A hash exists. Read the verdict raw — no helper, no throwing.
+        if (txHash && publicClient) {
+          const receipt = await publicClient.waitForTransactionReceipt({
+            hash: txHash as `0x${string}`,
+            timeout: 120_000,
+          });
+          receiptStatus = String(receipt.status);
+        }
+
+        record({
+          scenario,
+          at: new Date().toISOString(),
+          txHash,
+          receiptStatus,
+          revertData: null,
+          error: null,
+          env: readEnv(chainId),
+        });
+      } catch (error) {
+        const chain = serializeTxError(error);
+        record({
+          scenario,
+          at: new Date().toISOString(),
+          txHash,
+          receiptStatus,
+          revertData: findRevertData(chain),
+          error: chain,
+          env: readEnv(chainId),
+        });
+      } finally {
+        setRunning(null);
+      }
+    },
+    [address, badgesAddress, chainId, levelId, publicClient, record, shopAddress, usdcAddress, write],
+  );
+
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(JSON.stringify(reports, null, 2));
+  }, [reports]);
+
+  return (
+    <main style={{ padding: 16, fontFamily: "monospace", fontSize: 12, lineHeight: 1.5 }}>
+      <h1 style={{ fontSize: 16, fontWeight: 700 }}>MiniPay raw tx-error probe</h1>
+      <p>
+        Answers one question: does a contract revert reach the dapp with its 4-byte
+        revert data intact? Decodes nothing. Delete after use.
+      </p>
+
+      {!isConnected ? (
+        <button type="button" onClick={() => connectWallet()} style={btn}>
+          Connect wallet
+        </button>
+      ) : (
+        <p>
+          Connected: {address?.slice(0, 6)}…{address?.slice(-4)} · chain {chainId} ·
+          MiniPay {String(readEnv(chainId).isMiniPay)}
+        </p>
+      )}
+
+      <label style={{ display: "block", margin: "12px 0" }}>
+        levelId of a badge this wallet ALREADY owns (rook = 1):{" "}
+        <input
+          value={levelId}
+          onChange={(event) => setLevelId(event.target.value)}
+          inputMode="numeric"
+          style={{ width: 64, border: "1px solid #999", padding: 4 }}
+        />
+      </label>
+
+      <div style={{ display: "grid", gap: 8, maxWidth: 360 }}>
+        <button type="button" style={btn} disabled={!isConnected || running !== null} onClick={() => void run("cancel")}>
+          1. Cancel — approve(shop, 0), then REJECT in the wallet
+        </button>
+        <button type="button" style={btn} disabled={!isConnected || running !== null} onClick={() => void run("pre-broadcast")}>
+          2. Fail before broadcast — malformed /api/sign-badge
+        </button>
+        <button type="button" style={btn} disabled={!isConnected || running !== null} onClick={() => void run("revert")}>
+          3. Revert — re-claim an owned badge (costs gas)
+        </button>
+        <button type="button" style={btn} disabled={!isConnected || running !== null} onClick={() => void run("success")}>
+          4. Success control — approve(shop, 0), ACCEPT it
+        </button>
+      </div>
+
+      {running ? <p>Running “{running}” — watch the wallet.</p> : null}
+
+      {reports.length > 0 ? (
+        <>
+          <button type="button" style={{ ...btn, marginTop: 16 }} onClick={copy}>
+            Copy all reports as JSON
+          </button>
+          <pre style={{ whiteSpace: "pre-wrap", wordBreak: "break-all", marginTop: 12 }}>
+            {JSON.stringify(reports, null, 2)}
+          </pre>
+        </>
+      ) : null}
+    </main>
+  );
+}
+
+const btn: React.CSSProperties = {
+  border: "1px solid #333",
+  borderRadius: 6,
+  padding: "10px 12px",
+  textAlign: "left",
+  background: "#f3f3f3",
+};

--- a/apps/web/src/lib/debug/__tests__/serialize-tx-error.test.ts
+++ b/apps/web/src/lib/debug/__tests__/serialize-tx-error.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findRevertData,
+  redactLongHex,
+  serializeTxError,
+} from "../serialize-tx-error";
+
+const SIGNATURE = `0x${"ab".repeat(65)}`; // 65 bytes → 132 chars
+const REVERT_DATA = "0xc1ab61a1"; // CooldownActive()
+
+describe("redactLongHex", () => {
+  it("redacts a 65-byte signature", () => {
+    const out = redactLongHex(`args: (1, 2400, ${SIGNATURE})`);
+    expect(out).not.toContain(SIGNATURE);
+    expect(out).toContain("[redacted 132 chars]");
+  });
+
+  it("leaves a 4-byte selector alone — it is what we came for", () => {
+    expect(redactLongHex(`reverted with signature ${REVERT_DATA}`)).toContain(REVERT_DATA);
+  });
+
+  it("leaves an address and a tx hash alone", () => {
+    const addr = "0x1681aAA176d5f46e45789A8b18C8E990f663959a";
+    const hash = `0x${"cd".repeat(32)}`;
+    const out = redactLongHex(`${addr} ${hash}`);
+    expect(out).toContain(addr);
+    expect(out).toContain(hash);
+  });
+});
+
+describe("serializeTxError", () => {
+  it("captures name, message, code, data and own keys", () => {
+    const err = Object.assign(new Error("execution reverted"), {
+      code: 3,
+      data: REVERT_DATA,
+    });
+    const { top } = serializeTxError(err);
+    expect(top.name).toBe("Error");
+    expect(top.message).toBe("execution reverted");
+    expect(top.code).toBe(3);
+    expect(top.data).toBe(REVERT_DATA);
+    expect(top.keys).toContain("code");
+    expect(top.keys).toContain("data");
+  });
+
+  it("redacts a signature echoed into the message", () => {
+    const err = new Error(`args: (${SIGNATURE})`);
+    expect(serializeTxError(err).top.message).toContain("[redacted 132 chars]");
+  });
+
+  it("walks the cause chain outermost first", () => {
+    const inner = Object.assign(new Error("inner"), { data: REVERT_DATA });
+    const middle = Object.assign(new Error("middle"), { cause: inner });
+    const outer = Object.assign(new Error("outer"), { cause: middle });
+
+    const chain = serializeTxError(outer);
+    expect(chain.top.message).toBe("outer");
+    expect(chain.causes.map((c) => c.message)).toEqual(["middle", "inner"]);
+    expect(chain.depth).toBe(2);
+  });
+
+  it("survives a cyclic cause chain", () => {
+    const a = new Error("a") as Error & { cause?: unknown };
+    const b = new Error("b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(() => serializeTxError(a)).not.toThrow();
+    expect(serializeTxError(a).depth).toBeLessThanOrEqual(8);
+  });
+
+  it("handles a thrown non-object", () => {
+    expect(serializeTxError("boom").top.message).toBe("boom");
+  });
+});
+
+describe("findRevertData — the go/no-go signal", () => {
+  it("finds revert data on the top level", () => {
+    const err = Object.assign(new Error("x"), { data: REVERT_DATA });
+    expect(findRevertData(serializeTxError(err))).toBe(REVERT_DATA);
+  });
+
+  it("finds revert data nested in a cause", () => {
+    const inner = Object.assign(new Error("inner"), { data: REVERT_DATA });
+    const outer = Object.assign(new Error("outer"), { cause: inner });
+    expect(findRevertData(serializeTxError(outer))).toBe(REVERT_DATA);
+  });
+
+  it("finds revert data wrapped as { data: { data } }", () => {
+    const err = Object.assign(new Error("x"), { data: { data: REVERT_DATA } });
+    expect(findRevertData(serializeTxError(err))).toBe(REVERT_DATA);
+  });
+
+  it("falls back to viem's undecoded `signature` field", () => {
+    const err = Object.assign(new Error("x"), { signature: REVERT_DATA });
+    expect(findRevertData(serializeTxError(err))).toBe(REVERT_DATA);
+  });
+
+  it("returns null when the wallet stripped the revert data", () => {
+    const err = Object.assign(new Error("execution reverted"), { code: 3 });
+    expect(findRevertData(serializeTxError(err))).toBeNull();
+  });
+
+  it("does not mistake a user rejection for revert data", () => {
+    const err = Object.assign(new Error("User rejected the request"), { code: 4001 });
+    expect(findRevertData(serializeTxError(err))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/debug/serialize-tx-error.ts
+++ b/apps/web/src/lib/debug/serialize-tx-error.ts
@@ -1,0 +1,115 @@
+/**
+ * TEMPORARY — delete with `app/dev/tx-error-probe/`.
+ *
+ * Flattens an unknown thrown value into something a human can read off a phone
+ * screen, WITHOUT leaking the server-issued EIP-712 signature that viem echoes
+ * into its error messages.
+ *
+ * This file decodes nothing. It exists to answer one question with evidence:
+ * does MiniPay preserve revert data on its way back to the dapp? Whether we
+ * build a decoder is a decision that comes after, not before.
+ */
+
+/** An EIP-712 / ECDSA signature is 65 bytes → 132 chars. Revert data for two
+ *  32-byte args is 138. We cannot tell them apart by length alone, so we redact
+ *  long hex only inside free-text `message`, never inside a structured `data`
+ *  field — which is the one thing this probe is here to read. */
+const LONG_HEX = /0x[0-9a-fA-F]{100,}/g;
+
+export function redactLongHex(text: string): string {
+  return text.replace(LONG_HEX, (hex) => `0x${hex.slice(2, 8)}…[redacted ${hex.length} chars]`);
+}
+
+export type SerializedTxError = {
+  /** Constructor / duck-typed error name, e.g. ContractFunctionRevertedError. */
+  name: string | null;
+  /** Free text, with any long hex run redacted. */
+  message: string | null;
+  /** JSON-RPC error code. 4001 = user rejected, 3 = execution reverted. */
+  code: string | number | null;
+  /** THE PRIZE: revert data, if the wallet passed it through. */
+  data: unknown;
+  /** Present on viem's ContractFunctionRevertedError when the ABI lacked the error. */
+  signature: string | null;
+  /** Own enumerable keys, so we can see what MiniPay attached that we did not expect. */
+  keys: string[];
+};
+
+export type SerializedTxErrorChain = {
+  top: SerializedTxError;
+  /** `cause` chain, outermost first. Depth-capped: a cycle must not hang the probe. */
+  causes: SerializedTxError[];
+  depth: number;
+};
+
+function pick(error: unknown): SerializedTxError {
+  if (typeof error !== "object" || error === null) {
+    return {
+      name: null,
+      message: redactLongHex(String(error)),
+      code: null,
+      data: null,
+      signature: null,
+      keys: [],
+    };
+  }
+
+  const bag = error as Record<string, unknown>;
+  const message = typeof bag.message === "string" ? redactLongHex(bag.message) : null;
+  const code = typeof bag.code === "string" || typeof bag.code === "number" ? bag.code : null;
+  const signature = typeof bag.signature === "string" ? bag.signature : null;
+
+  return {
+    name: typeof bag.name === "string" ? bag.name : null,
+    message,
+    code,
+    // `data` may be a hex string (revert data) or an object ({ data: "0x..." }).
+    // Captured verbatim: it is never a secret, and it is the whole point.
+    data: bag.data ?? null,
+    signature,
+    keys: Object.keys(bag).sort(),
+  };
+}
+
+const MAX_DEPTH = 8;
+
+export function serializeTxError(error: unknown): SerializedTxErrorChain {
+  const top = pick(error);
+  const causes: SerializedTxError[] = [];
+  const seen = new Set<unknown>();
+
+  let current: unknown = error;
+  seen.add(current);
+
+  while (causes.length < MAX_DEPTH) {
+    const next =
+      typeof current === "object" && current !== null
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+    if (next === undefined || next === null || seen.has(next)) break;
+    seen.add(next);
+    causes.push(pick(next));
+    current = next;
+  }
+
+  return { top, causes, depth: causes.length };
+}
+
+/** The one fact that decides go / no-go: did any layer carry revert data? */
+export function findRevertData(chain: SerializedTxErrorChain): string | null {
+  for (const layer of [chain.top, ...chain.causes]) {
+    if (typeof layer.data === "string" && layer.data.startsWith("0x") && layer.data.length >= 10) {
+      return layer.data;
+    }
+    if (typeof layer.data === "object" && layer.data !== null) {
+      const nested = (layer.data as { data?: unknown }).data;
+      if (typeof nested === "string" && nested.startsWith("0x") && nested.length >= 10) {
+        return nested;
+      }
+    }
+    if (layer.signature && layer.signature.startsWith("0x") && layer.signature.length === 10) {
+      return layer.signature;
+    }
+  }
+  return null;
+}

--- a/docs/testing/2026-07-10-minipay-raw-error-probe-runbook.md
+++ b/docs/testing/2026-07-10-minipay-raw-error-probe-runbook.md
@@ -1,0 +1,120 @@
+# Runbook — probe del raw de MiniPay (custom errors go/no-go)
+
+**Fecha**: 2026-07-10
+**Estado**: instrumentación lista, **datos pendientes de captura en device**
+**Superficie**: `/dev/tx-error-probe` (404 en producción)
+
+---
+
+## Por qué existe
+
+`apps/web/src` no decodifica revert data en ningún lado. Construir el decoder +
+el generador de ABIs son 1-2h. **Ese trabajo vale cero si MiniPay no nos entrega
+la revert data.**
+
+Todo lo que sabemos hoy se midió con `publicClient.simulateContract` contra
+Forno, no con la wallet. La app **no simula**: va directo a `eth_sendTransaction`
+del provider inyectado. Si MiniPay estima adentro y devuelve un `Error` de texto
+plano, `raw` es `undefined` y el decoder muere en silencio.
+
+Este probe no decodifica nada. Solo reporta.
+
+---
+
+## Lo que el probe captura
+
+Por escenario: `txHash` (si existe), `receipt.status` (si hubo tx), y del error
+`name`, `message`, `code`, `data`, `signature`, las **keys propias**, y la cadena
+completa de `cause` hasta profundidad 8 (con guarda de ciclos).
+
+Más el contexto: `origin`, `chainId`, `userAgent`, `window.ethereum.isMiniPay`.
+
+**Redacción**: `serialize-tx-error.ts` reemplaza toda corrida de hex de ≥100
+caracteres **dentro de `message`** por `0xabcdef…[redacted N chars]`. Eso tapa la
+firma EIP-712 de 132 chars que viem imprime en `args:`. El campo estructurado
+`data` **no se redacta**: es revert data, no es un secreto, y es justamente lo
+que venimos a leer.
+
+---
+
+## Antes de correr
+
+1. **Deploy a preview** con este branch. Las `/dev` pages 404 en producción.
+2. La wallet de MiniPay necesita un saldo chico de un stable (USDC/USDT/cUSD):
+   el probe usa `feeCurrency`, y MiniPay no tiene CELO.
+3. **Escenario 3 gasta gas real.** Es una tx que se transmite y revierte.
+4. Anotá: modelo de teléfono, versión de MiniPay (Settings → About), y que el
+   entorno es `preview.chesscito.com`.
+
+---
+
+## Los cuatro escenarios
+
+Abrí `https://preview.chesscito.com/dev/tx-error-probe` **dentro de MiniPay**.
+
+| # | Botón | Acción exacta | Qué se espera aprender |
+| --- | --- | --- | --- |
+| 1 | Cancel | `approve(shop, 0)` sobre USDC, y **rechazás** en la wallet | Forma de la cancelación. ¿`code: 4001`? ¿hay hash? |
+| 2 | Fail before broadcast | POST malformado a `/api/sign-badge` | Un fallo que nunca toca la wallet. Control negativo. |
+| 3 | **Revert** | Re-clamar un badge que la wallet **ya tiene** (torre = `levelId 1`) | **La pregunta.** ¿Llega `0xfafe7970` (`BadgeAlreadyClaimed`)? ¿Hay hash, o la wallet rechaza en estimación? |
+| 4 | Success control | `approve(shop, 0)`, y **aceptás** | Confirma que el camino feliz funciona y que el receipt se lee. |
+
+`approve(shop, 0)` es una escritura real, con receipt real, y **efecto económico
+cero**. Es el control honesto.
+
+El escenario 3 funciona porque `/api/sign-badge` firma cualquier `levelId` sin
+mirar propiedad (`route.ts:23`). La firma es válida; el que dice que no es el
+contrato. Es la única forma de producir revert data real sin pelearse con los
+gates de la UI.
+
+Al terminar: **Copy all reports as JSON** y pegalo en el issue.
+
+---
+
+## Cómo se lee el resultado
+
+La distinción que decide todo está en el escenario 3:
+
+- **Hay `txHash` y `receiptStatus: "reverted"`** → la wallet transmitió y la tx
+  se minó revertida. **No hay revert data que decodificar**: un receipt revertido
+  no la trae. El decoder no sirve para este caso; lo que sirve es el chequeo de
+  `receipt.status`, que ya shipeamos en #199 / #200.
+- **No hay `txHash`, y `revertData` es un `0x…` de 10 caracteres** → MiniPay
+  rechazó en estimación y **conservó la revert data**. **GO**: el decoder tiene
+  material y `BadgeAlreadyClaimed` / `CooldownActive` / `DailyLimitReached` se
+  pueden distinguir.
+- **No hay `txHash`, y `revertData` es `null`** → MiniPay rechazó en estimación y
+  **tiró la revert data**. **NO-GO**: no hay nada que decodificar del lado del
+  cliente, y la salida sería server-side (`eth_call` de replay contra Forno con
+  los mismos args) o directamente no hacerlo.
+
+`findRevertData()` ya resuelve las tres formas conocidas en que un provider la
+adjunta: `error.data`, `error.data.data`, y el campo `signature` que viem deja
+cuando la ABI no tenía el error.
+
+---
+
+## Al terminar
+
+Borrar, en un solo commit:
+
+- `apps/web/src/app/dev/tx-error-probe/`
+- `apps/web/src/lib/debug/serialize-tx-error.ts` (+ su test)
+
+No hay código de producción que revertir: el probe no toca ninguno.
+
+---
+
+## Incertidumbres conocidas
+
+1. **El escenario 3 puede no revertir** si la wallet ya no tiene el badge de la
+   torre, o si `levelId 1` no es el correcto. Verificar propiedad antes
+   (`/hub` → Badges) y ajustar el campo `levelId`.
+2. **MiniPay podría no estimar** y transmitir siempre. En ese caso el escenario 3
+   cuesta gas y devuelve `reverted`, que ya es una respuesta: NO-GO para el
+   decoder por esa vía.
+3. `approve` con `feeCurrency` puede fallar si la wallet no tiene el stable que
+   `getMiniPayFeeCurrency` devuelve. El helper reintenta sin `feeCurrency`, pero
+   en MiniPay eso falla por falta de CELO. Si el escenario 4 no arranca, es esto.
+4. El probe corre contra **mainnet** (chain 42220), porque es donde está el badge
+   minteado. No hay versión testnet de este experimento.


### PR DESCRIPTION
Instrumentación para el bloque activo. **No decodifica nada, no toca producción.**

Runbook completo: `docs/testing/2026-07-10-minipay-raw-error-probe-runbook.md`

## La pregunta

Todo lo que sabemos de revert data se midió con `publicClient.simulateContract`
contra Forno. La app **no simula**: va directo a `eth_sendTransaction` del
provider inyectado. Si MiniPay estima adentro y devuelve un `Error` de texto
plano, la revert data nunca llega y el decoder nace muerto.

1-2h de decoder + generador de ABIs dependen de esta respuesta.

## Los cuatro escenarios

| # | Acción | Para qué |
| --- | --- | --- |
| 1 | `approve(shop, 0)`, rechazar en la wallet | forma de la cancelación (`code: 4001`?) |
| 2 | POST malformado a `/api/sign-badge` | fallo que nunca toca la wallet |
| 3 | **re-clamar un badge ya poseído** | **la pregunta**: ¿llega `0xfafe7970`? |
| 4 | `approve(shop, 0)`, aceptar | control de éxito |

El escenario 3 funciona porque `/api/sign-badge` firma cualquier `levelId` sin
mirar propiedad (`route.ts:23`). La firma es válida y el que dice que no es el
contrato. Es la única forma de producir revert data real sin pelearse con los
gates de la UI.

`approve(shop, 0)` es una escritura real, con receipt real, y efecto económico
cero. Control honesto.

## Qué captura

`txHash`, `receipt.status`, y del error: `name`, `message`, `code`, `data`,
`signature`, las **keys propias**, y la cadena de `cause` hasta profundidad 8 con
guarda de ciclos. Más `origin`, `chainId`, `userAgent`, `isMiniPay`.

`findRevertData()` resuelve las tres formas conocidas en que un provider adjunta
la data: `error.data`, `error.data.data`, y el `signature` que viem deja cuando
la ABI no tenía el error.

## Sobre datos sensibles

Se redacta toda corrida de hex de ≥100 caracteres **dentro de `message`** — ahí
es donde viem imprime la firma EIP-712 de 132 chars en `args:`.

El campo estructurado `data` **no se redacta**: es revert data, no es un secreto,
y es exactamente lo que venimos a leer. Un selector de 4 bytes, una address y un
tx hash pasan intactos; hay tests para los cuatro casos.

## Cómo se lee

La distinción que decide todo, en el escenario 3:

- **hash + `receiptStatus: "reverted"`** → se transmitió y se minó revertida. Un
  receipt revertido **no trae** revert data. NO-GO por esta vía; lo que sirve es
  `receipt.status`, ya shipeado en #199/#200.
- **sin hash + `revertData: "0x…"` (10 chars)** → MiniPay rechazó en estimación y
  **conservó** la data. **GO**.
- **sin hash + `revertData: null`** → rechazó y **tiró** la data. **NO-GO**.

## Removible

Borrar `apps/web/src/app/dev/tx-error-probe/` y `apps/web/src/lib/debug/`. Nada
de producción que revertir. Las `/dev` pages 404 en producción.

## Verificación

- Unit: **4834 passed, 0 failed** en **400 test files** (antes 4820 / 399)
- `tsc --noEmit`: limpio · `lint`: limpio (2 warnings preexistentes, otros archivos)

## Pendiente: los datos

El probe **no fue ejecutado**. Requiere MiniPay en un teléfono real, contra
preview. Los cuatro reportes son el entregable del bloque, y no los puedo
producir yo.

Wolfcito 🐾 @akawolfcito
