### PR TITLE
fix(dev): load the app fonts in the celebration probe

### DIFF
--- a/apps/web/src/app/dev/season-pass-celebration/page.tsx
+++ b/apps/web/src/app/dev/season-pass-celebration/page.tsx
@@ -1,8 +1,28 @@
+import { Fredoka, Rowdies } from "next/font/google";
 import { notFound } from "next/navigation";
 
 import { SeasonPassCelebrationFixture, type CelebrationVariant } from "./fixture";
 
 export const dynamic = "force-dynamic";
+
+// The /dev tree is its own root layout and never loads the app fonts, so
+// `--font-game-action` resolved to nothing here and the celebration rendered in
+// system type — a probe that misreports the typography it exists to validate.
+// Scoped to this page rather than the /dev layout on purpose: the VR fixtures
+// share that layout and their baselines were captured font-less, so hoisting
+// this would churn every one of them. Mirrors [locale]/layout.tsx.
+const fredoka = Fredoka({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-fredoka",
+  display: "swap",
+});
+const rowdies = Rowdies({
+  subsets: ["latin"],
+  weight: ["300", "400", "700"],
+  variable: "--font-rowdies",
+  display: "swap",
+});
 
 type SearchParams = { [key: string]: string | string[] | undefined };
 
@@ -32,5 +52,21 @@ export default function SeasonPassCelebrationDevPage({
     ? (raw as CelebrationVariant)
     : "credited";
 
-  return <SeasonPassCelebrationFixture variant={variant} />;
+  // `--font-game-action` is declared on :root as `var(--font-rowdies), ...` and
+  // custom properties substitute where they are DECLARED, not where they are
+  // used — so :root already resolved it against an undefined --font-rowdies.
+  // Re-declaring the derived tokens here (not just the base vars) is what
+  // actually puts Rowdies on the title.
+  const fontVars = {
+    "--font-rowdies": rowdies.style.fontFamily,
+    "--font-fredoka": fredoka.style.fontFamily,
+    "--font-game-action": `${rowdies.style.fontFamily}, system-ui, sans-serif`,
+    "--font-game-display": `${fredoka.style.fontFamily}, sans-serif`,
+  } as React.CSSProperties;
+
+  return (
+    <div style={fontVars}>
+      <SeasonPassCelebrationFixture variant={variant} />
+    </div>
+  );
 }


### PR DESCRIPTION
## What

The probe rendered the celebration title in **system type, not Rowdies** — so it misreported the typography it exists to validate.

The real modal was always correct. Measured:

| | `--font-rowdies` |
|---|---|
| `/dev` probe | *(empty)* → falls back to SF Pro |
| `[locale]` tree (real app) | `'__Rowdies_83c428'` |

The `/dev` tree is its own root layout and never loaded Rowdies/Fredoka.

## The subtle part

Declaring the base vars on a wrapper is **not enough**. `--font-game-action` is declared on `:root` as `var(--font-rowdies), ...`, and custom properties substitute **where they are declared, not where they are used** — `:root` had already resolved it against an undefined `--font-rowdies`. The derived tokens (`--font-game-action`, `--font-game-display`) are re-declared on the probe wrapper too. Verified by reading computed `fontFamily` from the browser, not by eye.

## Why scoped to the page, not the /dev layout

The VR fixtures share that layout and their baselines were captured font-less. Hoisting the fonts there would churn all 51 baselines.

That also means **VR does not currently guard real typography** — every fixture baseline is in system type. Worth a decision on its own; deliberately not slipped in here.

Wolfcito 🐾 @akawolfcito