### PR TITLE
docs: register the custom-errors decoder, open the MiniPay smoke block

### DIFF
--- a/docs/backlog/2026-07-10-custom-errors-decoder.md
+++ b/docs/backlog/2026-07-10-custom-errors-decoder.md
@@ -1,0 +1,42 @@
+# Siguiente mejora priorizada — decoder de custom errors
+
+**Fecha**: 2026-07-10 · **Estado**: GO aceptado, **no implementar todavía**
+**Evidencia**: `docs/testing/2026-07-10-minipay-raw-error-probe-results.md`
+
+## Por qué no bloquea estabilidad
+
+Los reverts ya se interceptan (MiniPay rechaza en `eth_estimateGas`), no producen
+éxito falso (#199 / #200), y existe fallback genérico (`error.revert`). El
+decoder mejora la **copy**, no la corrección.
+
+## Qué hay que construir
+
+1. ✅ **Extractor** — `extractRevertDataFromMessage()`, ya escrito y con el
+   mensaje real del device como fixture (`lib/debug/serialize-tx-error.ts`).
+2. ⬜ **Generador de error-ABIs** desde `apps/contracts/artifacts/**`, hermano de
+   `generate-event-abis.mjs`. Nunca a mano ([[feedback_verifier_abi_lesson]]).
+3. ⬜ **Mapa** selector/nombre → `TxErrorKind` → copy, con claves nuevas en
+   `editorial.ts` + `messages/es.ts` (`en.ts` es derivado).
+
+## Riesgos, todos registrados
+
+1. 🔴 **La extracción desde `message` no es contractual.** Es el error del
+   provider, stringificado. Una actualización de MiniPay cambia el formato y el
+   extractor deja de matchear **en silencio**.
+   → El fallback debe ser el `revert` genérico actual. **Nunca una excepción.**
+2. 🟠 **Diferencias entre dispositivos y providers.** La única captura es
+   iPhone / iOS 18.7 / MiniPay. Android, y cualquier wallet web, pueden
+   serializar distinto — o entregar `error.data` estructurado, que el decoder
+   también debe aceptar.
+3. 🟠 **Una cancelación llega como `ContractFunctionRevertedError`** de viem, con
+   `reason: "User rejected transaction"`. Un decoder que trate esa clase como
+   revert on-chain convertiría cancelaciones en fallos.
+   → `isUserCancellation` debe seguir corriendo antes. Nuestro
+   `TransactionRevertedError` es propio, no el de viem: no confundirlos.
+4. 🟡 **Solo hay evidencia real de `BadgeAlreadyClaimed`** (`0xfafe7970`).
+   `CooldownActive` (`0xc1ab61a1`) y `DailyLimitReached` (`0xeba8fe8a`) se
+   asumen iguales por venir del mismo camino de estimación. Sin medir.
+
+## Costo
+
+1-2h. El extractor ya está hecho.

--- a/docs/handoffs/_next-session-prompt.md
+++ b/docs/handoffs/_next-session-prompt.md
@@ -26,12 +26,18 @@ paso: el síntoma que los motivaba era una misclasificación (#197), y debajo
 apareció algo peor — badge y score declaran éxito sobre el hash, no sobre el
 receipt (#199 cerró el helper; falta el lado del jugador).
 
-1. **`docs/specs/receipt-status-learn-handlers.md`** — bloque activo. Seam
-   testable + handlers de LEARN + estado `confirming`.
-2. **Probe en device del `raw` de MiniPay** — sin esto, decodificar custom errors
-   es una apuesta (`docs/reviews/2026-07-09-custom-errors-plan-redteam.md`).
-3. **Smoke test del flujo crítico** en mainnet.
+1. ~~`receipt-status-learn-handlers`~~ — **CERRADO** (#200).
+2. ~~Probe del `raw` de MiniPay~~ — **CERRADO** (#201, #202). Veredicto **GO**
+   para el decoder: la revert data llega, pero dentro de `message`, no en
+   `error.data`. Ver `docs/testing/2026-07-10-minipay-raw-error-probe-results.md`.
+3. **▶️ Smoke del flujo crítico en MiniPay** — bloque activo. Matriz lista en
+   `docs/testing/2026-07-10-minipay-critical-flow-smoke.md`. **Requiere device.**
 4. **Checkpoint de estabilidad.**
+
+Después del checkpoint, la siguiente mejora priorizada es el **decoder de custom
+errors** (`docs/backlog/2026-07-10-custom-errors-decoder.md`). **No bloquea
+estabilidad**: los reverts ya se interceptan, no producen éxito falso, y hay
+fallback genérico. Mejora la copy, no la corrección.
 
 Regla activa: si un hallazgo no bloquea el bloque, se **difiere**, no se abre.
 

--- a/docs/testing/2026-07-10-minipay-critical-flow-smoke.md
+++ b/docs/testing/2026-07-10-minipay-critical-flow-smoke.md
@@ -1,0 +1,78 @@
+# Smoke — flujo crítico en MiniPay
+
+**Fecha**: 2026-07-10 · **Estado**: matriz lista, **pendiente de ejecución en device**
+**Build bajo prueba**: `main` ≥ `#202` · `learn-preview.chesscito.com` · Celo Mainnet
+
+Lo que cambió desde el último smoke: **badge y score ya no celebran sobre el hash**,
+sino sobre un receipt verificado (#199, #200). Eso agrega un estado `confirming`
+de unos segundos que antes no existía. Este smoke busca regresiones ahí.
+
+---
+
+## Antes de empezar
+
+- Wallet con saldo chico de un stable. Sin CELO no hay gas (`feeCurrency`).
+- Anotá modelo, versión de MiniPay, y el commit del deploy.
+- El badge de la **torre ya está minteado** en la wallet de prueba. Para probar el
+  claim hace falta una pieza sin badge, o una wallet limpia.
+
+---
+
+## Matriz
+
+| # | Criterio | Paso | Esperado | Resultado | Notas |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Entrada y navegación | Abrir la app en MiniPay | Splash resuelve, HUB carga, dock responde | ⬜ | |
+| 1 | Navegación | Tocar cada slot del dock | Cada superficie abre y cierra | ⬜ | |
+| 2 | Ejercicio | Completar un ejercicio con ≥1 estrella | Estrellas y progreso se registran | ⬜ | |
+| 2 | Ejercicio | Completar el siguiente | El drawer avanza, no se traba | ⬜ | |
+| 3 | **Score / confirming** | Tocar "Save proof" on-chain | CTA se deshabilita, aparece estado de confirmación (~5s) | ⬜ | **nuevo** |
+| 3 | **Score / éxito** | Esperar el receipt | Recién ahí: overlay de éxito, done-hold, y el score aparece en leaderboard | ⬜ | |
+| 3 | **Score / persistencia** | Cerrar y reabrir | El score guardado sigue ahí | ⬜ | |
+| 4 | **Badge / confirming** | Reclamar un badge ganado | Sin celebración hasta el receipt | ⬜ | **nuevo** |
+| 4 | **Badge / éxito** | Esperar el receipt | Háptica, celebración, modal `piece-unlocked`, badge en Owned | ⬜ | |
+| 5 | **Cancelación** | Tocar Save, **rechazar** en la wallet | Toast de cancelado. **Sin** overlay de éxito, **sin** overlay de error, score NO persistido | ⬜ | |
+| 5 | **Cancelación (badge)** | Tocar Claim, **rechazar** | Vuelve a idle. Sin celebración, `justClaimed` sin setear | ⬜ | |
+| 5 | **Error / revert** | Reclamar un badge que la wallet YA tiene (si el CTA lo permite) | Overlay de error con retry. **Nunca** éxito | ⬜ | ver nota |
+| 6 | Refresh | Recargar durante `confirming` | Estado coherente al volver: badge se auto-cura leyendo la cadena | ⬜ | |
+| 6 | Cierre / reapertura | Cerrar MiniPay durante `confirming`, reabrir | Sin celebración fantasma, sin score falso | ⬜ | ver riesgo |
+| 7 | Shop | Abrir Shop desde el dock | Tiles cargan con precio (`$1.99` en PRO), no "Coming soon" | ⬜ | |
+| 7 | Shop | Cerrar Shop | Vuelve al HUB, dock intacto | ⬜ | |
+| 7 | Navegación | Arena → Coach → HUB | Sin pantallas muertas ni loading infinito | ⬜ | |
+
+**Nota sobre el revert (fila 5c):** la UI esconde el CTA de Claim si el badge ya
+está poseído. Si no se puede disparar desde la pantalla normal, usar
+`/dev/tx-error-probe` botón 3, que ya demostró el camino: MiniPay rechaza en
+estimación y el error nunca pasa por éxito.
+
+---
+
+## Riesgos conocidos, a observar (no son bloqueantes por defecto)
+
+1. **Espera de `confirming`.** Antes 0s, ahora hasta 120s en el peor caso. Si el
+   WebView pausa timers al ir a background, la percepción puede ser peor. Si se
+   observa un spinner colgado > 30s, **anotarlo**: hay un umbral de UI diferido
+   en `receipt-status-learn-handlers.md`.
+2. **Divergencia asimétrica al cerrar en `confirming`.** El badge se auto-cura
+   (se lee de la cadena al montar). El score **no**: `recordSaveFor` escribe
+   localStorage y nadie reconcilia. Si la tx confirma con la app cerrada, el
+   score existe on-chain y no en local.
+3. **`/api/cache-score` es fire-and-forget** con `.catch(() => {})`. Si falla tras
+   un receipt exitoso, el leaderboard no ve el score y no hay señal.
+4. **Telemetría**: `stage: "success"` ahora significa "minada", no "broadcast".
+   Las tasas van a caer. No es regresión.
+
+---
+
+## Qué se corrige dentro del bloque
+
+Solo lo que **impida completar los flujos** o **corrompa progreso, pagos o estado**.
+Copy, decoder, refactors y mejoras no bloqueantes se difieren.
+
+---
+
+## Resultado
+
+- Bloqueantes encontrados: _(pendiente)_
+- Bloqueantes corregidos: _(pendiente)_
+- Recomendación de checkpoint: _(pendiente)_


### PR DESCRIPTION
Solo docs. Cierra el registro del decoder y abre el bloque del smoke.

## Decoder de custom errors — registrado, no implementado

El probe devolvió **GO**, pero **no bloquea estabilidad**: los reverts ya se
interceptan en `eth_estimateGas`, no pueden producir éxito falso (#199 / #200), y
existe fallback genérico (`error.revert`). Mejora la copy, no la corrección.

`docs/backlog/2026-07-10-custom-errors-decoder.md`, con sus cuatro riesgos:

1. 🔴 la extracción desde `message` **no es contractual** — una actualización de
   MiniPay la rompe **en silencio**; el fallback debe ser `revert`, nunca una
   excepción;
2. 🟠 diferencias entre dispositivos y providers (una sola captura: iOS 18.7);
3. 🟠 una **cancelación** llega como `ContractFunctionRevertedError` de viem — no
   confundirla con un revert on-chain;
4. 🟡 solo hay evidencia real de `BadgeAlreadyClaimed`.

## Smoke del flujo crítico — matriz lista, requiere device

`docs/testing/2026-07-10-minipay-critical-flow-smoke.md`, con los 7 criterios y
foco en lo que cambió: badge y score ahora liquidan sobre un receipt verificado,
lo que introduce un estado `confirming` que antes no existía.

## Verificación local del mismo build

| Check | Resultado |
| --- | --- |
| Unit | **4838 passed, 0 failed** · 400 test files |
| `tsc --noEmit` | limpio |
| `lint` | limpio (2 warnings preexistentes, otros archivos) |
| E2E `--project=minipay` | **130 passed, 0 failed**, 14 skipped |
| VR | 52 passed |

El E2E es idéntico al baseline en `97fb522d` — el commit **anterior** al merge de
#200. Sin regresiones automatizables.

### Una falsa alarma que vale registrar

Un run anterior reportó **45 fallidos**. Eran un dev server que quedó vivo en el
puerto 3000 del run de VR inmediatamente anterior, sirviendo un build viejo.

Mismo patrón que el baseline VR de la tienda esta mañana: **el entorno mintió
antes que el código**. Con `lsof -ti:3000` vacío, 0 fallidos.

Wolfcito 🐾 @akawolfcito
