### PR TITLE
feat(dev): season-pass celebration probe (+ stat row fix it caught)

### DIFF
--- a/apps/web/src/app/dev/season-pass-celebration/fixture.tsx
+++ b/apps/web/src/app/dev/season-pass-celebration/fixture.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+
+import { VictoryPopupShell } from "@/components/arena/victory-popup-shell";
+import {
+  CELEBRATION_PANEL_BG,
+  SeasonPassCelebration,
+} from "@/components/payments/season-pass-celebration";
+import { getSeasonPass } from "@/lib/payments/rail-config";
+
+export type CelebrationVariant = "credited" | "pending";
+
+/** Shields the celebration was handed by the verified receipt. `pending` is the
+ *  real path where the payment settled but the Redis grant did not
+ *  (`verify-payment` answers 0) — the one a founder can never reach on demand
+ *  with a live purchase, which is the whole point of this probe. */
+const SHIELDS: Record<CelebrationVariant, number> = {
+  credited: 3,
+  pending: 0,
+};
+
+export function SeasonPassCelebrationFixture({
+  variant,
+}: {
+  variant: CelebrationVariant;
+}) {
+  const pass = getSeasonPass("lite_season_pass_21");
+  const [replay, setReplay] = useState(0);
+
+  return (
+    <div className="min-h-dvh">
+      {/* Remounts the celebration so the confetti burst replays — the
+          animation is `both`-filled and otherwise only fires on mount. */}
+      <button
+        type="button"
+        onClick={() => setReplay((n) => n + 1)}
+        className="fixed left-3 top-3 z-[80] rounded-md bg-black/70 px-3 py-1.5 text-xs font-bold text-white"
+      >
+        Replay confetti
+      </button>
+
+      <VictoryPopupShell
+        key={replay}
+        onClose={() => {}}
+        ariaLabel="21-Day Mind Challenge Pass"
+        closeLabel="Close"
+        panelBackgroundImage={CELEBRATION_PANEL_BG}
+      >
+        <SeasonPassCelebration
+          durationDays={pass.durationDays}
+          shieldsCredited={SHIELDS[variant]}
+          onStartFocus={() => {}}
+        />
+      </VictoryPopupShell>
+    </div>
+  );
+}

--- a/apps/web/src/app/dev/season-pass-celebration/page.tsx
+++ b/apps/web/src/app/dev/season-pass-celebration/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+
+import { SeasonPassCelebrationFixture, type CelebrationVariant } from "./fixture";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = { [key: string]: string | string[] | undefined };
+
+const VARIANTS = new Set<CelebrationVariant>(["credited", "pending"]);
+
+/**
+ * Post-purchase celebration probe — renders the "You are in!" screen without
+ * spending a cent, so the flow can be validated on preview without a live
+ * payment.
+ *
+ * Gated on VERCEL_ENV (not NODE_ENV) on purpose: preview builds also run with
+ * NODE_ENV=production, and a probe that 404s on preview cannot be used for the
+ * validation it exists for. Dead in production.
+ *
+ *   /dev/season-pass-celebration              → shields credited (+3)
+ *   /dev/season-pass-celebration?variant=pending → shields not yet granted
+ */
+export default function SeasonPassCelebrationDevPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  if (process.env.VERCEL_ENV === "production") notFound();
+
+  const raw = typeof searchParams.variant === "string" ? searchParams.variant : "credited";
+  const variant = VARIANTS.has(raw as CelebrationVariant)
+    ? (raw as CelebrationVariant)
+    : "credited";
+
+  return <SeasonPassCelebrationFixture variant={variant} />;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -14305,11 +14305,15 @@ button.hud-resource-chip:active:not(:disabled) {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
+/* nowrap keeps the row on one line: the pending-shields label is longer than
+   "+3 Shields" and, allowed to wrap, it dragged the day count into two lines
+   and broke the row. Type shrinks instead of wrapping. */
 .season-pass-celebration-stat {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 15px;
+  white-space: nowrap;
+  font-size: clamp(13px, 3.7vw, 15px);
   font-weight: 800;
   color: rgba(63, 34, 8, 0.95);
 }

--- a/apps/web/src/components/payments/__tests__/season-pass-sheet.test.tsx
+++ b/apps/web/src/components/payments/__tests__/season-pass-sheet.test.tsx
@@ -140,7 +140,7 @@ describe('SeasonPassSheet — post-purchase celebration', () => {
     render(<SeasonPassSheet open={true} onOpenChange={() => {}} />)
 
     const stats = screen.getByTestId('season-pass-celebration-stats')
-    expect(stats).toHaveTextContent('Shields on the way')
+    expect(stats).toHaveTextContent('Shields soon')
     expect(stats).not.toHaveTextContent('+0 Shields')
   })
 

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -3232,7 +3232,7 @@ export const CHALLENGE_CARD_COPY = {
   celebrationSubtitle: "Your 21-Day Mind Challenge has started.",
   celebrationDaysStat: "{days} days",
   celebrationShieldsStat: "+{count} Shields",
-  celebrationShieldsPending: "Shields on the way",
+  celebrationShieldsPending: "Shields soon",
   celebrationHabit: "Your 21-day mind habit starts now.",
 } as const;
 

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -1747,7 +1747,7 @@ const messages = {
     celebrationSubtitle: "Tu Reto Mental de 21 Días ha comenzado.",
     celebrationDaysStat: "{days} días",
     celebrationShieldsStat: "+{count} Escudos",
-    celebrationShieldsPending: "Escudos en camino",
+    celebrationShieldsPending: "Escudos pronto",
     celebrationHabit: "Tu hábito mental de 21 días empieza ahora.",
   },
   HUB_LITE_COPY: {


### PR DESCRIPTION
## What

Keeps the celebration reachable for validation without a live purchase, behind `/dev` — dead in production.

```
/dev/season-pass-celebration                  → shields credited (+3)
/dev/season-pass-celebration?variant=pending  → shields not yet granted
```

Includes a **Replay confetti** button (the burst is `both`-filled and otherwise only fires on mount).

## The probe paid for itself on its first run

With shields pending, **"Shields on the way" wrapped and dragged the day count into two lines, breaking the stat row.** That state only happens when the payment settles but the Redis shield grant does not — it cannot be reached by hand, so no amount of manual testing would have found it. Shortened the label to "Shields soon" and pinned the stats to `nowrap` so type shrinks instead of wrapping.

## Gating

`VERCEL_ENV === "production"`, **not** `NODE_ENV`. Preview builds also run `NODE_ENV=production`, so the `NODE_ENV` guard other probes use would 404 the page on preview — where the validation actually needs to happen. Production is dead either way.

## Verification

- Unit suite **4865 passing / 401 files**.
- VR **51/51**.
- Both variants screenshotted at 390px in a real browser.

Wolfcito 🐾 @akawolfcito