### PR TITLE
fix(shields): refresh the credited cache after Season Pass + Welcome Pack grants

### DIFF
--- a/apps/web/src/lib/season-pass/__tests__/use-season-pass-rail.test.tsx
+++ b/apps/web/src/lib/season-pass/__tests__/use-season-pass-rail.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+const WALLET = "0xcc4179a22b473ea2eb2b9b9b210458d0f60fc2dd" as const;
+const TREASURY = "0x1681aaa1be1e0d4a4a1f4b8e0f6b3f4d5c6a7b8c" as const;
+const TX_HASH = "0xabc0000000000000000000000000000000000000000000000000000000000001" as const;
+
+const writeContractAsync = vi.fn(async () => TX_HASH);
+const waitForTransactionReceipt = vi.fn(async () => ({ status: "success" }));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ address: WALLET }),
+  useChainId: () => 42220,
+  usePublicClient: () => ({ waitForTransactionReceipt }),
+  useWriteContract: () => ({ writeContractAsync }),
+}));
+
+vi.mock("@/lib/payments/rail-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/payments/rail-config")>();
+  return { ...actual, getTreasuryAddressClient: () => TREASURY };
+});
+
+import { readCreditedCache, writeCreditedCache } from "@/lib/shop/shield-storage";
+import { useSeasonPassRail } from "@/lib/season-pass/use-season-pass-rail";
+
+/** Routes fetch by URL: the pass verification answers a shield DELTA
+ *  (`shieldsCredited: 3`), while /api/shields/me answers the ABSOLUTE
+ *  monotonic counter. Only the latter is safe to cache. */
+function mockFetch(credited: number) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.startsWith("/api/verify-payment")) {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          seasonId: "21day-mind-challenge-2026-q3",
+          expiresAt: "2026-08-01T00:00:00.000Z",
+          shieldsCredited: 3,
+          supporterStatus: "challenger",
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.startsWith("/api/shields/me")) {
+      return new Response(JSON.stringify({ ok: true, credited }), {
+        status: 200,
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+describe("useSeasonPassRail — post-purchase shield reconciliation", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+    writeContractAsync.mockClear();
+    waitForTransactionReceipt.mockClear();
+  });
+
+  it("refreshes the credited-cache from the server once the payment verifies", async () => {
+    // Buyer already held a stale cache (e.g. spent down before buying).
+    writeCreditedCache(1);
+    mockFetch(6);
+
+    const { result } = renderHook(() =>
+      useSeasonPassRail({ sku: "lite_season_pass_21", tokenSymbol: "USDC" }),
+    );
+
+    await act(async () => {
+      await result.current.pay();
+    });
+
+    await waitFor(() => expect(result.current.phase).toBe("success"));
+    // Without the reconciliation the chip keeps rendering the stale 1
+    // until some other screen remounts useShieldSync.
+    expect(readCreditedCache()).toBe(6);
+  });
+
+  it("still reports success when the shield read fails", async () => {
+    writeCreditedCache(1);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("/api/verify-payment")) {
+        return new Response(
+          JSON.stringify({ ok: true, shieldsCredited: 3 }),
+          { status: 200 },
+        );
+      }
+      return new Response("nope", { status: 500 });
+    });
+
+    const { result } = renderHook(() =>
+      useSeasonPassRail({ sku: "lite_season_pass_21", tokenSymbol: "USDC" }),
+    );
+
+    await act(async () => {
+      await result.current.pay();
+    });
+
+    await waitFor(() => expect(result.current.phase).toBe("success"));
+    expect(result.current.result?.shieldsCredited).toBe(3);
+    expect(readCreditedCache()).toBe(1);
+  });
+
+  it("fires onVerified after the cache is reconciled", async () => {
+    mockFetch(6);
+    const seenAtCallback: number[] = [];
+
+    const { result } = renderHook(() =>
+      useSeasonPassRail({
+        sku: "lite_season_pass_21",
+        tokenSymbol: "USDC",
+        onVerified: () => seenAtCallback.push(readCreditedCache()),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.pay();
+    });
+
+    await waitFor(() => expect(result.current.phase).toBe("success"));
+    // The hub's onSuccess closes the sheet — by then the count must be real.
+    expect(seenAtCallback).toEqual([6]);
+  });
+});

--- a/apps/web/src/lib/season-pass/use-season-pass-rail.ts
+++ b/apps/web/src/lib/season-pass/use-season-pass-rail.ts
@@ -12,6 +12,7 @@ import {
   type SeasonPassSku,
 } from "@/lib/payments/rail-config";
 import { buildSeasonPassTransfer } from "@/lib/payments/transfer-builder";
+import { syncShieldsFromServer } from "@/lib/shop/shield-sync";
 export { mapSeasonPassError } from "@/lib/season-pass/map-season-pass-error";
 
 const CELO_MAINNET_CHAIN_ID = 42220;
@@ -127,6 +128,12 @@ export function useSeasonPassRail({
               overpaid: Boolean(json.overpaid),
             };
             setResult(railResult);
+            // The receipt carries a DELTA (`shieldsCredited`), not the
+            // monotonic counter the HUD renders from — so re-read the
+            // authoritative total before anyone reacts to the success.
+            // Skipping this left the shields chip on its pre-purchase
+            // value until another screen remounted useShieldSync.
+            if (address) await syncShieldsFromServer(address);
             setPhase("success");
             onVerified?.(railResult);
             return;

--- a/apps/web/src/lib/shop/__tests__/shield-sync.test.ts
+++ b/apps/web/src/lib/shop/__tests__/shield-sync.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { subscribeToShieldChanges } from "@/lib/shop/shield-events";
+import {
+  readCreditedCache,
+  writeCreditedCache,
+} from "@/lib/shop/shield-storage";
+import {
+  applyServerCredited,
+  syncShieldsFromServer,
+} from "@/lib/shop/shield-sync";
+
+const WALLET = "0xcc4179a22b473ea2eb2b9b9b210458d0f60fc2dd" as const;
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+describe("syncShieldsFromServer", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("mirrors the server credited counter into the local cache and notifies subscribers", async () => {
+    const seen = vi.fn();
+    const unsubscribe = subscribeToShieldChanges(seen);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      okResponse({ ok: true, credited: 6 }),
+    );
+
+    const credited = await syncShieldsFromServer(WALLET);
+
+    expect(credited).toBe(6);
+    expect(readCreditedCache()).toBe(6);
+    expect(seen).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("reads the counter for the given wallet", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(okResponse({ ok: true, credited: 3 }));
+
+    await syncShieldsFromServer(WALLET);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `/api/shields/me?wallet=${encodeURIComponent(WALLET)}`,
+    );
+  });
+
+  it("leaves the cached counter untouched when the read fails", async () => {
+    writeCreditedCache(3);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 500 }),
+    );
+
+    expect(await syncShieldsFromServer(WALLET)).toBeNull();
+    expect(readCreditedCache()).toBe(3);
+  });
+
+  it("survives a network throw without clobbering the cache", async () => {
+    writeCreditedCache(3);
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    expect(await syncShieldsFromServer(WALLET)).toBeNull();
+    expect(readCreditedCache()).toBe(3);
+  });
+});
+
+describe("applyServerCredited", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("caches an absolute counter the server already handed us and notifies", () => {
+    const seen = vi.fn();
+    const unsubscribe = subscribeToShieldChanges(seen);
+
+    applyServerCredited(3);
+
+    expect(readCreditedCache()).toBe(3);
+    expect(seen).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+});

--- a/apps/web/src/lib/shop/__tests__/use-welcome-pack-claim.test.tsx
+++ b/apps/web/src/lib/shop/__tests__/use-welcome-pack-claim.test.tsx
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+const WALLET = "0xcc4179a22b473ea2eb2b9b9b210458d0f60fc2dd" as const;
+
+const signMessageAsync = vi.fn(async () => "0xsignature" as `0x${string}`);
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ address: WALLET, isConnected: true }),
+  useSignMessage: () => ({ signMessageAsync }),
+}));
+
+vi.mock("@/lib/wallet/use-connect-wallet", () => ({
+  useConnectWallet: () => ({ connectWallet: vi.fn() }),
+}));
+
+import { readCreditedCache, writeCreditedCache } from "@/lib/shop/shield-storage";
+import { useWelcomePackClaim } from "@/lib/shop/use-welcome-pack-claim";
+
+/** `/api/welcome-pack/claim` answers the ABSOLUTE credited counter (the
+ *  return of the Redis INCRBY), so the client can cache it as-is. */
+function mockClaim(payload: Record<string, unknown>) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.startsWith("/api/welcome-pack/status")) {
+      return new Response(JSON.stringify({ ok: true, claimed: false }), {
+        status: 200,
+      });
+    }
+    if (url.startsWith("/api/welcome-pack/claim")) {
+      return new Response(JSON.stringify(payload), { status: 200 });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+describe("useWelcomePackClaim — credited-cache reconciliation", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+    signMessageAsync.mockClear();
+  });
+
+  it("caches the credited counter the claim returns", async () => {
+    mockClaim({
+      ok: true,
+      claimed: true,
+      shields_granted: 3,
+      credited: 3,
+      claimed_at: "2026-07-11T00:00:00.000Z",
+    });
+
+    const { result } = renderHook(() => useWelcomePackClaim());
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+
+    await act(async () => {
+      result.current.onClaim();
+    });
+
+    await waitFor(() => expect(result.current.state).toBe("claimed"));
+    // Dispatching the change event without writing the counter made every
+    // subscriber re-read a stale localStorage — the chip stayed at 0.
+    expect(readCreditedCache()).toBe(3);
+  });
+
+  it("does not touch the cache on an already-claimed pack", async () => {
+    writeCreditedCache(3);
+    mockClaim({
+      ok: true,
+      already_claimed: true,
+      claimed_at: "2026-07-01T00:00:00.000Z",
+    });
+
+    const { result } = renderHook(() => useWelcomePackClaim());
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+
+    await act(async () => {
+      result.current.onClaim();
+    });
+
+    await waitFor(() => expect(result.current.state).toBe("claimed"));
+    expect(readCreditedCache()).toBe(3);
+  });
+});

--- a/apps/web/src/lib/shop/shield-sync.ts
+++ b/apps/web/src/lib/shop/shield-sync.ts
@@ -1,0 +1,45 @@
+/** Server → client reconciliation of the `credited` shield counter.
+ *
+ *  `credited` is a monotonic counter owned by Redis; the client keeps a
+ *  mirror in localStorage and derives the displayed count from it
+ *  (`min(MAX_SHIELDS, credited - consumed)`, see shield-storage.ts). Any
+ *  flow that credits shields server-side MUST push the new counter back
+ *  into that mirror, or the HUD keeps rendering the pre-purchase value
+ *  until some other screen remounts `useShieldSync`.
+ *
+ *  Plain functions, not a hook: the Season Pass rail needs to reconcile
+ *  from inside a callback, and mounting a second `useShieldSync` in the
+ *  same tree would duplicate a cache+fetch hook. */
+
+import { dispatchShieldChange } from "@/lib/shop/shield-events";
+import { writeCreditedCache } from "@/lib/shop/shield-storage";
+
+type ShieldsMeResponse = { ok?: boolean; credited?: number };
+
+/** Caches an absolute counter the server already handed us (e.g. the
+ *  Redis INCRBY return that `/api/welcome-pack/claim` echoes back) and
+ *  notifies the in-tab subscribers. Never pass a delta here. */
+export function applyServerCredited(credited: number): void {
+  writeCreditedCache(credited);
+  dispatchShieldChange();
+}
+
+/** Reads the authoritative counter for `address` and mirrors it locally.
+ *  Returns the counter, or null when the read failed — a failure leaves
+ *  the cache untouched, so the next sync (or boot) still reconciles. */
+export async function syncShieldsFromServer(
+  address: string,
+): Promise<number | null> {
+  try {
+    const res = await fetch(
+      `/api/shields/me?wallet=${encodeURIComponent(address)}`,
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as ShieldsMeResponse;
+    if (typeof data.credited !== "number") return null;
+    applyServerCredited(data.credited);
+    return data.credited;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/shop/use-shield-sync.ts
+++ b/apps/web/src/lib/shop/use-shield-sync.ts
@@ -3,10 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAccount } from "wagmi";
 
-import { dispatchShieldChange } from "@/lib/shop/shield-events";
+import { syncShieldsFromServer } from "@/lib/shop/shield-sync";
 import {
   consumeLegacyShieldsForMigration,
-  writeCreditedCache,
   SHIELDS_CONSUMED_KEY,
   SHIELDS_LEGACY_KEY,
   SHIELDS_CREDITED_CACHE_KEY,
@@ -18,8 +17,6 @@ export type UseShieldSyncReturn = {
   /** Manual trigger (e.g., right after a credit-shield write). */
   refresh: () => Promise<void>;
 };
-
-type ShieldsMeOk = { ok: true; credited: number };
 
 /** Boot-time + post-purchase shield reconciliation hook. Spec §
  *  "useShieldSync sequence" (purchase-queue drain step retired in
@@ -57,21 +54,8 @@ export function useShieldSync(): UseShieldSyncReturn {
       }
 
       // 2. Read current credit total.
-      try {
-        const res = await fetch(
-          `/api/shields/me?wallet=${encodeURIComponent(address)}`,
-        );
-        if (res.ok) {
-          const data = (await res.json()) as ShieldsMeOk;
-          if (mountedRef.current) {
-            writeCreditedCache(data.credited);
-            setServerCredited(data.credited);
-            dispatchShieldChange();
-          }
-        }
-      } catch {
-        // ignore — next sync retries
-      }
+      const credited = await syncShieldsFromServer(address);
+      if (credited != null && mountedRef.current) setServerCredited(credited);
     } finally {
       syncingRef.current = false;
     }

--- a/apps/web/src/lib/shop/use-welcome-pack-claim.ts
+++ b/apps/web/src/lib/shop/use-welcome-pack-claim.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAccount, useSignMessage } from "wagmi";
 import { useConnectWallet } from "@/lib/wallet/use-connect-wallet";
 
-import { dispatchShieldChange } from "@/lib/shop/shield-events";
+import { applyServerCredited } from "@/lib/shop/shield-sync";
 import type { WelcomePackTileState } from "@/components/exercises/welcome-pack-tile";
 
 /**
@@ -196,11 +196,13 @@ export function useWelcomePackClaim(
           setClaimed(true);
           setClaimedAt(at);
           writeCache(walletLower, true, at);
-          // Notify HUD chip + Account inventory row of new balance.
-          // Only fire on fresh claim — already_claimed should NOT
-          // create a phantom shield delta in the UI.
+          // Cache the new counter, THEN notify the HUD chip + Account
+          // inventory row. Dispatching alone just made them re-read a
+          // stale localStorage. `credited` is the absolute INCRBY return,
+          // safe to cache as-is. Only on a fresh claim — already_claimed
+          // must NOT create a phantom shield delta in the UI.
           if (payload.claimed && typeof payload.credited === "number") {
-            dispatchShieldChange();
+            applyServerCredited(payload.credited);
             // Fire post-fresh-claim callback (e.g. auto-close Shop
             // sheet so the player returns to the exercises arena).
             // Only on fresh claim — already_claimed should NOT


### PR DESCRIPTION
## The bug

Buying the Season Pass showed **+3 Shields** in the celebration, and then the exercises screen showed a lower count. Reported from a real MiniPay purchase: the chip read 1, and only became 3 after navigating to the hub and back.

The shields were never lost. `verify-payment` credits them in Redis correctly. What was broken is the mirror.

## Root cause

`credited` is a monotonic counter owned by Redis. The client mirrors it in `localStorage` and derives the displayed count as `min(MAX_SHIELDS, credited - consumed)`. The **only** thing that ever wrote that mirror from the server was `useShieldSync`, mounted in exactly one place: `legacy-hub-client.tsx:186`, on mount.

Neither grant path pushed the new counter back:

- **Season Pass rail** — verified the payment, built the result, called `onVerified`. Never touched the shield cache.
- **Welcome Pack** — dispatched `dispatchShieldChange()` but never wrote the counter, so every subscriber woke up and re-read the same stale value.

Hence the "fixed itself" behavior: leaving to the hub remounted `useShieldSync`, which finally reconciled.

## The fix

New `lib/shop/shield-sync.ts` with two plain functions (not a hook — a second `useShieldSync` in the tree would duplicate a cache+fetch hook):

- `syncShieldsFromServer(address)` — reads `/api/shields/me`, mirrors the absolute counter, notifies. Failure leaves the cache untouched.
- `applyServerCredited(credited)` — caches a counter the server already handed us.

The rail calls the former on success **before** `onVerified` (the hub closes the sheet in that callback, so the count must be real by then). The Welcome Pack calls the latter with the `INCRBY` return its own endpoint already echoes — no extra round trip.

`shieldsOnPurchase: 3` is unchanged. The number was never the problem.

## Tests

10 new tests across 3 files, written red first: cache reconciliation, wallet scoping, failure paths leaving the cache intact, `onVerified` ordering, and `already_claimed` not inventing a delta.

**Suite: 4875 passing / 404 files.** Typecheck clean.

Wolfcito 🐾 @akawolfcito