### PR TITLE
feat(play-hub): give Coach the framed training badge

### DIFF
--- a/apps/web/src/components/hub/play-hub-scaffold.tsx
+++ b/apps/web/src/components/hub/play-hub-scaffold.tsx
@@ -196,7 +196,7 @@ export function PlayHubScaffold({
         <div className="play-hub-tools-grid" aria-label={tPlay("actionsAriaLabel")}>
           <PlayTacticsTile className="" />
           <HubActionTile
-            iconSrc="/art/redesign/icons/coach.png"
+            iconSrc="/art/new-icons-chesscito/training.png"
             label={tPlay("coachLabel")}
             ariaLabel={tHud("coachAriaLabel")}
             onClick={onCoachTap}


### PR DESCRIPTION
## What

The CHESS TOOLS grid on the play hub put a bare purple whistle next to Tactics' framed red/gold badge. The whistle was the only tile in cool tones and the only one without a frame — that's the "disconnected" feel from the backlog (PLAY #7).

`play-hub-scaffold.tsx:199` now points at `/art/new-icons-chesscito/training.png`. `HubActionTile` derives the avif/webp sources from the png path, and all three formats already ship.

## Verified, not assumed

The triage called this "a path swap". It nearly wasn't: `HubActionTile` renders a `.reward-tile` and clamps the icon to 38×42, and `training.png` carries its own baked frame — a plausible frame-inside-frame.

So I rendered it at 390px instead of guessing. The tile is a flat yellow plate, the badge sits on it cleanly, and the wolf is legible at the clamp. `PlayTacticsTile` already proves the pattern: it feeds the framed `ejercicio-diario-chess.png` through the same component.

Result: Tactics and Coach now read as one family.

## What I did not do

Shop keeps its unframed stall. No framed shop asset exists under `new-icons-chesscito/`, and minting one is an art request, not a code change. Two of three tiles coherent beats a purple outlier.

## Gap worth filing

The play hub has **no visual-regression coverage** — no VR test visits it, so no baseline guards this surface. That's why an icon could drift here unnoticed.

## Testing

`hub` + `tactics` suites: 181 passing. `tsc` and `lint` clean. No other consumer of `redesign/icons/coach.png` remains in `src` or `e2e`.

Wolfcito 🐾 @akawolfcito
