### PR TITLE
fix(exercises): stop reading a stale tx hash as a pending receipt

### DIFF
--- a/apps/web/src/lib/exercises/__tests__/tx-toast-lifecycle.test.tsx
+++ b/apps/web/src/lib/exercises/__tests__/tx-toast-lifecycle.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Composition test for the SAVE toast lifecycle.
+ *
+ * `tx-toast-state.test.ts` proves the derivation in isolation and
+ * `use-onchain-write.test.tsx` proves the phase machine in isolation. Both were
+ * green while the device showed "STEP 2 of 2 — Confirming…" pinned above the
+ * dock forever: nothing tested the two together.
+ *
+ * This drives the real hook and feeds its real outputs into the real
+ * derivation, exactly as `<ExercisesScreen>` wires them.
+ */
+import { describe, expect, it } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Hash, TransactionReceipt } from "viem";
+
+import { TransactionRevertedError } from "@/lib/contracts/transaction-helpers";
+import { useDoneHold } from "../use-done-hold";
+import { useOnChainWrite } from "../use-onchain-write";
+import { deriveTxToastState, type TxToastState } from "../tx-toast-state";
+
+const HASH = "0xfeed" as Hash;
+const SUCCESS = { transactionHash: HASH, status: "success" } as unknown as TransactionReceipt;
+const REVERTED = { transactionHash: HASH, status: "reverted" } as unknown as TransactionReceipt;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Mirrors the wiring in `exercises-screen.tsx`. */
+function useSaveToast() {
+  const saveWrite = useOnChainWrite();
+  const doneHold = useDoneHold();
+  const toast: TxToastState = deriveTxToastState({
+    isWriting: saveWrite.phase === "signing",
+    isConfirming: saveWrite.phase === "confirming",
+    hasFailed: saveWrite.outcome?.status === "failed",
+    txHash: saveWrite.txHash,
+    doneAt: doneHold.doneAt,
+  });
+  return { saveWrite, doneHold, toast };
+}
+
+const current = (toast: TxToastState) => (toast.show ? toast.current : null);
+
+describe("SAVE toast lifecycle — success", () => {
+  it("signing → confirming → success → the indicator stops rendering", async () => {
+    const broadcast = deferred<Hash>();
+    const confirm = deferred<TransactionReceipt>();
+    const { result } = renderHook(() => useSaveToast());
+
+    expect(current(result.current.toast)).toBeNull();
+
+    act(() => {
+      void result.current.saveWrite.run({
+        broadcast: () => broadcast.promise,
+        confirm: () => confirm.promise,
+      });
+    });
+
+    // 1. signing
+    await waitFor(() => expect(result.current.saveWrite.phase).toBe("signing"));
+    expect(current(result.current.toast)).toBe("sign");
+
+    // 2. confirming
+    await act(async () => {
+      broadcast.resolve(HASH);
+    });
+    await waitFor(() => expect(result.current.saveWrite.phase).toBe("confirming"));
+    expect(current(result.current.toast)).toBe("wait");
+
+    // 3. success — the screen opens the done-hold from the success sequencer
+    await act(async () => {
+      confirm.resolve(SUCCESS);
+    });
+    await waitFor(() => expect(result.current.saveWrite.phase).toBe("settled"));
+    act(() => result.current.doneHold.start(HASH));
+    expect(current(result.current.toast)).toBe("done");
+
+    // 4. the done-hold expires. The hash is still set — it must not read as a
+    //    receipt in flight.
+    act(() => result.current.doneHold.reset());
+    expect(result.current.saveWrite.txHash).toBe(HASH);
+    expect(result.current.toast.show).toBe(false);
+  });
+});
+
+describe("SAVE toast lifecycle — the label never sticks", () => {
+  it("clears on a cancellation that already broadcast", async () => {
+    const { result } = renderHook(() => useSaveToast());
+
+    await act(async () => {
+      await result.current.saveWrite.run({
+        broadcast: async () => HASH,
+        confirm: async () => {
+          throw new Error("User rejected the request");
+        },
+      });
+    });
+
+    expect(result.current.saveWrite.outcome).toMatchObject({ status: "cancelled" });
+    expect(result.current.toast.show).toBe(false);
+  });
+
+  it("clears on a cancellation before the broadcast", async () => {
+    const { result } = renderHook(() => useSaveToast());
+
+    await act(async () => {
+      await result.current.saveWrite.run({
+        broadcast: async () => {
+          throw new Error("User rejected the request");
+        },
+        confirm: async () => SUCCESS,
+      });
+    });
+
+    expect(result.current.toast.show).toBe(false);
+  });
+
+  it("shows `failed`, not `wait`, on a reverted receipt", async () => {
+    const { result } = renderHook(() => useSaveToast());
+
+    await act(async () => {
+      await result.current.saveWrite.run({
+        broadcast: async () => HASH,
+        confirm: async () => {
+          throw new TransactionRevertedError(HASH, REVERTED);
+        },
+      });
+    });
+
+    // The failed toast is sticky by design (Cluster C SAVE residue defer #1):
+    // a terminal chain verdict stays on screen. What must never happen is it
+    // degrading back into "Confirming…".
+    expect(current(result.current.toast)).toBe("failed");
+  });
+
+  it("reset() clears phase, outcome and txHash, and the toast with them", async () => {
+    const { result } = renderHook(() => useSaveToast());
+
+    await act(async () => {
+      await result.current.saveWrite.run({
+        broadcast: async () => HASH,
+        confirm: async () => {
+          throw new TransactionRevertedError(HASH, REVERTED);
+        },
+      });
+    });
+    expect(current(result.current.toast)).toBe("failed");
+
+    act(() => {
+      result.current.saveWrite.reset();
+      result.current.doneHold.reset();
+    });
+
+    expect(result.current.saveWrite.phase).toBe("idle");
+    expect(result.current.saveWrite.outcome).toBeNull();
+    expect(result.current.saveWrite.txHash).toBeNull();
+    expect(result.current.toast.show).toBe(false);
+  });
+});

--- a/apps/web/src/lib/exercises/__tests__/tx-toast-state.test.ts
+++ b/apps/web/src/lib/exercises/__tests__/tx-toast-state.test.ts
@@ -66,6 +66,40 @@ describe("deriveTxToastState — wait phase", () => {
   });
 });
 
+// Device smoke, 2026-07-10: "STEP 2 of 2 — Confirming…" stayed pinned above
+// the dock forever after a successful save. `saveWrite.txHash` is never cleared
+// on `settled`, and the derivation read a bare `hasTxHash` as "receipt in
+// flight". Once the 1500ms done-hold expired, it fell straight back into `wait`.
+describe("deriveTxToastState — settled: a stale hash is not a pending receipt", () => {
+  const settledWithHash = { ...base, txHash: "0xabc" };
+
+  it("hides the toast after a successful save once the done-hold expires", () => {
+    expect(deriveTxToastState(settledWithHash)).toEqual({ show: false });
+  });
+
+  it("hides the toast after a cancellation that had already broadcast", () => {
+    expect(deriveTxToastState({ ...settledWithHash, doneAt: null })).toEqual({
+      show: false,
+    });
+  });
+
+  it("hides the toast after a cancellation before broadcast", () => {
+    expect(deriveTxToastState({ ...base, txHash: null })).toEqual({ show: false });
+  });
+
+  it("never renders `wait` without an in-flight confirmation", () => {
+    const state = deriveTxToastState(settledWithHash);
+    expect(state.show === true && state.current === "wait").toBe(false);
+  });
+
+  it("still renders `wait` while the receipt is genuinely pending", () => {
+    expect(deriveTxToastState({ ...settledWithHash, isConfirming: true })).toEqual({
+      show: true,
+      current: "wait",
+    });
+  });
+});
+
 describe("deriveTxToastState — done phase", () => {
   it("shows current='done' during the done-hold window (doneAt set)", () => {
     expect(

--- a/apps/web/src/lib/exercises/tx-toast-state.ts
+++ b/apps/web/src/lib/exercises/tx-toast-state.ts
@@ -46,10 +46,16 @@ export function deriveTxToastState(inputs: TxToastInputs): TxToastState {
     return { show: true, current: "done" };
   }
 
-  if (hasTxHash) {
-    // Receipt is in flight — render the wait phase regardless of whether
-    // wagmi has flipped `isConfirming` true yet (there's a one-render gap
-    // between writeContract resolving and the receipt watcher mounting).
+  // `wait` means a receipt is genuinely in flight, so it reads the phase — not
+  // the mere presence of a hash.
+  //
+  // This branch used to be `if (hasTxHash)`, tolerating a one-render gap
+  // between `writeContract` resolving and wagmi's receipt watcher mounting.
+  // That watcher is gone: `useOnChainWrite` flips to `confirming` in the same
+  // tick it publishes the hash, so the tolerance bought nothing — and the hash
+  // outlives `settled`, which pinned "Confirming…" above the dock forever once
+  // the done-hold expired (device smoke, 2026-07-10).
+  if (inputs.isConfirming) {
     return { show: true, current: "wait" };
   }
 


### PR DESCRIPTION
Único bloqueante del smoke en device. Corrección acotada al ciclo de vida del
indicador. **No toca persistencia, receipts, cache-score, badges ni otros flujos.**

## La señal que lo mantenía vivo

No era `isBusy`, ni `phase`, ni `outcome`, ni el done-hold.

Era **`txHash` sin resetear, leído por la derivación en `tx-toast-state`**:

```ts
if (hasTxHash) {
  return { show: true, current: "wait" };   // ← "Confirming…"
}
```

`saveWrite.txHash` sobrevive a `settled`. Cuando el done-hold de 1500 ms expira,
la derivación cae en esa rama y concluye que hay un receipt en vuelo. Para
siempre.

La máquina de fases estaba **correcta**. Nadie la estaba leyendo.

## Por qué existía esa rama

Toleraba un hueco de un render entre `writeContract` resolviendo y el watcher de
receipt de wagmi montándose. **Ese watcher ya no existe** (#200):
`useOnChainWrite` cambia a `confirming` en el mismo tick en que publica el hash.
La tolerancia no compraba nada y costaba un label pegado.

`wait` ahora lee `isConfirming`.

## Los tests aislados estaban verdes

`tx-toast-state.test.ts` probaba la derivación sola. `use-onchain-write.test.tsx`
probaba la máquina sola. **Ninguno las manejaba juntas**, que es exactamente donde
vivía el bug.

`tx-toast-lifecycle.test.tsx` compone el hook real con la derivación real, tal
como lo cablea `<ExercisesScreen>`, y recorre:

- `signing` → `confirming` → `success` → **el indicador deja de renderizarse**;
- cancelación **antes** del broadcast → oculto;
- cancelación **después** del broadcast (hash presente) → oculto;
- receipt revertido → `failed`, **nunca** `wait`;
- `reset()` → `phase: idle`, `outcome: null`, `txHash: null`, toast oculto.

`failed` sigue siendo sticky por diseño (Cluster C SAVE residue defer #1): un
veredicto terminal de la cadena se queda en pantalla. Lo que no puede hacer es
degradarse de vuelta a "Confirming…", y eso ahora está afirmado.

## Criterios de cierre

| # | Criterio | Estado |
| --- | --- | --- |
| 1 | Aparece al entrar en `confirming` | ✅ |
| 2 | Desaparece en `settled`: success / cancelled / failed | ✅ (failed muestra `failed`, no `wait`) |
| 3 | No depende solo del done-hold | ✅ lee `isConfirming` |
| 4 | `reset()` limpia phase, outcome, txHash y lo derivado | ✅ afirmado |
| 5 | Test signing → confirming → success → oculto | ✅ |
| 6 | Cobertura de cancelación y fallo | ✅ |
| 7 | Sin tocar otros flujos | ✅ un solo `if` |

## Verificación

- Unit: **4848 passed, 0 failed** · 401 test files (antes 4838 / 400)
- `tsc --noEmit`: limpio
- `lint`: limpio (2 warnings preexistentes, otros archivos)
- VR: **52 passed** (env limpio, puerto 3000 libre)

Wolfcito 🐾 @akawolfcito
