### PR TITLE
fix(season-pass): checkout copy completes the habit promise

### DIFF
--- a/apps/web/src/components/payments/__tests__/season-pass-sheet.test.tsx
+++ b/apps/web/src/components/payments/__tests__/season-pass-sheet.test.tsx
@@ -45,7 +45,7 @@ function defaultRail() {
 }
 
 describe('SeasonPassSheet', () => {
-  it('shows PRO Benefit included and does not render a purchase CTA', () => {
+  it('shows Included with PRO and does not render a purchase CTA', () => {
     statusMock.mockReturnValue({
       active: true,
       source: 'pro',
@@ -59,7 +59,7 @@ describe('SeasonPassSheet', () => {
     render(<SeasonPassSheet open={true} onOpenChange={() => {}} />)
 
     expect(screen.getByTestId('season-pass-included-pro')).toHaveTextContent(
-      'PRO Benefit included',
+      'Included with PRO',
     )
     expect(screen.queryByTestId('season-pass-pay')).toBeNull()
     expect(screen.queryByText(/\+3 shields/i)).toBeNull()

--- a/apps/web/src/components/payments/season-pass-sheet.tsx
+++ b/apps/web/src/components/payments/season-pass-sheet.tsx
@@ -111,7 +111,7 @@ function SeasonPassSheetInner({
           </div>
         ) : trainingPass.active && trainingPass.source === "pro" ? (
           <div data-testid="season-pass-included-pro" className="flex flex-col items-center gap-3">
-            <p className="arena-result-title">{t("includedWithPro")}</p>
+            <p className="arena-result-title">{t("proIncludedTitle")}</p>
             <p className="max-w-[220px] text-sm opacity-80">
               {t("trainingPassStat")} · {t("accessActive")}
             </p>
@@ -157,13 +157,15 @@ function SeasonPassSheetInner({
         ) : (
           <>
             <ShieldIcon />
-            <p className="arena-result-title">21-Day Mind Challenge</p>
-            <p className="text-sm opacity-80 max-w-[220px]">
-              Unlock unlimited practice with +{pass.shieldsOnPurchase} shields for{" "}
-              {pass.durationDays} days.
-            </p>
+            <p className="arena-result-title">{t("offerTitle")}</p>
+            <p className="text-sm opacity-80 max-w-[240px]">{t("offerHabit")}</p>
+            <ul className="flex flex-col items-center gap-1 text-sm opacity-80">
+              <li>{t("offerPractice", { days: pass.durationDays })}</li>
+              <li>{t("offerShieldsBonus", { count: pass.shieldsOnPurchase })}</li>
+            </ul>
 
             <span className="candy-stat-pill text-base font-bold">{priceLabel}</span>
+            <p className="text-[0.7rem] opacity-60">{t("offerPriceNote")}</p>
 
             {!rail.available ? (
               /* ---- UNAVAILABLE (no wallet / wrong chain) ---- */
@@ -275,7 +277,7 @@ function SeasonPassSheetInner({
                 </PrincipalButton>
 
                 <p className="text-[0.7rem] opacity-50">
-                  Paid with {tokenSymbol} on Celo. No subscription.
+                  Paid with {tokenSymbol} on Celo.
                 </p>
               </div>
             )}

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -3215,6 +3215,16 @@ export const CHALLENGE_CARD_COPY = {
   dotFilledAria: "Day {index} done",
   dotEmptyAria: "Day {index}",
   focusTapAria: "Continue today's focus",
+  // SeasonPassSheet offer state — the checkout must complete the same promise
+  // that starts in onboarding and continues in the ChallengeCard: a daily habit
+  // via the Focus Passport, not "volume + consumables". The +Shields line is the
+  // direct-purchase bonus ONLY; PRO holders see proIncludedTitle with no bonus.
+  offerTitle: "Join the 21-Day Mind Challenge",
+  offerHabit: "Build a daily chess habit and keep your Focus Passport active.",
+  offerPractice: "Unlimited challenge practice for {days} days",
+  offerShieldsBonus: "Includes the direct-purchase +{count} Shields bonus",
+  offerPriceNote: "One-time payment · No subscription",
+  proIncludedTitle: "Included with PRO",
 } as const;
 
 export const HUB_LITE_COPY = {

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -1737,6 +1737,12 @@ const messages = {
     dotFilledAria: "Día {index} hecho",
     dotEmptyAria: "Día {index}",
     focusTapAria: "Continúa tu foco de hoy",
+    offerTitle: "Únete al Reto Mental de 21 Días",
+    offerHabit: "Crea un hábito diario de ajedrez y mantén activo tu Pasaporte de foco.",
+    offerPractice: "Práctica ilimitada del reto por {days} días",
+    offerShieldsBonus: "Incluye el bono de +{count} Escudos por compra directa",
+    offerPriceNote: "Pago único · Sin suscripción",
+    proIncludedTitle: "Incluido con PRO",
   },
   HUB_LITE_COPY: {
     ...en.HUB_LITE_COPY,


### PR DESCRIPTION
## What

Rewrites the `SeasonPassSheet` **offer-state copy** so the checkout completes the same value promise that starts in onboarding slide 2 and continues in the `ChallengeCard`: a **daily habit via the Focus Passport**, not "unlimited practice + shields" (which reduced the product to volume + consumables).

New offer hierarchy:
1. Join the 21-Day Mind Challenge
2. Build a daily chess habit and keep your Focus Passport active
3. Unlimited challenge practice for 21 days
4. Includes the direct-purchase +3 Shields bonus
5. $0.99 · One-time payment · No subscription

PRO holders now see **"Included with PRO"** — no direct purchase, no +3 Shields bonus (that bonus belongs to direct purchase only).

## Why

Point-of-sale audit found the Season Pass narrative fragmented across surfaces (onboarding = habit, checkout = shields). Product decision: **Season Pass is a LEARN product** — Gap 1 (no PLAY point-of-sale) closed *by design*; PLAY may cross-promote to LEARN but never sells the Pass. This PR fixes Gap 2 (checkout copy) only.

## Scope / guarantees

- **Copy only.** Mode gate (`CHESSCITO_LITE_MODE`), entry points (LEARN dock SHOP slot + Join CTA), and the Season Pass ↔ PRO separation are untouched.
- **i18n key parity**: new keys in `CHALLENGE_CARD_COPY` (`editorial.ts`, derived `en.ts`) + ES overrides in `messages/es.ts`. `en.ts` not hand-edited.
- Sheet-scoped `proIncludedTitle` key leaves the shared `includedWithPro` (ChallengeCard badge) unchanged.

## Tests

`season-pass-sheet` + `learn-shop-sheet` + `challenge-card` — 12/12 green. `tsc --noEmit` clean. No VR baseline renders this modal, and no `ChallengeCard`-rendered string changed, so `hub-clean.png` is unaffected; string guard is the unit tests.

Wolfcito 🐾 @akawolfcito