### PR TITLE
test(dev): capture MiniPay's raw error shape, and fix the probe that hid it

### DIFF
--- a/apps/web/src/lib/debug/__tests__/serialize-tx-error.test.ts
+++ b/apps/web/src/lib/debug/__tests__/serialize-tx-error.test.ts
@@ -9,11 +9,27 @@ import {
 const SIGNATURE = `0x${"ab".repeat(65)}`; // 65 bytes → 132 chars
 const REVERT_DATA = "0xc1ab61a1"; // CooldownActive()
 
+/** Verbatim from an iPhone 18.7 / MiniPay capture, 2026-07-10, mainnet.
+ *  `claimBadgeSigned` on a badge the wallet already owns. The wallet rejected
+ *  at `eth_estimateGas` and never opened the confirmation sheet. */
+const MINIPAY_REVERT_MESSAGE =
+  'The contract function "claimBadgeSigned" reverted with the following reason:\n' +
+  "Remote method 'eth_estimateGas' failed with an error: " +
+  '{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted",' +
+  `"data":"0xfafe7970${"00".repeat(64)}"}}`;
+
 describe("redactLongHex", () => {
   it("redacts a 65-byte signature", () => {
     const out = redactLongHex(`args: (1, 2400, ${SIGNATURE})`);
     expect(out).not.toContain(SIGNATURE);
     expect(out).toContain("[redacted 132 chars]");
+  });
+
+  // The first capture cut the selector at 3 bytes (`0xfafe79`), leaving the
+  // error ambiguous. 4 bytes is the selector; on a signature it reveals nothing.
+  it("preserves the full 4-byte selector of redacted revert data", () => {
+    const data = `0xfafe7970${"00".repeat(64)}`;
+    expect(redactLongHex(`"data":"${data}"`)).toContain("0xfafe7970…[redacted");
   });
 
   it("leaves a 4-byte selector alone — it is what we came for", () => {
@@ -104,5 +120,39 @@ describe("findRevertData — the go/no-go signal", () => {
   it("does not mistake a user rejection for revert data", () => {
     const err = Object.assign(new Error("User rejected the request"), { code: 4001 });
     expect(findRevertData(serializeTxError(err))).toBeNull();
+  });
+
+  // The device answer: MiniPay hands viem no structured revert data. It puts
+  // the node's JSON-RPC blob into the revert *reason* string, so `data`, `raw`
+  // and `signature` are all null and the text is the only carrier.
+  it("recovers revert data embedded in MiniPay's message blob", () => {
+    const inner = Object.assign(new Error(MINIPAY_REVERT_MESSAGE), {
+      name: "ContractFunctionRevertedError",
+      data: null,
+      raw: null,
+      signature: null,
+    });
+    const outer = Object.assign(new Error(MINIPAY_REVERT_MESSAGE), {
+      name: "ContractFunctionExecutionError",
+      cause: inner,
+    });
+
+    const chain = serializeTxError(outer);
+    expect(chain.revertDataInMessage).toBe(`0xfafe7970${"00".repeat(64)}`);
+    expect(findRevertData(chain)).toBe(`0xfafe7970${"00".repeat(64)}`);
+  });
+
+  it("extracts the data before redaction destroys it", () => {
+    const err = new Error(MINIPAY_REVERT_MESSAGE);
+    const chain = serializeTxError(err);
+    // The message that gets displayed is redacted...
+    expect(chain.top.message).toContain("[redacted");
+    // ...but the data was captured off the raw string first.
+    expect(chain.revertDataInMessage).toMatch(/^0xfafe7970/);
+  });
+
+  it("returns null for a message with no embedded data field", () => {
+    const err = new Error("The contract function reverted: User rejected transaction");
+    expect(serializeTxError(err).revertDataInMessage).toBeNull();
   });
 });

--- a/apps/web/src/lib/debug/serialize-tx-error.ts
+++ b/apps/web/src/lib/debug/serialize-tx-error.ts
@@ -16,8 +16,16 @@
  *  field — which is the one thing this probe is here to read. */
 const LONG_HEX = /0x[0-9a-fA-F]{100,}/g;
 
+/** Keeps the first 4 bytes. On revert data that is the error selector — the
+ *  whole point of the probe, and it was being cut off at 3 bytes. On a
+ *  signature it is 4 bytes of a 65-byte blob, which reveals nothing. */
+const SELECTOR_CHARS = 10; // "0x" + 8 hex
+
 export function redactLongHex(text: string): string {
-  return text.replace(LONG_HEX, (hex) => `0x${hex.slice(2, 8)}…[redacted ${hex.length} chars]`);
+  return text.replace(
+    LONG_HEX,
+    (hex) => `${hex.slice(0, SELECTOR_CHARS)}…[redacted ${hex.length} chars]`,
+  );
 }
 
 export type SerializedTxError = {
@@ -40,7 +48,23 @@ export type SerializedTxErrorChain = {
   /** `cause` chain, outermost first. Depth-capped: a cycle must not hang the probe. */
   causes: SerializedTxError[];
   depth: number;
+  /** Revert data recovered from the RAW message before redaction.
+   *
+   *  Measured on device 2026-07-10: MiniPay does not hand viem structured
+   *  revert data. It surfaces the node's JSON-RPC error blob as the revert
+   *  *reason* string, so `error.data`, `.raw` and `.signature` are all null and
+   *  the only carrier is the text. */
+  revertDataInMessage: string | null;
 };
+
+/** `{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted","data":"0x..."}}`
+ *  embedded inside a viem error message. Not an API — a provider's stringified
+ *  error that happens to be parseable. Treated as evidence, not as a contract. */
+const DATA_IN_MESSAGE = /"data"\s*:\s*"(0x[0-9a-fA-F]{8,})"/;
+
+export function extractRevertDataFromMessage(message: string): string | null {
+  return message.match(DATA_IN_MESSAGE)?.[1] ?? null;
+}
 
 function pick(error: unknown): SerializedTxError {
   if (typeof error !== "object" || error === null) {
@@ -73,10 +97,21 @@ function pick(error: unknown): SerializedTxError {
 
 const MAX_DEPTH = 8;
 
+function rawMessageOf(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  const message = (value as { message?: unknown }).message;
+  return typeof message === "string" ? message : null;
+}
+
 export function serializeTxError(error: unknown): SerializedTxErrorChain {
   const top = pick(error);
   const causes: SerializedTxError[] = [];
   const seen = new Set<unknown>();
+
+  // Scanned on the RAW error, before `pick` redacts long hex out of the
+  // message. Redacting first would destroy the very thing we are hunting.
+  let revertDataInMessage: string | null =
+    extractRevertDataFromMessage(rawMessageOf(error) ?? "") ?? null;
 
   let current: unknown = error;
   seen.add(current);
@@ -89,14 +124,19 @@ export function serializeTxError(error: unknown): SerializedTxErrorChain {
     if (next === undefined || next === null || seen.has(next)) break;
     seen.add(next);
     causes.push(pick(next));
+    revertDataInMessage ??= extractRevertDataFromMessage(rawMessageOf(next) ?? "");
     current = next;
   }
 
-  return { top, causes, depth: causes.length };
+  return { top, causes, depth: causes.length, revertDataInMessage };
 }
 
 /** The one fact that decides go / no-go: did any layer carry revert data? */
 export function findRevertData(chain: SerializedTxErrorChain): string | null {
+  // Checked FIRST because it is where MiniPay actually puts it. The structured
+  // fields below stayed null on every device capture.
+  if (chain.revertDataInMessage) return chain.revertDataInMessage;
+
   for (const layer of [chain.top, ...chain.causes]) {
     if (typeof layer.data === "string" && layer.data.startsWith("0x") && layer.data.length >= 10) {
       return layer.data;

--- a/docs/testing/2026-07-10-minipay-raw-error-probe-results.md
+++ b/docs/testing/2026-07-10-minipay-raw-error-probe-results.md
@@ -1,0 +1,111 @@
+# Resultados — probe del raw de MiniPay
+
+**Fecha**: 2026-07-10 · **Ejecutado en device**
+**Dispositivo**: iPhone, iOS 18.7, WebKit 605.1.15 · `isMiniPay: true`
+**Entorno**: `learn-preview.chesscito.com` · Celo Mainnet (42220)
+**Wallet**: `0xCc4179…c2dD` · **Veredicto: GO, con una condición**
+
+---
+
+## Tabla comparativa
+
+| # | Escenario | `txHash` | `receipt.status` | Error top | `error.data` / `.raw` / `.signature` | Revert data |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Cancelación | `null` | — | `ContractFunctionExecutionError` | los tres `null` | ninguna |
+| 2 | Fallo pre-broadcast | `null` | — | `Error` (`Invalid player address`) | los tres `null` | ninguna |
+| 3 | **Revert** | **`null`** | — | `ContractFunctionExecutionError` | **los tres `null`** | **`0xfafe79…` en `message`** |
+| 4 | Éxito (control) | `0x5527eb32…5092` | `success` | — | — | — |
+
+---
+
+## Los tres hechos
+
+### 1. MiniPay rechaza en estimación. Nunca transmite una tx que revierte.
+
+En el escenario 3 la hoja de confirmación **no apareció**, no hubo hash y no se
+gastó gas. El mensaje lo dice literal:
+
+```
+Remote method 'eth_estimateGas' failed with an error:
+{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted","data":"0xfafe79…"}}
+```
+
+Esto es una **buena noticia** y responde una pregunta abierta desde
+`receipt-status-verification`: en MiniPay, un revert es interceptado antes de
+firmar. El chequeo de `receipt.status` que shipeamos en #199/#200 sigue siendo
+correcto (protege contra otras wallets y contra reverts que sí se minan), pero
+**no es el camino que MiniPay recorre**.
+
+### 2. La revert data existe, pero viem no la ve.
+
+`ContractFunctionRevertedError` trae las keys `data`, `raw` y `signature` —
+**las tres nulas**. viem interpretó el blob JSON-RPC completo como el *reason*
+textual del revert, no como revert data estructurada.
+
+El único portador es el string de `message`.
+
+Por eso `findRevertData()` devolvía `null` en la primera captura: buscaba en
+`error.data`. La corrección está en este mismo commit: se extrae del mensaje
+**antes** de redactar, con `extractRevertDataFromMessage()`.
+
+### 3. El selector es `0xfafe7970` = `BadgeAlreadyClaimed(address,uint256)`.
+
+La captura mostró `0xfafe79…[redacted 138 chars]` — mi propio redactor cortó el
+selector a 3 bytes de 4. Ya está arreglado (preserva 4 bytes).
+
+La identificación es concluyente aun con la captura truncada:
+
+- prefijo `0xfafe79` coincide con `0xfafe7970`, derivado de artifacts;
+- 138 chars = `0x` + 136 hex = **68 bytes** = 4 de selector + 2 args de 32 bytes,
+  exactamente la aridad de `BadgeAlreadyClaimed(address player, uint256 levelId)`;
+- la llamada fue `claimBadgeSigned` sobre un badge que la wallet ya posee.
+
+---
+
+## Conclusión
+
+**Sí existe revert data decodificable.** Llega íntegra al dapp, embebida como
+texto dentro de `message`, no en los campos estructurados de viem.
+
+## Recomendación: **GO**, con un cambio de diseño
+
+El plan original (una ABI generada + `decodeErrorResult` sobre `error.data`)
+**no habría funcionado**: `error.data` es `null`. El decoder necesita dos piezas:
+
+1. **Un extractor**: regex sobre la cadena de `message`, ya escrito y con tests
+   (`extractRevertDataFromMessage`). Devuelve `0xfafe7970…`.
+2. **Un decodificador**: `decodeErrorResult` contra la ABI de errores generada
+   desde artifacts. Esa parte del plan original sigue en pie.
+
+Costo estimado: se mantiene en 1-2h. El extractor ya existe.
+
+---
+
+## Riesgos e incertidumbres
+
+1. 🔴 **El formato del mensaje no es una API.** Es el error del provider,
+   stringificado. Una actualización de MiniPay puede cambiarlo y el extractor
+   deja de matchear **en silencio**. Mitigación: el fallback debe ser el
+   `revert` genérico actual, nunca una excepción; y el extractor necesita un
+   test con el fixture real (ya está).
+2. 🟠 **Un solo dispositivo, un solo OS.** iPhone / iOS 18.7. Android puede
+   serializar distinto. Sin evidencia.
+3. 🟠 **Una cancelación llega como `ContractFunctionRevertedError`** con
+   `reason: "User rejected transaction"`. Un decoder ingenuo que trate esa clase
+   como "revert on-chain" reportaría cancelaciones como fallos. Nuestro
+   clasificador está a salvo porque `isUserCancellation` corre sobre el mensaje y
+   nuestro tipo `TransactionRevertedError` es propio, no el de viem. **No perder
+   esa distinción al agregar el decoder.**
+4. 🟡 Solo se observó `BadgeAlreadyClaimed`. `CooldownActive` y
+   `DailyLimitReached` se asumen iguales por venir del mismo camino de
+   estimación, pero no se midieron.
+
+---
+
+## Diferidos (no bloquean, registrados)
+
+- `Invalid player address` (escenario 2) clasifica hoy como `unknown` →
+  *"Something went wrong"*. Es un fallo del endpoint de firma y debería ser
+  `signingUnavailable`. `classifyTxErrorKind` no lo matchea.
+- El probe (`app/dev/tx-error-probe/`, `lib/debug/`) queda en el repo hasta que
+  el decoder esté shipeado; sirve para validar el extractor contra otro device.


### PR DESCRIPTION
Cierra el bloque del probe. Ejecutado en device: **iPhone / iOS 18.7, MiniPay,
Celo mainnet, `learn-preview.chesscito.com`**.

Informe completo: `docs/testing/2026-07-10-minipay-raw-error-probe-results.md`

## Tabla

| # | Escenario | `txHash` | `receipt.status` | `error.data`/`.raw`/`.signature` | Revert data |
| --- | --- | --- | --- | --- | --- |
| 1 | Cancelación | `null` | — | los tres `null` | ninguna |
| 2 | Fallo pre-broadcast | `null` | — | los tres `null` | ninguna |
| 3 | **Revert** | **`null`** | — | **los tres `null`** | **en `message`** |
| 4 | Éxito (control) | `0x5527eb32…` | `success` | — | — |

## Los tres hechos

**MiniPay rechaza en estimación.** La hoja de confirmación nunca se abrió, no
hubo hash, no se gastó gas. Responde una pregunta que quedó abierta en
`receipt-status-verification`: en MiniPay un revert se intercepta antes de firmar.

**La revert data sobrevive, pero no donde el plan asumía.** El
`ContractFunctionRevertedError` de viem trae `data`, `raw` y `signature`
**los tres null**: leyó el blob JSON-RPC del nodo como el *reason* textual. El
único portador es el `message`:

```
Remote method 'eth_estimateGas' failed with an error:
{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted","data":"0xfafe7970..."}}
```

**El selector es `0xfafe7970` = `BadgeAlreadyClaimed(address,uint256)`.** El
prefijo coincide con el derivado de artifacts, y 138 chars = 4 bytes de selector
+ dos args de 32 bytes, que es su aridad exacta.

## Dos defectos del probe, ambos tapaban la respuesta

- `findRevertData` buscaba en `error.data`. Devolvía `null` sobre una captura que
  **visiblemente contenía la data**. Ahora escanea la cadena de `message` cruda,
  primero.
- `redactLongHex` cortaba el selector a 3 bytes (`0xfafe79`), dejando el error
  ambiguo. Ahora preserva 4. Sobre una firma, 4 bytes no revelan nada.

La extracción corre **antes** de la redacción. Al revés, el redactor destruye
justo lo que el probe existe para encontrar.

## Veredicto: GO, con un cambio de diseño

El plan original — ABI generada + `decodeErrorResult(error.data)` — **no habría
decodificado nada**, porque `error.data` es `null`. Hace falta un extractor
delante. Ya está escrito, con el mensaje real del device como fixture.

Costo: se mantiene en 1-2h. El generador de ABIs sigue en pie.

## Riesgos

1. 🔴 **El formato del mensaje no es una API.** Una actualización de MiniPay lo
   cambia y el extractor deja de matchear **en silencio**. El fallback debe ser
   el `revert` genérico, nunca una excepción.
2. 🟠 Un solo dispositivo, un solo OS. Android puede serializar distinto.
3. 🟠 Una **cancelación** llega como `ContractFunctionRevertedError` con
   `reason: "User rejected transaction"`. Un decoder ingenuo que trate esa clase
   como revert on-chain reportaría cancelaciones como fallos. Nuestro
   clasificador está a salvo — `isUserCancellation` corre sobre el mensaje y
   nuestro `TransactionRevertedError` es propio, no el de viem. No perder esa
   distinción.
4. 🟡 Solo se midió `BadgeAlreadyClaimed`. `CooldownActive` y `DailyLimitReached`
   se asumen iguales, sin evidencia.

## Diferido

`Invalid player address` (escenario 2) clasifica como `unknown` → *"Something
went wrong"*. Es un fallo del endpoint de firma; debería ser `signingUnavailable`.

## Verificación

- Unit: **4838 passed, 0 failed** en **400 test files** (antes 4834)
- `tsc --noEmit`: limpio

Wolfcito 🐾 @akawolfcito
