### PR TITLE
docs(handoff): close the 2026-07-10 victory-cancel cluster

### DIFF
--- a/docs/backlog/2026-07-08-lote2-smoke-findings-learn-play-backlog.md
+++ b/docs/backlog/2026-07-08-lote2-smoke-findings-learn-play-backlog.md
@@ -1,5 +1,10 @@
 # Lote 2 — smoke manual + backlog LEARN/PLAY (2026-07-08)
 
+> ⚠️ **PARCIALMENTE SUPERADO.** Índice vigente:
+> `docs/backlog/2026-07-10-backlog-index.md`. Ya cerrados y descritos abajo como
+> abiertos: el **CTA dorado "Save proof"** (#183), **LEARN #4 Post-Focus Free
+> Practice** (#191) y **PLAY #7 Coach HUB icon** (#207). No trabajarlos.
+
 > Lote 2 se mantiene CERRADO. Nada de esto se implementa ahora. Solo
 > confirmación/documentación + backlog priorizable. Item 3 vive en
 > `docs/backlog/2026-07-08-tactical-day-gift-proof-of-consistency-lote-2.5.md`.

--- a/docs/backlog/2026-07-10-backlog-index.md
+++ b/docs/backlog/2026-07-10-backlog-index.md
@@ -1,0 +1,127 @@
+# Índice de backlog — 2026-07-10
+
+> Auditado **contra el código**, no contra las listas. Reemplaza al triage del 2026-07-09.
+> Antes de trabajar un item, verificá que siga vivo: dos entradas ya estaban muertas la
+> última vez que alguien miró.
+
+**Estado:** `main` = `827e7cfe` · 4853 passing / 401 files · smoke de MiniPay cerrado en device.
+
+---
+
+## 0. Cerrado desde el triage anterior — no reabrir
+
+| Item | Cerrado en | Evidencia |
+| --- | --- | --- |
+| CTA dorado "Save proof" inalcanzable | #183 | `exercises-screen.tsx:1072` usa `deriveCanSaveOnChain()` |
+| LEARN #4 Post-Focus Free Practice | #191 | `exercise-drawer.tsx:120` `isExerciseReplayable()` |
+| Baseline VR `hub-shop-sheet-open` rojo | `28b2f75` | eran dos fallos: SKUs retirados + env contaminado |
+| PLAY #7 Coach HUB icon | **#207** | `play-hub-scaffold.tsx` → `new-icons-chesscito/training.png` |
+| Dead-end de cancelación en victory | **#206** | cancelar vuelve a `VictoryCelebration` + toast |
+
+`docs/backlog/2026-07-08-lote2-smoke-findings-learn-play-backlog.md` todavía describe los dos
+primeros como abiertos. Es deriva de documentación.
+
+---
+
+## 1. Investigación primero, no código
+
+**"Claim 3 Shields"** (LEARN #1) — el **único** pendiente con comportamiento inexplicado.
+¿Pertenece al Welcome Pack, al Season Pass o al rescue gift? ¿Duplica los 3 shields de
+onboarding? ¿Por qué al tocarlo lanza el 21-Day Mind Challenge? **No cambiar lógica hasta
+entenderlo.** Puede esconder un bug.
+
+---
+
+## 2. Barato (1–3 h), sobre superficie existente
+
+- **Decoder de custom errors** — `docs/backlog/2026-07-10-custom-errors-decoder.md`. GO con
+  evidencia, **no bloquea estabilidad**: los reverts ya se interceptan, no producen éxito
+  falso, y hay fallback genérico. Hoy `BadgeAlreadyClaimed`, `CooldownActive` y
+  `DailyLimitReached` salen los tres como "Try again". El extractor está escrito; falta el
+  generador de error-ABIs desde `artifacts/` y el mapa nombre → copy.
+- **PLAY #8 — quitar la confirmación redundante de LUZ.** Tocar Coach Review lanza análisis
+  directo; LUZ conserva personalidad en loading y resultado. Borra una pantalla.
+- **Cobertura VR del play hub** (nuevo, 2026-07-10). Ningún test visual visita esa superficie.
+
+---
+
+## 3. Medio (medio día), necesitan ojo de diseño (GOAL → Sally → mock → código)
+
+- **PLAY #9 Coach Analysis Loading Overlay** + **PLAY #10 Save Match Success Celebration** —
+  ambos son "cerrar el loop emocional después de una acción". Agrupables.
+- **LEARN #2 Post-Claim Gift Overlay** — mismo patrón: mostrar QUÉ ganó y para qué sirve.
+- **Modal `Piece Unlocked` fuera del vocabulario visual** —
+  `docs/backlog/2026-07-09-piece-unlocked-modal-visual-vocabulary.md`.
+- **PLAY #11 Dock de 4 slots** — simetría/espaciado tras ocultar Leaderboard. No es swap de
+  asset. Ojo en device + baseline VR.
+- **LEARN #5 Shop Active State** — con Season Pass activo el Shop solo muestra un modal. Hay
+  una pregunta de producto adentro: ¿merece slot en el dock?
+- **PLAY #6 Coach Review Flow** — sin PRO, el diario no debe quedar enterrado. Valor mínimo
+  visible para free.
+- **Icono de Shop sin marco** (nuevo). Tactics y Coach son badges enmarcados; Shop no. No
+  existe asset enmarcado de shop → **pedido de arte**, no cambio de código.
+
+---
+
+## 4. Deuda con consecuencias — decidir, no postergar
+
+- ⚠️ **`/api/sign-badge` firma cualquier `levelId` 1..10000 sin verificar estrellas**
+  (`route.ts:23`). El gate de 10★ es **client-only**. El contrato bloquea reclamar *dos veces*,
+  no reclamar *sin merecerlo*. Cierra con server-verified progress.
+- **Server-verified progress** — el único anti-cheat real. Requerido antes de que haya dinero
+  colgando de un score. **Feature, no un `if`.**
+  Diseño ya decidido: un umbral proporcional evaluado en vivo **des-califica retroactivamente**
+  a medida que crece el pool. Usar un bit monótono `qualified(player, piece)` escrito al cruzar
+  por primera vez; `sign-badge` lee el bit, no el catálogo vivo. Guardar el mapa disperso
+  `exerciseId → stars`, nunca un `totalStars`.
+- **`timeout` ofrece *Try Again*** aunque la tx ya se firmó y transmitió
+  (`WaitForTransactionReceiptTimeoutError`). Reintentar sobre un mint que quizá aterrizó
+  necesita evidencia. **Medir antes de tocar.**
+
+---
+
+## 5. Diferidos de `project_receipt_status_verification`
+
+- Fallo silencioso de `/api/cache-score` (`.catch(() => {})`): tras un receipt exitoso, el
+  leaderboard no ve el score y no hay señal.
+- Divergencia score/badge si la app se cierra durante `confirming`. El badge se auto-cura
+  leyendo la cadena; el score **no** reconcilia.
+- `Invalid player address` se clasifica como `unknown`.
+
+---
+
+## 6. Grande — no abrir sin decidirlo
+
+- **Belt System** (#189) — espina aceptada, **no agendada**. No abrir hasta que cierren
+  MiniPay/slides. Único item con reloj: `BADGE_THRESHOLD` → proporción, barato mientras haya
+  exactamente un badge minteado.
+- **Lote 2.5** — Tactical Day Gift + Proof of Consistency
+  (`docs/backlog/2026-07-08-tactical-day-gift-proof-of-consistency-lote-2.5.md`).
+  El shield protege el COMBO, **no** el Daily. **Nunca construir recovery para el Daily-Streak.**
+
+---
+
+## 7. Issues de GitHub abiertos
+
+| # | Prioridad | Título |
+| --- | --- | --- |
+| 104 | P1 | Treasure hunt — pieza única móvil |
+| 101 | P2 | Prize pool distribution v2 (falta método en el contrato) |
+| 67 | P2 | Exercise world map — visual progression path |
+
+---
+
+## 8. Otros docs de backlog, sin agendar
+
+- `2026-06-17-edge-walls-on-borders.md`
+- `2026-06-17-isolate-dev-tools-into-separate-app.md`
+- `2026-06-26-exercises-sheet-open-slide-unification.md`
+
+## 9. No scopeado
+
+Social login · gift-able PRO (`project_pro_growth_ideas_backlog`) · specs de Welcome Package y
+Exercises Save Flow · Focus Passport P1.5 calendar · Deep Hint · observability tracker +
+deuda de `onProTap`.
+
+**Caveat aceptado:** `MAX_SHIELDS=3` es cap de activos/display; `credited` es monótono y
+bufferea el excedente. Un cap duro real es cambio de modelo.

--- a/docs/handoffs/2026-07-10-victory-cancel-and-coach-icon-handoff.md
+++ b/docs/handoffs/2026-07-10-victory-cancel-and-coach-icon-handoff.md
@@ -1,0 +1,115 @@
+# Handoff — smoke cerrado, cancelación de victory, icono de Coach (2026-07-10)
+
+**`main` = `827e7cfe`.** Suite **4853 passing / 401 test files**. `tsc` y `lint` limpios.
+PRs de esta sesión: **#206**, **#207**.
+
+---
+
+## Qué pasó
+
+### 1. Smoke de MiniPay ejecutado en device — checkpoint firmado
+
+El founder corrió la matriz completa en device. **17/17 filas verdes.** La única anomalía
+(label de confirm pegado) ya había cerrado en #204 y se reverificó.
+
+Registrado en `docs/testing/2026-07-10-minipay-critical-flow-smoke.md` con una nota de
+procedencia explícita: son **reporte del founder**, no observación del agente. Esa distinción
+importa — un doc que no dice quién miró se lee después como si hubiera evidencia automatizada.
+
+**Recomendación de checkpoint: FIRMAR.** El criterio del bloque era "impide completar los
+flujos o corrompe progreso, pagos o estado". Lo que apareció después no corrompe nada.
+
+### 2. Dead-end de cancelación en el mint de victory (#206)
+
+Encontrado **fuera de la matriz**, por uso real.
+
+Ganás en Arena, tocás Claim, rechazás en la wallet, y en vez de volver a la pantalla de
+victoria caías en un popup `PAUSED`. Sus tres salidas: *Try Again*, *Play Again* (descarta la
+partida) y la X, que navegaba al HUB. **Una cancelación te costaba la celebración.**
+
+**No era el decoder de custom errors.** No hay revert que decodificar. `use-mint-victory.ts`
+ya clasificaba bien la cancelación con `isUserCancellation`. El bug estaba aguas abajo:
+`"cancelled"` estaba modelado como **fase terminal**, y `arena-end-state.tsx` montaba
+`VictoryClaimError` para ella. El `reset()` del hook, que volvía a `"ready"`, existía y nadie
+lo llamaba.
+
+**Ahora:** cancelar es un no-op. La fase vuelve a `"ready"` y un one-shot `justCancelled`
+levanta un toast transitorio "Not saved yet" sobre la pantalla de victoria intacta. El claim
+sigue disponible ahí y en el Diario. `error` y `timeout` conservan el popup.
+
+### 3. El typecheck verde que no probaba nada
+
+Al borrar la fase muerta, `tsc --noEmit` dio **cero errores**. Causa: `arena-end-state.tsx`
+**redeclaraba** su propio `export type ClaimPhase` con el mismo nombre en vez de importar el
+del hook. Dos uniones independientes, mismo nombre. El valor angosto del hook asignaba sin
+queja contra la copia ancha del consumidor.
+
+Es la versión en el eje de tipos de `feedback_tests_green_against_dead_shape`. Ahora
+`arena-end-state` re-exporta el tipo del hook. Guardado como
+`feedback_duplicate_union_defeats_tsc_migration`.
+
+Borrados en el mismo PR: `"cancelled"` de `ClaimPhase` y `ClaimEndKind`, sus claves de copy
+(`errorKindCopy.cancelled`, `statusHeadlinePaused`) en EN y ES, la variante `win-cancelled`
+del fixture `/dev`, y el baseline VR `vr9-arena-end-state-win-cancelled`.
+
+### 4. Icono de Coach en el play hub (#207)
+
+El triage lo llamaba "swap de ruta". Casi no lo era: `HubActionTile` clampea el icono a 38×42
+y `training.png` trae su propio marco horneado — un plausible marco-dentro-de-marco.
+
+Lo rendericé a 390px en vez de asumir. El tile es una placa amarilla plana, el badge asienta
+limpio, y el lobo es legible. `PlayTacticsTile` ya probaba el patrón con
+`ejercicio-diario-chess.png` a través del mismo componente. Tactics y Coach ahora leen como
+una familia; Shop queda sin marco (no existe asset de shop enmarcado — eso es pedido de arte).
+
+---
+
+## Lecciones de esta sesión
+
+- **Un tipo redeclarado con el mismo nombre desarma al compilador como guía de migración.**
+  Importá el tipo de quien lo posee. Ante un cambio de forma, `grep` el nombre del miembro:
+  fixtures y specs guardan literales que `tsc` nunca compara.
+- **La matriz de smoke tenía un agujero con forma de superficie.** Cubría cancelación de score
+  y de badge (LEARN) y ninguna del mint de victory (PLAY) — el tercer camino que pide firma.
+  Al escribir una matriz, enumerá los **caminos que piden firma**, no las pantallas.
+- **Verificá pixeles antes de llamar trivial a un cambio de arte.** El asset era un *tile*, no
+  un *icono*. Lo salvó el vecino ya shippeado, no mi intuición.
+- **Un flujo opcional no puede tener un estado terminal de cancelación.** Si el usuario puede
+  hacerlo después, cancelar es un no-op.
+
+---
+
+## Estado de VR
+
+- Borrado `vr9-arena-end-state-win-cancelled`: el estado ya no tiene pantalla propia, y un
+  toast que se auto-descarta a 3200 ms es mal sujeto de screenshot. Fijado con fake timers en
+  `arena-end-state.test.tsx`.
+- **El play hub no tiene cobertura VR.** Ningún test visual lo visita. Por eso un icono podía
+  derivar ahí sin guarda. Vale un issue.
+
+---
+
+## Próximos pasos (en orden sugerido)
+
+1. **Investigar "Claim 3 Shields"** — el único pendiente con comportamiento *inexplicado*.
+   Nadie sabe a qué sistema pertenece, si duplica los 3 shields de onboarding, ni por qué al
+   tocarlo lanza el 21-Day Mind Challenge. **No cambiar lógica hasta entenderlo.**
+2. **Decoder de custom errors** — `docs/backlog/2026-07-10-custom-errors-decoder.md`. GO, no
+   bloquea estabilidad. Mejora la copy, no la corrección.
+3. **Quitar la confirmación redundante de LUZ** (PLAY #8) — borra una pantalla intermedia.
+
+Después de eso la conversación es **Belt System vs server-verified progress**, y esa es
+decisión de producto, no de ingeniería.
+
+Listado completo: `docs/backlog/2026-07-10-backlog-index.md`.
+
+---
+
+## Open questions
+
+- **`timeout` ofrece *Try Again* como CTA primario**, pero un timeout es
+  `WaitForTransactionReceiptTimeoutError`: la tx ya se firmó y transmitió. ¿Reintentar sobre un
+  mint que quizá aterrizó es seguro? El contrato scopea por `gameId`, así que probablemente
+  revierta — pero eso es una hipótesis, no evidencia. **Medir antes de tocar.**
+- ¿El play hub merece un baseline VR propio, o su superficie cambia demasiado seguido?
+- `MAX_SHIELDS=3` es cap de display/activos, no cap duro. El caveat sigue aceptado.

--- a/docs/handoffs/_next-session-prompt.md
+++ b/docs/handoffs/_next-session-prompt.md
@@ -1,85 +1,79 @@
-# Next session prompt — post 2026-07-10 receipt-status cluster
+# Next session prompt — post 2026-07-10 victory-cancel + coach-icon
 
 Di **"continuemos"** y el agente debe leer este archivo y seguirlo.
 
 ---
 
-**Estado al arrancar:** `main` = `339e0383`. Suite **4848 passing / 401 test files**.
-`tsc` y `lint` limpios. VR 52 passed. E2E minipay 130 passed / 0 failed.
+**Estado al arrancar:** `main` = `827e7cfe`. Suite **4853 passing / 401 test files**.
+`tsc` y `lint` limpios. Smoke de MiniPay **cerrado en device (17/17)**, checkpoint firmado.
 
 **Leer primero:**
-- `docs/handoffs/2026-07-10-receipt-status-and-minipay-probe-handoff.md` — la sesión.
-- `docs/testing/2026-07-10-minipay-critical-flow-smoke.md` — la matriz pendiente.
+- `docs/handoffs/2026-07-10-victory-cancel-and-coach-icon-handoff.md` — la sesión.
+- `docs/backlog/2026-07-10-backlog-index.md` — el backlog vigente, auditado contra el código.
 
-**Modo:** cierre y estabilización. Un solo bloque activo a la vez. Si un hallazgo no
-bloquea el bloque, se **difiere**; no se abre.
+**Modo:** pulido sobre lo que ya existe. Un solo bloque activo a la vez.
 
 ---
 
 ## Ruta vigente
 
-1. **▶️ Smoke del flujo crítico en MiniPay** — bloque activo. **Requiere device.**
-   Matriz en `docs/testing/2026-07-10-minipay-critical-flow-smoke.md`, todas las
-   filas en ⬜. Necesita un redeploy de preview con `339e0383` o posterior.
+1. **▶️ Investigar "Claim 3 Shields"** — el único pendiente con comportamiento *inexplicado*.
+   Nadie sabe a qué sistema pertenece, si duplica los 3 shields de onboarding, ni por qué al
+   tocarlo lanza el 21-Day Mind Challenge. **Investigación, no código. No cambiar lógica
+   hasta entenderlo.**
 
-   El paso que importa: **cerrar el overlay de éxito y esperar 2 s**. El toast está
-   suprimido mientras el overlay está montado, así que un label pegado solo se ve
-   después de cerrarlo. Por eso el smoke encontró el bug de #204 y ningún test lo vio.
+2. **Decoder de custom errors** — `docs/backlog/2026-07-10-custom-errors-decoder.md`.
+   GO, **no bloquea estabilidad**. Mejora la copy, no la corrección. El extractor está
+   escrito; falta el generador de error-ABIs desde `artifacts/` y el mapa nombre → copy.
 
-2. **Checkpoint de estabilidad** — solo con la matriz llena. No firmar un checkpoint
-   sobre suite verde: los criterios que más importan son justo los que el código
-   nuevo cambió, y ninguno tiene evidencia de device.
+3. **PLAY #8 — quitar la confirmación redundante de LUZ.** Borra una pantalla intermedia.
 
-3. **Decoder de custom errors** — `docs/backlog/2026-07-10-custom-errors-decoder.md`.
-   **GO con evidencia**, y **no bloquea estabilidad**: los reverts ya se interceptan,
-   no producen éxito falso, y hay fallback genérico. Mejora la copy, no la corrección.
-   El extractor ya está escrito; falta el generador de error-ABIs desde `artifacts/`
-   y el mapa nombre → copy.
-
-Después de eso: **Belt System vs server-verified progress**, que es decisión de
-producto, no de ingeniería.
+Después de eso: **Belt System vs server-verified progress**, que es decisión de producto.
 
 ---
 
 ## Antes de correr cualquier cosa
 
-- **`env | grep NEXT_PUBLIC` debe salir vacío.** Un `NEXT_PUBLIC_CHAIN_ID` exportado
-  en el shell gana sobre `.env.local` y apunta el dev server a Sepolia sin avisar.
-  Para correr limpio sin tocar el shell:
+- **`env | grep NEXT_PUBLIC` debe salir vacío.** Confirmado sucio el 2026-07-10: el shell
+  exporta `NEXT_PUBLIC_CHAIN_ID=11142220` y **le gana a `.env.local`**, apuntando el dev
+  server a Sepolia sin avisar. Para correr limpio sin tocar el shell:
   `env -u NEXT_PUBLIC_CHAIN_ID -u NEXT_PUBLIC_BADGES_ADDRESS -u NEXT_PUBLIC_SCOREBOARD_ADDRESS pnpm -C apps/web <cmd>`
-- **`lsof -ti:3000` debe salir vacío** antes de VR o E2E. Un dev server viejo sirve el
-  build anterior y produce fallos fantasma (45 de ellos, 2026-07-10).
+- **`lsof -ti:3000` debe salir vacío** antes de VR o E2E.
+- El **play hub** solo se monta con `NEXT_PUBLIC_CHESSCITO_MODE=play` (flag de build). El
+  switch de modo en la UI **no** lo alcanza.
 
----
+## Higiene de comandos (evita prompts de permiso)
 
-## Reglas que esta sesión ganó a golpes
+- **Nunca prefijes con `cd`.** Usá `git -C <ruta>` y `pnpm -C <ruta>`.
+- **Un comando por llamada.** Sin pipes, sin `;` encadenados, sin heredocs.
+- Typecheck con `pnpm exec tsc --noEmit` pelado.
+- Archivos temporales: la tool Write, nunca `>` (zsh tiene `noclobber`).
 
-- **El entorno miente antes que el código.** Ante un rojo masivo, sospechar del
-  entorno antes que del diff. Comparar contra un baseline en el commit anterior.
-- **Dos suites aisladas verdes no prueban su composición.** El toast pegado de #204
-  vivía exactamente entre dos suites verdes.
-- **Si sabés qué es el error, no le preguntes al texto.** Los errores tipados se
-  clasifican antes que toda heurística de string, incluida la de cancelación.
-- **Un fallo puede esconder otro.** Leer el mensaje de error real antes de creerle al
-  handoff sobre la causa.
-- **Un instrumento puede tapar lo que vino a medir.** El redactor del probe censuró el
-  selector que el probe existía para leer.
-- **VR:** refrescar con `--update-snapshots=all`, y después **abrir el PNG**. Un
-  baseline hereda el entorno del que lo escribe.
+## Reglas que estas sesiones ganaron a golpes
+
+- **Un tipo redeclarado con el mismo nombre desarma al compilador.** `arena-end-state.tsx`
+  tenía su propio `ClaimPhase`; borrar un miembro en el hook dio `tsc` verde con la variante
+  muerta todavía alcanzable. Importá el tipo de quien lo posee; `grep` el nombre del miembro.
+- **Un flujo opcional no puede tener estado terminal de cancelación.** Si se puede hacer
+  después, cancelar es un no-op.
+- **Una matriz de smoke se escribe por caminos que piden firma, no por pantallas.** El
+  dead-end de victory vivía en el único camino de firma sin fila.
+- **Verificá pixeles antes de llamar trivial a un cambio de arte.**
+- **El entorno miente antes que el código.** Rojo masivo → sospechar del entorno.
+- **Dos suites aisladas verdes no prueban su composición.**
 
 ## Qué NO tocar todavía
 
-- **No implementar el decoder** hasta cerrar el smoke y el checkpoint.
 - **No abrir el Belt System** hasta que cierren MiniPay/slides. Único item con reloj:
   `BADGE_THRESHOLD` → proporción, mientras haya exactamente un badge minteado.
 - **Nunca construir recovery para el Daily-Streak.** El shield protege el COMBO.
-- **No implementar server-verified progress con umbral proporcional evaluado en vivo**
-  — des-califica retroactivamente. Bit monótono `qualified(player, piece)`.
+- **No implementar server-verified progress con umbral proporcional evaluado en vivo** — des-
+  califica retroactivamente. Bit monótono `qualified(player, piece)`.
 - **No subir ningún techo a un literal.** Una constante derivada de contenido debe ser
   función del contenido.
+- **No tocar el *Try Again* de `timeout`** sin medir: la tx ya se firmó y transmitió.
 
 ## Si el usuario dice…
 
 - **"continuemos"** → leer este archivo + el handoff, y arrancar por el punto 1.
-- **"qué falta"** → la matriz del smoke.
-- **"ship it"** → redeploy de preview y confirmar la matriz en device antes de nada.
+- **"qué falta"** → `docs/backlog/2026-07-10-backlog-index.md`.


### PR DESCRIPTION
docs(handoff): close the 2026-07-10 victory-cancel cluster

Handoff for the session that closed the MiniPay device smoke (17/17), fixed the
victory-claim cancellation dead-end (#206) and swapped the Coach icon (#207).

Adds a backlog index audited against the code rather than against the previous
lists, since two entries had already been fixed and nobody had noted it. Marks
the 2026-07-08 lote2 findings as partially superseded: it still describes the
gold "Save proof" CTA, Post-Focus Free Practice and the Coach icon as open.

Rewrites the next-session prompt: the active block is now investigating "Claim 3
Shields", the only pending item with unexplained behaviour. Records the confirmed
shell env contamination, the play hub's build flag, and command hygiene.

Wolfcito 🐾 @akawolfcito
