### PR TITLE
feat(progression): earn it, celebrate it, then open it

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7275,6 +7275,46 @@ button.hud-resource-chip:active:not(:disabled) {
   text-shadow: 0 1px 0 rgba(255, 245, 215, 0.7);
 }
 
+/* ── Progression unlock overlay (2026-07-11) ──
+ * Rendered inside the canonical VictoryPopupShell (forest panel-bg1 +
+ * red X), same shell as the language-switch modal above. The earned
+ * artifact icon replaces the wolf mascot as the central image; the
+ * title reuses `.language-modal-title`. `-absorbed` is a recognition
+ * LINE for a lower major folded into this closer, never a second
+ * modal. `-dismiss` mirrors the plain underlined secondary CTA used
+ * by the Welcome Package modal (no new CTA token family). */
+.progression-overlay-icon {
+  display: flex;
+  justify-content: center;
+  margin: 0 auto 0.25rem;
+}
+
+.progression-overlay-body {
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(110, 65, 15, 0.55);
+}
+
+.progression-overlay-absorbed {
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(120, 65, 5, 0.75);
+}
+
+.progression-overlay-dismiss {
+  align-self: center;
+  margin: 0 auto;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  color: rgba(110, 65, 15, 0.50);
+  background: transparent;
+  border: none;
+}
+
 /* `--pro` modifier — same shape/size as the cream candy chip, but
  * the cream gradient is replaced by the PRO purple palette so PRO
  * subscribers get a visual distinction without changing the chip

--- a/apps/web/src/components/daily/__tests__/daily-tactic-slot-unbundle.test.tsx
+++ b/apps/web/src/components/daily/__tests__/daily-tactic-slot-unbundle.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent } from "@testing-library/react";
+import { renderWithIntl as render, screen } from "@/test-utils/render-with-intl";
+import { getDailyProgress } from "@/lib/daily/progress";
+import { getWelcomePackageState } from "@/lib/welcome-package/storage";
+import type { DailyTacticData } from "@/lib/daily/daily-puzzles";
+
+/**
+ * Task 10 — THE defect this cluster exists for. One `if` inside
+ * `handleSolve` used to grant `firstFocusDayJustEarned` (the
+ * `first-focus-day` badge, which stays exactly as-is) AND unlock the
+ * Welcome Package gift together. The gift now belongs to the
+ * `first-reward` milestone (4 stars AND >=2 exercises, cumulative),
+ * derived by the milestone machine — never by the first Daily Focus
+ * alone. This file reuses the render conventions of
+ * `daily-tactic-sheet.test.tsx` (renderWithIntl + gridcell clicks for
+ * the rook a1->h1 solve) and `welcome-package-stamp.test.tsx` /
+ * `use-welcome-package.test.ts` (mocking `@/lib/feature-flags` Lite ON
+ * + mocking `wagmi`'s `useAccount`/`useSignMessage`).
+ */
+
+vi.mock("@/lib/feature-flags", () => ({ CHESSCITO_LITE_MODE: true }));
+
+const PUZZLE: DailyTacticData = {
+  id: "test-dt-rook-1",
+  name: "Rook — horizontal slide",
+  piece: "rook",
+  exercise: {
+    id: "test-dt-rook-1",
+    startPos: { file: 0, rank: 0 },
+    targetPos: { file: 7, rank: 0 },
+    optimalMoves: 1,
+  },
+  hint: "Slide the rook along the rank.",
+};
+
+// Pin the puzzle so the solve interaction (a1 -> h1) is deterministic
+// regardless of which UTC date the suite runs on. Keep every other
+// export (getPuzzleDifficulty, etc. — consumed by daily telemetry)
+// wired to the real module.
+vi.mock("@/lib/daily/daily-puzzles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/daily/daily-puzzles")>();
+  return {
+    ...actual,
+    getDailyTactic: () => PUZZLE,
+  };
+});
+
+const useAccountMock = vi.hoisted(() => vi.fn());
+const signMessageAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("wagmi", () => ({
+  useAccount: useAccountMock,
+  useSignMessage: () => ({ signMessageAsync: signMessageAsyncMock }),
+}));
+
+const { DailyTacticSlot } = await import("../daily-tactic-slot");
+
+function getPedestal(): HTMLButtonElement {
+  return screen
+    .getByTestId("daily-tactic-card")
+    .querySelector('[data-component="stone-pedestal"]') as HTMLButtonElement;
+}
+
+/** Renders the slot, opens the sheet, and solves the a1->h1 rook puzzle
+ *  — driving the component to `handleSolve` exactly like a real first
+ *  Daily Focus completion. */
+function solveFirstDailyFocus(): void {
+  render(<DailyTacticSlot />);
+  fireEvent.click(getPedestal());
+  fireEvent.click(screen.getByRole("gridcell", { name: "Square a1" }));
+  fireEvent.click(screen.getByRole("gridcell", { name: "Square h1" }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useAccountMock.mockReturnValue({ address: undefined, isConnected: false });
+  signMessageAsyncMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the gift is no longer bundled with the first Daily Focus", () => {
+  it("does not unlock the gift when the first daily tactic is solved", () => {
+    solveFirstDailyFocus();
+
+    expect(getDailyProgress().totalCompleted).toBe(1);
+    expect(getWelcomePackageState().unlocked).toBe(false);
+  });
+
+  it("still marks the solved status and shows the solve screen (regression guard)", () => {
+    solveFirstDailyFocus();
+
+    expect(screen.getByTestId("daily-status-solved")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/daily/daily-tactic-slot.tsx
+++ b/apps/web/src/components/daily/daily-tactic-slot.tsx
@@ -112,7 +112,6 @@ export function DailyTacticSlot() {
     const prev = progress;
     if (CHESSCITO_LITE_MODE && prev.totalCompleted === 0) {
       firstFocusDayJustEarned.current = true;
-      welcomePackage.unlock();
     }
     const next = recordDailyCompletion(today);
     setProgress(next);

--- a/apps/web/src/components/exercises/__tests__/badge-claim-cross-piece.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/badge-claim-cross-piece.test.tsx
@@ -1,0 +1,327 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, screen } from "@testing-library/react";
+
+import { renderWithAppProviders } from "@/test-utils/render-with-app-providers";
+import { ContentCatalogProvider } from "@/lib/content/catalog-context";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
+import {
+  dailyStarsStorageKey,
+  labyrinthBestStorageKey,
+  milestoneStorageKey,
+  pieceProgressStorageKey,
+} from "@/lib/lite-progress-storage";
+import type { Exercise } from "@/lib/game/types";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
+import { markMilestonesSeeded } from "@/lib/progression/seed-milestones";
+
+/**
+ * The claim is scoped to `step.piece`. The RE-RESOLVE must be too.
+ *
+ * `piece-badge-eligible:rook` is persisted the instant it is earned and stays
+ * PENDING until the player dismisses it — persistence precedes rendering, so a
+ * kill/reload with the overlay up is a fully supported state. The player comes
+ * back, switches to BISHOP, solves a bishop exercise, and the queue re-surfaces
+ * the rook closer (`buildCelebrationQueue` finds it by id; it does not filter by
+ * the selected piece). They tap CLAIM: rook is minted on-chain.
+ *
+ * The bug this file locks down: the success path forced `badgeClaimed: true`
+ * into a resolve that gathered every OTHER input for `selectedPiece`. Since
+ * `mastery` gates on `badgeClaimed && allLabyrinthsComplete` with NO star
+ * requirement, a bishop with its labyrinths done got a MASTERY crown on a badge
+ * that was never minted — and `mastery:bishop` was persisted CELEBRATED, eating
+ * the real bishop crown forever.
+ */
+
+vi.mock("@/lib/feature-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/feature-flags")>();
+  return {
+    ...actual,
+    CHESSCITO_MODE: "learn" as const,
+    CHESSCITO_LITE_MODE: true,
+    isLearnMode: () => true,
+    isPlayMode: () => false,
+    isFullMode: () => false,
+  };
+});
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    back: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+  usePathname: () => "/exercises",
+  redirect: (path: string) => path,
+  getPathname: ({ href }: { href: string }) => href,
+}));
+
+const CHAIN_ID = 42220;
+const WALLET = "0x1111111111111111111111111111111111111111" as const;
+const BADGES = "0x2222222222222222222222222222222222222222" as const;
+const TX_HASH = "0x3333333333333333333333333333333333333333333333333333333333333333" as const;
+
+/** Connected, on the configured chain, with the badge read ANSWERED — the shape
+ *  `isMilestoneSeedReady` demands before anything may seed or resolve. */
+vi.mock("wagmi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("wagmi")>();
+  return {
+    ...actual,
+    useAccount: () => ({
+      address: WALLET,
+      isConnected: true,
+      status: "connected" as const,
+    }),
+    useChainId: () => CHAIN_ID,
+    useWriteContract: () => ({ writeContractAsync: vi.fn(), isPending: false, reset: vi.fn() }),
+    useReadContracts: () => ({
+      data: Array.from({ length: 6 }, () => ({ result: false, status: "success" as const })),
+      refetch: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@/lib/contracts/chains", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/contracts/chains")>();
+  return {
+    ...actual,
+    getConfiguredChainId: () => CHAIN_ID,
+    getBadgesAddress: () => BADGES,
+  };
+});
+
+const claim = vi.hoisted(() => {
+  let settle: ((outcome: unknown) => void) | null = null;
+  return {
+    run: vi.fn(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve;
+        }),
+    ),
+    confirm: () =>
+      settle?.({ status: "success", txHash: TX_HASH, receipt: { status: "success" } }),
+  };
+});
+
+vi.mock("@/lib/exercises/use-onchain-write", () => ({
+  useOnChainWrite: () => ({
+    phase: "idle" as const,
+    txHash: null,
+    outcome: null,
+    isBusy: false,
+    run: claim.run,
+    reset: vi.fn(),
+  }),
+}));
+
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+  root = null;
+  rootMargin = "";
+  thresholds: number[] = [];
+}
+vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+
+const { ExercisesScreen } = await import("../exercises-screen");
+
+/** Rook: five one-move exercises along the files. */
+const ROOK_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
+  id: `t-rook-${n}`,
+  startPos: { file: 0, rank: n - 1 },
+  targetPos: { file: 7, rank: n - 1 },
+  optimalMoves: 1,
+}));
+
+/** Bishop: five one-move DIAGONALS (a1→h8, a2→g8, …). */
+const BISHOP_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
+  id: `t-bishop-${n}`,
+  startPos: { file: 0, rank: n - 1 },
+  targetPos: { file: 8 - n, rank: 7 },
+  optimalMoves: 1,
+}));
+
+const ROOK_LABS: Exercise[] = [
+  { id: "t-rook-lab-1", startPos: { file: 0, rank: 0 }, targetPos: { file: 7, rank: 0 }, optimalMoves: 1 },
+];
+const BISHOP_LABS: Exercise[] = [
+  { id: "t-bishop-lab-1", startPos: { file: 0, rank: 0 }, targetPos: { file: 7, rank: 7 }, optimalMoves: 1 },
+];
+
+function renderScreen() {
+  return renderWithAppProviders(
+    <ContentCatalogProvider
+      value={{
+        exercises: { ...EXERCISES, rook: ROOK_POOL, bishop: BISHOP_POOL },
+        labyrinths: { ...LABYRINTHS, rook: ROOK_LABS, bishop: BISHOP_LABS },
+        descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
+      }}
+    >
+      <ExercisesScreen initialPiece="bishop" />
+    </ContentCatalogProvider>,
+  );
+}
+
+function solve(exercise: Exercise) {
+  const from = `Square ${String.fromCharCode(97 + exercise.startPos.file)}${exercise.startPos.rank + 1}`;
+  const to = `Square ${String.fromCharCode(97 + exercise.targetPos.file)}${exercise.targetPos.rank + 1}`;
+  fireEvent.click(screen.getByRole("gridcell", { name: from }));
+  fireEvent.click(screen.getByRole("gridcell", { name: to }));
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** The store as the player left it: rook's badge moment EARNED and still
+ *  PENDING (the kill/reload), everything older already recognized. */
+function seedStore() {
+  const now = new Date().toISOString();
+  localStorage.setItem(
+    milestoneStorageKey(),
+    JSON.stringify({
+      version: 1,
+      dailyDate: today(),
+      events: {
+        "first-reward": { id: "first-reward", earnedAt: now, celebratedAt: now },
+        "special-training": { id: "special-training", earnedAt: now, celebratedAt: now },
+        "first-labyrinth:rook": {
+          id: "first-labyrinth",
+          piece: "rook",
+          earnedAt: now,
+          celebratedAt: now,
+        },
+        "first-labyrinth:bishop": {
+          id: "first-labyrinth",
+          piece: "bishop",
+          earnedAt: now,
+          celebratedAt: now,
+        },
+        // THE pending closer. Rook, not bishop.
+        "piece-badge-eligible:rook": {
+          id: "piece-badge-eligible",
+          piece: "rook",
+          earnedAt: now,
+        },
+      },
+    }),
+  );
+}
+
+/** Rook: 15★, badge-eligible, every labyrinth solved — the crown is one claim
+ *  away. Bishop: 6★ (never badge-eligible), but its labyrinths ARE solved, so
+ *  a `badgeClaimed: true` leaking onto bishop is all `mastery` would need. */
+function seedProgress() {
+  localStorage.setItem(
+    pieceProgressStorageKey("rook"),
+    JSON.stringify({
+      piece: "rook",
+      currentId: "t-rook-1",
+      stars: {
+        "t-rook-1": 3,
+        "t-rook-2": 3,
+        "t-rook-3": 3,
+        "t-rook-4": 3,
+        "t-rook-5": 3,
+      },
+    }),
+  );
+  localStorage.setItem(
+    pieceProgressStorageKey("bishop"),
+    JSON.stringify({
+      piece: "bishop",
+      currentId: "t-bishop-3",
+      stars: { "t-bishop-1": 3, "t-bishop-2": 3 },
+    }),
+  );
+  localStorage.setItem(
+    labyrinthBestStorageKey("rook"),
+    JSON.stringify({ "t-rook-lab-1": 1 }),
+  );
+  localStorage.setItem(
+    labyrinthBestStorageKey("bishop"),
+    JSON.stringify({ "t-bishop-lab-1": 1 }),
+  );
+  localStorage.setItem(
+    dailyStarsStorageKey(),
+    JSON.stringify({ date: today(), stars: 0 }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem("chesscito:onboarded", "true");
+  markMilestonesSeeded();
+  seedStore();
+  seedProgress();
+  claim.run.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("a badge claimed for a piece OTHER than the one on screen", () => {
+  it("crowns the piece the chain minted, and never the selected one", async () => {
+    renderScreen();
+
+    // A bishop solve re-surfaces the rook closer: the queue finds
+    // `piece-badge-eligible` by id, with no regard for `selectedPiece`.
+    solve(BISHOP_POOL[2]);
+    expect(screen.getByText("Badge Ready to Claim")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Claim Badge" }));
+    expect(claim.run).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      claim.confirm();
+    });
+
+    const events = getMilestoneStore().events;
+
+    // (a) The false crown. Bishop's badge was never minted; bishop's labyrinths
+    // are done; a `badgeClaimed: true` evaluated against BISHOP would have
+    // fired — and PERSISTED — a mastery it has not earned.
+    expect(events["mastery:bishop"]).toBeUndefined();
+    expect(events["piece-badge-claimed:bishop"]).toBeUndefined();
+
+    // (b) The real one. Rook is what the chain confirmed, so rook is what the
+    // machine must evaluate.
+    expect(events["mastery:rook"]).toBeDefined();
+    expect(events["piece-badge-claimed:rook"]).toBeDefined();
+  });
+
+  it("RENDERS the crown instead of stamping it — the dismiss precedes the re-resolve", async () => {
+    renderScreen();
+
+    solve(BISHOP_POOL[2]);
+    fireEvent.click(screen.getByRole("button", { name: "Claim Badge" }));
+    await act(async () => {
+      claim.confirm();
+    });
+
+    // Order is load-bearing. `resolve()` REPLACES the queue: re-resolving
+    // BEFORE the dismiss would rebuild it headed by `mastery` with the badge
+    // step absorbed into it, and the following `dismissCurrent()` would stamp
+    // the crown celebrated WITHOUT EVER RENDERING IT. The player would lose the
+    // biggest moment in the game to a line-ordering slip, silently.
+    expect(screen.getByText("Piece Mastered")).toBeInTheDocument();
+    expect(document.querySelectorAll('[aria-modal="true"]')).toHaveLength(1);
+
+    // Still awaiting its dismissal — earned, shown, not yet recognized.
+    expect(getMilestoneStore().events["mastery:rook"]?.celebratedAt).toBeUndefined();
+    // And the badge moment it replaced IS recognized: dismissed, not lost.
+    expect(
+      getMilestoneStore().events["piece-badge-eligible:rook"]?.celebratedAt,
+    ).toBeDefined();
+  });
+});

--- a/apps/web/src/components/exercises/__tests__/badge-claim-success-one-modal.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/badge-claim-success-one-modal.test.tsx
@@ -1,0 +1,271 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, screen, within } from "@testing-library/react";
+
+import { renderWithAppProviders } from "@/test-utils/render-with-app-providers";
+import { ContentCatalogProvider } from "@/lib/content/catalog-context";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
+import {
+  dailyStarsStorageKey,
+  milestoneStorageKey,
+  pieceProgressStorageKey,
+} from "@/lib/lite-progress-storage";
+import type { Exercise } from "@/lib/game/types";
+
+/**
+ * NEW-1 — the badge path with a claim that actually CONFIRMS.
+ *
+ * `celebration-order.test.tsx` drives the same screen, but with no wallet: every
+ * claim there resolves `false` and no test advances the clock. That is exactly
+ * the blind spot this file covers. On the real mainline path:
+ *
+ *   1. the 10th star mounts `<UnlockOverlay piece-badge-eligible>` AND arms the
+ *      15s auto-reset that flips `showPieceComplete`;
+ *   2. the MiniPay round trip easily outlives those 15s;
+ *   3. the claim confirms → `applyBadgeClaimSuccess` sets `resultOverlay` +
+ *      `unlockedPiece`, and the queue drains, all in the SAME commit.
+ *
+ * Every gate that was keyed only on `celebration.current === null` opened at
+ * once → two `aria-modal` surfaces. The invariant is counted on
+ * `[aria-modal="true"]`, never on `role="dialog"`: `<LabyrinthCompleteOverlay>`
+ * passes `role="alert"` to the same shell, so counting roles would report green
+ * on a visible stack.
+ */
+
+vi.mock("@/lib/feature-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/feature-flags")>();
+  return {
+    ...actual,
+    CHESSCITO_MODE: "learn" as const,
+    CHESSCITO_LITE_MODE: true,
+    isLearnMode: () => true,
+    isPlayMode: () => false,
+    isFullMode: () => false,
+  };
+});
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    back: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+  usePathname: () => "/exercises",
+  redirect: (path: string) => path,
+  getPathname: ({ href }: { href: string }) => href,
+}));
+
+const CHAIN_ID = 42220;
+const WALLET = "0x1111111111111111111111111111111111111111" as const;
+const BADGES = "0x2222222222222222222222222222222222222222" as const;
+const TX_HASH = "0x3333333333333333333333333333333333333333333333333333333333333333" as const;
+
+/** A connected wallet on the configured chain — the preconditions
+ *  `handleClaimBadge` demands before it will even call `run()`. */
+vi.mock("wagmi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("wagmi")>();
+  return {
+    ...actual,
+    useAccount: () => ({ address: WALLET, isConnected: true }),
+    useChainId: () => CHAIN_ID,
+    useWriteContract: () => ({ writeContractAsync: vi.fn(), isPending: false, reset: vi.fn() }),
+    useReadContracts: () => ({ data: undefined, refetch: vi.fn() }),
+  };
+});
+
+vi.mock("@/lib/contracts/chains", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/contracts/chains")>();
+  return {
+    ...actual,
+    getConfiguredChainId: () => CHAIN_ID,
+    getBadgesAddress: () => BADGES,
+  };
+});
+
+/** The claim, held open on purpose. `run()` resolves only when the test settles
+ *  it — that pending window is where the 15s auto-reset lands, exactly as a
+ *  MiniPay signature + receipt does in the wild. */
+const claim = vi.hoisted(() => {
+  let settle: ((outcome: unknown) => void) | null = null;
+  return {
+    run: vi.fn(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve;
+        }),
+    ),
+    confirm: () =>
+      settle?.({ status: "success", txHash: TX_HASH, receipt: { status: "success" } }),
+  };
+});
+
+vi.mock("@/lib/exercises/use-onchain-write", () => ({
+  useOnChainWrite: () => ({
+    phase: "idle" as const,
+    txHash: null,
+    outcome: null,
+    isBusy: false,
+    run: claim.run,
+    reset: vi.fn(),
+  }),
+}));
+
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+  root = null;
+  rootMargin = "";
+  thresholds: number[] = [];
+}
+vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+
+const { ExercisesScreen } = await import("../exercises-screen");
+
+const ROOK_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
+  id: `t-rook-${n}`,
+  startPos: { file: 0, rank: n - 1 },
+  targetPos: { file: 7, rank: n - 1 },
+  optimalMoves: 1,
+}));
+
+function renderScreen() {
+  return renderWithAppProviders(
+    <ContentCatalogProvider
+      value={{
+        exercises: { ...EXERCISES, rook: ROOK_POOL },
+        labyrinths: { ...LABYRINTHS, rook: [] },
+        descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
+      }}
+    >
+      <ExercisesScreen />
+    </ContentCatalogProvider>,
+  );
+}
+
+function solve(exercise: Exercise) {
+  const from = `Square ${String.fromCharCode(97 + exercise.startPos.file)}${exercise.startPos.rank + 1}`;
+  const to = `Square ${String.fromCharCode(97 + exercise.targetPos.file)}${exercise.targetPos.rank + 1}`;
+  fireEvent.click(screen.getByRole("gridcell", { name: from }));
+  fireEvent.click(screen.getByRole("gridcell", { name: to }));
+}
+
+/** THE invariant. Every popup on this screen is a `VictoryPopupShell` with
+ *  `aria-modal="true"`, whatever `role` it passes. */
+function modalCount(): number {
+  return document.querySelectorAll('[aria-modal="true"]').length;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function seedCelebrated(...keys: string[]) {
+  const now = new Date().toISOString();
+  const events: Record<string, unknown> = {};
+  for (const key of keys) {
+    const [id, piece] = key.split(":");
+    events[key] = piece
+      ? { id, piece, earnedAt: now, celebratedAt: now }
+      : { id, earnedAt: now, celebratedAt: now };
+  }
+  localStorage.setItem(
+    milestoneStorageKey(),
+    JSON.stringify({ version: 1, events, dailyDate: today() }),
+  );
+}
+
+/** 12★ over four exercises: the fifth (and last) solve makes it 15★ — the badge
+ *  threshold, on the same tap that arms the 15s piece-complete timer. */
+function seedNearBadge() {
+  localStorage.setItem(
+    pieceProgressStorageKey("rook"),
+    JSON.stringify({
+      piece: "rook",
+      currentId: "t-rook-5",
+      stars: { "t-rook-1": 3, "t-rook-2": 3, "t-rook-3": 3, "t-rook-4": 3 },
+    }),
+  );
+  localStorage.setItem(
+    dailyStarsStorageKey(),
+    JSON.stringify({ date: today(), stars: 0 }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem("chesscito:onboarded", "true");
+  claim.run.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("a badge claim that CONFIRMS still leaves exactly one modal", () => {
+  it("holds the piece-complete menu behind the badge result, then hands it over", async () => {
+    seedCelebrated("first-reward", "first-labyrinth:rook", "special-training");
+    seedNearBadge();
+    renderScreen();
+
+    // Fake timers only from here: the 15s auto-reset is armed by THIS solve.
+    vi.useFakeTimers();
+    solve(ROOK_POOL[4]);
+
+    expect(modalCount()).toBe(1);
+    expect(screen.getByText("Badge Ready to Claim")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Claim Badge" }));
+    expect(claim.run).toHaveBeenCalledTimes(1);
+
+    // The wallet round trip outlives the auto-reset (1.5s + 13.5s). This is the
+    // step that flips `showPieceComplete` behind the player's back.
+    act(() => {
+      vi.advanceTimersByTime(20_000);
+    });
+
+    // Still signing: the recognition owns the screen, alone.
+    expect(modalCount()).toBe(1);
+    expect(screen.getByText("Badge Ready to Claim")).toBeInTheDocument();
+
+    // The chain rules. `applyBadgeClaimSuccess` sets `resultOverlay` +
+    // `unlockedPiece` and the queue drains — all in the same commit.
+    await act(async () => {
+      claim.confirm();
+    });
+
+    expect(modalCount()).toBe(1);
+    expect(screen.getByText("Badge Earned!")).toBeInTheDocument();
+    // The bug: this used to un-gate in the same commit as the result card.
+    expect(screen.queryByText("All Exercises Complete!")).not.toBeInTheDocument();
+
+    // `ResultOverlay` plays a 250ms exit before it calls `onDismiss`, so the
+    // card is still mounted for a beat after the tap. Even mid-exit the count
+    // must hold at one: the next surface may not mount until this one is gone.
+    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+    expect(modalCount()).toBe(1);
+    expect(screen.getByText("Badge Earned!")).toBeInTheDocument();
+
+    // Deferred, never swallowed — the continuation still arrives, one at a time.
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(modalCount()).toBe(1);
+    expect(screen.getByText("Bishop Unlocked!")).toBeInTheDocument();
+    expect(screen.queryByText("All Exercises Complete!")).not.toBeInTheDocument();
+
+    const unlocked = screen.getByRole("dialog");
+    fireEvent.click(within(unlocked).getByRole("button", { name: "Close" }));
+
+    expect(modalCount()).toBe(1);
+    expect(screen.getByText("All Exercises Complete!")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/exercises/__tests__/badge-claim-success-one-modal.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/badge-claim-success-one-modal.test.tsx
@@ -66,15 +66,29 @@ const BADGES = "0x2222222222222222222222222222222222222222" as const;
 const TX_HASH = "0x3333333333333333333333333333333333333333333333333333333333333333" as const;
 
 /** A connected wallet on the configured chain — the preconditions
- *  `handleClaimBadge` demands before it will even call `run()`. */
+ *  `handleClaimBadge` demands before it will even call `run()`.
+ *
+ *  `status` and an ANSWERED badge read are not decoration: the seeding gate
+ *  (`isMilestoneSeedReady`) is built from both. Mocking `useAccount` without
+ *  `status` left `accountStatus` undefined, so the gate could never be true and
+ *  this file passed only because `markMilestonesSeeded()` runs in `beforeEach`
+ *  — it never exercised the gate it sits behind. Six `false` results = a real
+ *  player with no badges claimed yet, which is exactly this scenario. */
 vi.mock("wagmi", async (importOriginal) => {
   const actual = await importOriginal<typeof import("wagmi")>();
   return {
     ...actual,
-    useAccount: () => ({ address: WALLET, isConnected: true }),
+    useAccount: () => ({
+      address: WALLET,
+      isConnected: true,
+      status: "connected" as const,
+    }),
     useChainId: () => CHAIN_ID,
     useWriteContract: () => ({ writeContractAsync: vi.fn(), isPending: false, reset: vi.fn() }),
-    useReadContracts: () => ({ data: undefined, refetch: vi.fn() }),
+    useReadContracts: () => ({
+      data: Array.from({ length: 6 }, () => ({ result: false, status: "success" as const })),
+      refetch: vi.fn(),
+    }),
   };
 });
 

--- a/apps/web/src/components/exercises/__tests__/badge-claim-success-one-modal.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/badge-claim-success-one-modal.test.tsx
@@ -12,6 +12,7 @@ import {
   pieceProgressStorageKey,
 } from "@/lib/lite-progress-storage";
 import type { Exercise } from "@/lib/game/types";
+import { markMilestonesSeeded } from "@/lib/progression/seed-milestones";
 
 /**
  * NEW-1 — the badge path with a claim that actually CONFIRMS.
@@ -202,6 +203,10 @@ function seedNearBadge() {
 beforeEach(() => {
   localStorage.clear();
   localStorage.setItem("chesscito:onboarded", "true");
+  // Already on the milestone machine — the one-time migration (Task 15) has
+  // run for this profile. Without the marker, mounting the screen would seed
+  // this player's 12★ as history and suppress the badge moment under test.
+  markMilestonesSeeded();
   claim.run.mockClear();
 });
 

--- a/apps/web/src/components/exercises/__tests__/celebration-order.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/celebration-order.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 
 import { renderWithAppProviders } from "@/test-utils/render-with-app-providers";
 import { ContentCatalogProvider } from "@/lib/content/catalog-context";
@@ -8,22 +8,29 @@ import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
 import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
 import {
   dailySessionStorageKey,
+  dailyStarsStorageKey,
+  milestoneStorageKey,
   pieceProgressStorageKey,
 } from "@/lib/lite-progress-storage";
+import { getDailyStars } from "@/lib/progression/stars";
 import { getWelcomePackageState } from "@/lib/welcome-package/storage";
 import type { Exercise } from "@/lib/game/types";
 
 /**
- * Task 13 — THE inversion this cluster exists to fix.
+ * Task 13 — THE inversion this cluster exists to fix, plus the composition
+ * hazards its review found.
  *
  * The evaluation order is the contract:
  *   1. record the activity → 2. evaluate milestones → 3. persist →
  *   4. build + drain the queue → 5. render → 6. return to the experience →
  *   7. ONLY THEN, on the next start, evaluate the session limit.
  *
- * The session limit must never be consulted while a recognition is pending.
- * The player who struggles, retries, and burns the daily quota gets the
- * CELEBRATION, not the paywall.
+ * And the governing rule of the whole cluster: EXACTLY ONE DIALOG PER DRAIN.
+ * An absorbed recognition is a LINE inside the closer, never a second modal.
+ * The hook's unit tests prove the queue in isolation; only a screen-level test
+ * proves the queue COMPOSED with the legacy popups that share the same
+ * `VictoryPopupShell` z-layer — and that gap is exactly what let the stacked
+ * badge dialogs through the first time.
  *
  * Harness conventions borrowed from `daily-tactic-slot-unbundle.test.tsx`
  * (feature-flags mocked Lite ON, gridcell clicks to solve) and
@@ -59,6 +66,21 @@ vi.mock("@/i18n/navigation", () => ({
   getPathname: ({ href }: { href: string }) => href,
 }));
 
+/** jsdom has no IntersectionObserver; the WELL DONE Lottie observes its canvas
+ *  on mount and would otherwise throw into whichever async test is running. */
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+  root = null;
+  rootMargin = "";
+  thresholds: number[] = [];
+}
+vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+
 const { ExercisesScreen } = await import("../exercises-screen");
 
 /** Five trivial one-move rook slides. `optimalMoves: 1` → every solve is a
@@ -70,12 +92,21 @@ const ROOK_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
   optimalMoves: 1,
 }));
 
-function renderScreen() {
+/** One trivial maze: a clean vertical slide, no obstacles in the way. */
+const ROOK_LAB: Exercise = {
+  id: "t-lab-1",
+  startPos: { file: 3, rank: 0 },
+  targetPos: { file: 3, rank: 7 },
+  optimalMoves: 1,
+  obstacles: [],
+};
+
+function renderScreen(labyrinths: Exercise[] = []) {
   return renderWithAppProviders(
     <ContentCatalogProvider
       value={{
         exercises: { ...EXERCISES, rook: ROOK_POOL },
-        labyrinths: { ...LABYRINTHS, rook: [] },
+        labyrinths: { ...LABYRINTHS, rook: labyrinths },
         descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
       }}
     >
@@ -92,10 +123,63 @@ function solve(exercise: Exercise) {
   fireEvent.click(screen.getByRole("gridcell", { name: to }));
 }
 
+/** Enters the maze the way a player does: open the path drawer, tap the node.
+ *  (The contextual "Enter Labyrinth" pin is not reachable here — the Welcome
+ *  Pack CTA legitimately owns the idle action slot until it is claimed.) */
+async function enterLabyrinth() {
+  fireEvent.click(screen.getByRole("button", { name: "Exercises" }));
+  const node = await screen.findByRole("button", { name: "Labyrinth 1" });
+  fireEvent.click(node);
+  // The exit pin only exists inside the labyrinth layer — proof we are in.
+  await screen.findByRole("button", { name: "Exit Labyrinth" });
+}
+
+/** Modals on screen, counted the way the player experiences them: every one of
+ *  these is a `VictoryPopupShell` at `z-[70]` with `aria-modal="true"`. Some
+ *  pass `role="alert"` (the labyrinth score card) instead of `role="dialog"`,
+ *  so counting by role alone would miss a stacked popup. */
+function modalCount(): number {
+  return document.querySelectorAll('[aria-modal="true"]').length;
+}
+
 function seedRookProgress(currentId: string, stars: Record<string, number>) {
   localStorage.setItem(
     pieceProgressStorageKey("rook"),
     JSON.stringify({ piece: "rook", currentId, stars }),
+  );
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Pre-credits the daily star ledger, so a single 3★ solve can be pushed over
+ *  GREAT_SESSION_STARS (8) without burning the session quota. */
+function seedDailyStars(stars: number) {
+  localStorage.setItem(
+    dailyStarsStorageKey(),
+    JSON.stringify({ date: today(), stars }),
+  );
+}
+
+/**
+ * Marks milestones as already earned AND already celebrated, so they neither
+ * re-fire nor crowd the queue. Lets a test isolate the ONE recognition it is
+ * about. Keys are `id` or `id:piece` — the same `milestoneKey` shape the store
+ * writes.
+ */
+function seedCelebrated(...keys: string[]) {
+  const now = new Date().toISOString();
+  const events: Record<string, unknown> = {};
+  for (const key of keys) {
+    const [id, piece] = key.split(":");
+    events[key] = piece
+      ? { id, piece, earnedAt: now, celebratedAt: now }
+      : { id, earnedAt: now, celebratedAt: now };
+  }
+  localStorage.setItem(
+    milestoneStorageKey(),
+    JSON.stringify({ version: 1, events, dailyDate: today() }),
   );
 }
 
@@ -104,7 +188,7 @@ function exhaustSessionQuota() {
   localStorage.setItem(
     dailySessionStorageKey(),
     JSON.stringify({
-      date: new Date().toISOString().slice(0, 10),
+      date: today(),
       consumedContentIds: Array.from(
         { length: 10 },
         (_, i) => `exercise:bishop:spent-${i}`,
@@ -166,5 +250,175 @@ describe("celebration order on the exercises screen", () => {
     // forever and the celebration is a lie.
     expect(getWelcomePackageState().unlocked).toBe(true);
     expect(getWelcomePackageState().claimed).toBe(false);
+  });
+});
+
+describe("one dialog per drain (composition)", () => {
+  /** CRITICAL 1 — every player hits this. The solve that crosses 10★ used to
+   *  mount `<UnlockOverlay>` AND the legacy `<BadgeEarnedPrompt>`: two
+   *  `VictoryPopupShell`s, both `role="dialog"`, both `z-[70]`, the later one
+   *  in JSX painting over the other. */
+  it("renders exactly ONE dialog on the solve that crosses the badge threshold", () => {
+    seedCelebrated("first-reward", "first-labyrinth:rook", "special-training");
+    // 12★ over four exercises; the fifth (last) solve makes it 15★ — the badge
+    // prompt's own `newTotal >= BADGE_THRESHOLD && isLastExercise` trigger AND
+    // the machine's `pieceStars >= BADGE_THRESHOLD`, on the same tap.
+    seedRookProgress("t-rook-5", {
+      "t-rook-1": 3,
+      "t-rook-2": 3,
+      "t-rook-3": 3,
+      "t-rook-4": 3,
+    });
+    renderScreen();
+
+    solve(ROOK_POOL[4]);
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(modalCount()).toBe(1);
+    // The milestone machine owns the badge moment: its overlay is the one that
+    // can actually CLAIM. The legacy prompt only said "Continue".
+    expect(screen.getByText("Badge Ready to Claim")).toBeInTheDocument();
+    expect(document.querySelector("#badge-earned-title")).toBeNull();
+  });
+
+  /** CRITICAL 1, labyrinth path — `labyrinthCompleted` + the overlay from
+   *  `resolveMilestonesRef.current()` fire in the same tick. */
+  it("renders exactly ONE dialog when a labyrinth completion fires a recognition", async () => {
+    seedCelebrated("first-reward", "first-labyrinth:rook");
+    seedRookProgress("t-rook-4", {
+      "t-rook-1": 3,
+      "t-rook-2": 3,
+      "t-rook-3": 3,
+    });
+    seedDailyStars(6); // +3 from the maze → 9 ≥ GREAT_SESSION_STARS (8)
+    renderScreen([ROOK_LAB]);
+
+    // 9★ over 3 exercises unlocks the maze, so the idle action slot offers it.
+    await enterLabyrinth();
+    solve(ROOK_LAB);
+
+    await waitFor(() => {
+      expect(screen.getByText("Great Focus Session")).toBeInTheDocument();
+    });
+    expect(modalCount()).toBe(1);
+    expect(screen.queryByText("Labyrinth Solved!")).not.toBeInTheDocument();
+
+    // The maze score card is a CONTINUATION, not a celebration — suppressed,
+    // never lost. It comes back the moment the queue drains.
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => {
+      expect(screen.getByText("Labyrinth Solved!")).toBeInTheDocument();
+    });
+    expect(modalCount()).toBe(1);
+  });
+
+  /** IMPORTANT 5(a) — the claim-cancel ordering, at the composition level.
+   *  A badge claim that never completes must NOT consume the Great Focus
+   *  Session it absorbed. `releaseAbsorbed` runs, `dismissCurrent` does not. */
+  it("still recognizes an absorbed Great Focus Session when the badge claim does not complete", async () => {
+    seedCelebrated("first-reward", "first-labyrinth:rook", "special-training");
+    seedRookProgress("t-rook-5", {
+      "t-rook-1": 3,
+      "t-rook-2": 3,
+      "t-rook-3": 3,
+      "t-rook-4": 3,
+    });
+    seedDailyStars(6); // +3 from the solve → 9 ≥ 8
+    renderScreen();
+
+    solve(ROOK_POOL[4]);
+
+    // The badge is the closer; the Great Focus Session is absorbed INTO it.
+    expect(screen.getByText("Badge Ready to Claim")).toBeInTheDocument();
+    expect(screen.getByText("Great Focus Session recognized.")).toBeInTheDocument();
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+
+    // No wallet → the claim resolves `false` (the cancellation shape).
+    fireEvent.click(screen.getByRole("button", { name: "Claim Badge" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Great Focus Session")).toBeInTheDocument();
+    });
+    expect(modalCount()).toBe(1);
+  });
+});
+
+describe("the daily star ledger takes only NET improvement", () => {
+  /** IMPORTANT 5(c) — if a replay ever credited its full star count, a player
+   *  could grind one solved exercise into a Great Focus Session. */
+  it("adds ZERO to dailyStars when a solved exercise is replayed", () => {
+    seedRookProgress("t-rook-1", { "t-rook-1": 3 });
+    renderScreen();
+
+    expect(getDailyStars()).toBe(0);
+    solve(ROOK_POOL[0]); // same 3★, no improvement
+    expect(getDailyStars()).toBe(0);
+  });
+
+  /** IMPORTANT 5(b) — a session spent in the mazes must still be able to reach
+   *  a Great Focus Session. `addNetStars` is fed the PRE-solve best: if it ever
+   *  read the post-solve best the net gain would always be 0, `dailyStars`
+   *  would never grow, and the whole suite would still be green. */
+  it("credits a first labyrinth completion to dailyStars", async () => {
+    seedCelebrated("first-reward", "first-labyrinth:rook");
+    seedRookProgress("t-rook-4", {
+      "t-rook-1": 3,
+      "t-rook-2": 3,
+      "t-rook-3": 3,
+    });
+    renderScreen([ROOK_LAB]);
+
+    expect(getDailyStars()).toBe(0);
+    await enterLabyrinth();
+    solve(ROOK_LAB);
+
+    await waitFor(() => {
+      expect(screen.getByText("Labyrinth Solved!")).toBeInTheDocument();
+    });
+    expect(getDailyStars()).toBe(3);
+  });
+});
+
+describe("first-reward routes to the gift, not the shield Welcome Pack", () => {
+  /** CRITICAL 2 — the overlay promised the Welcome Package GIFT
+   *  (`lib/welcome-package/storage.ts`, `unlocked`/`claimed`). Its primary used
+   *  to call `useWelcomePackClaim().onClaim()` — the SERVER SHIELD Welcome Pack:
+   *  a different product, a `personal_sign` → `/api/welcome-pack/claim`
+   *  round-trip, never gated on this unlock. */
+  it("opens the Welcome Package gift modal from the primary CTA", async () => {
+    // 3★ on one exercise; the second solve reaches 6★ / 2 exercises → the gift
+    // gate (4★ / 2). Still only 2 exercises, so the maze gate (3) stays shut
+    // and `first-reward` is the ONLY step in the queue.
+    seedRookProgress("t-rook-2", { "t-rook-1": 3 });
+    renderScreen();
+
+    solve(ROOK_POOL[1]);
+    expect(screen.getByText("First Reward Earned")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Gift" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("welcome-package-modal")).toBeInTheDocument();
+    });
+    // Still exactly one modal — the overlay handed the moment over, it did
+    // not stack on top of it.
+    expect(modalCount()).toBe(1);
+    expect(screen.queryByText("First Reward Earned")).not.toBeInTheDocument();
+  });
+
+  it("claims the gift through the modal, flipping the real `claimed` flag", async () => {
+    seedRookProgress("t-rook-2", { "t-rook-1": 3 });
+    renderScreen();
+
+    solve(ROOK_POOL[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Open Gift" }));
+    await screen.findByTestId("welcome-package-modal");
+
+    expect(getWelcomePackageState().claimed).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: "Claim" }));
+
+    await waitFor(() => {
+      expect(getWelcomePackageState().claimed).toBe(true);
+    });
   });
 });

--- a/apps/web/src/components/exercises/__tests__/celebration-order.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/celebration-order.test.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+
+import { renderWithAppProviders } from "@/test-utils/render-with-app-providers";
+import { ContentCatalogProvider } from "@/lib/content/catalog-context";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
+import {
+  dailySessionStorageKey,
+  pieceProgressStorageKey,
+} from "@/lib/lite-progress-storage";
+import { getWelcomePackageState } from "@/lib/welcome-package/storage";
+import type { Exercise } from "@/lib/game/types";
+
+/**
+ * Task 13 — THE inversion this cluster exists to fix.
+ *
+ * The evaluation order is the contract:
+ *   1. record the activity → 2. evaluate milestones → 3. persist →
+ *   4. build + drain the queue → 5. render → 6. return to the experience →
+ *   7. ONLY THEN, on the next start, evaluate the session limit.
+ *
+ * The session limit must never be consulted while a recognition is pending.
+ * The player who struggles, retries, and burns the daily quota gets the
+ * CELEBRATION, not the paywall.
+ *
+ * Harness conventions borrowed from `daily-tactic-slot-unbundle.test.tsx`
+ * (feature-flags mocked Lite ON, gridcell clicks to solve) and
+ * `arena-play-mode-dock-destinations.test.tsx` (`@/i18n/navigation` mock).
+ * The exercise pool is injected through `ContentCatalogProvider` so every
+ * solve is a deterministic single rook slide worth exactly 3 stars.
+ */
+
+vi.mock("@/lib/feature-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/feature-flags")>();
+  return {
+    ...actual,
+    CHESSCITO_MODE: "learn" as const,
+    CHESSCITO_LITE_MODE: true,
+    isLearnMode: () => true,
+    isPlayMode: () => false,
+    isFullMode: () => false,
+  };
+});
+
+const pushMock = vi.fn();
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    back: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+  usePathname: () => "/exercises",
+  redirect: (path: string) => path,
+  getPathname: ({ href }: { href: string }) => href,
+}));
+
+const { ExercisesScreen } = await import("../exercises-screen");
+
+/** Five trivial one-move rook slides. `optimalMoves: 1` → every solve is a
+ *  clean 3★, so the star arithmetic in the assertions is exact. */
+const ROOK_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
+  id: `t-rook-${n}`,
+  startPos: { file: 0, rank: n - 1 },
+  targetPos: { file: 7, rank: n - 1 },
+  optimalMoves: 1,
+}));
+
+function renderScreen() {
+  return renderWithAppProviders(
+    <ContentCatalogProvider
+      value={{
+        exercises: { ...EXERCISES, rook: ROOK_POOL },
+        labyrinths: { ...LABYRINTHS, rook: [] },
+        descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
+      }}
+    >
+      <ExercisesScreen />
+    </ContentCatalogProvider>,
+  );
+}
+
+/** Drives the board exactly like a player: tap the rook, tap the target. */
+function solve(exercise: Exercise) {
+  const from = `Square ${String.fromCharCode(97 + exercise.startPos.file)}${exercise.startPos.rank + 1}`;
+  const to = `Square ${String.fromCharCode(97 + exercise.targetPos.file)}${exercise.targetPos.rank + 1}`;
+  fireEvent.click(screen.getByRole("gridcell", { name: from }));
+  fireEvent.click(screen.getByRole("gridcell", { name: to }));
+}
+
+function seedRookProgress(currentId: string, stars: Record<string, number>) {
+  localStorage.setItem(
+    pieceProgressStorageKey("rook"),
+    JSON.stringify({ piece: "rook", currentId, stars }),
+  );
+}
+
+/** Burns the free daily quota (10 slots) on unrelated content. */
+function exhaustSessionQuota() {
+  localStorage.setItem(
+    dailySessionStorageKey(),
+    JSON.stringify({
+      date: new Date().toISOString().slice(0, 10),
+      consumedContentIds: Array.from(
+        { length: 10 },
+        (_, i) => `exercise:bishop:spent-${i}`,
+      ),
+      paidUnlocked: 0,
+    }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // Skip the first-visit mission briefing so the board is the only surface.
+  localStorage.setItem("chesscito:onboarded", "true");
+  pushMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("celebration order on the exercises screen", () => {
+  it("never shows the session limit while a recognition is pending", () => {
+    exhaustSessionQuota();
+    renderScreen();
+
+    // Pre-state: the quota is spent, so the limit card owns the screen.
+    expect(screen.getByText("Great focus today!")).toBeInTheDocument();
+
+    // A fresh solve with the quota already burned: the session ended, so the
+    // Great Focus Session fires.
+    solve(ROOK_POOL[0]);
+
+    expect(screen.getByText("Great Focus Session")).toBeInTheDocument();
+    expect(screen.queryByText("Great focus today!")).not.toBeInTheDocument();
+  });
+
+  it("shows the gift overlay before the maze overlay, never stacked", () => {
+    // 6★ across 2 exercises already; the third solve crosses BOTH the gift
+    // gate (4★ / 2 exercises) and the maze gate (6★ / 3 exercises) at once.
+    seedRookProgress("t-rook-3", { "t-rook-1": 3, "t-rook-2": 3 });
+    renderScreen();
+
+    solve(ROOK_POOL[2]);
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(screen.getByText("First Reward Earned")).toBeInTheDocument();
+    expect(screen.queryByText("First Maze Unlocked")).not.toBeInTheDocument();
+  });
+
+  it("makes the gift claimable when first-reward fires", () => {
+    seedRookProgress("t-rook-3", { "t-rook-1": 3, "t-rook-2": 3 });
+    expect(getWelcomePackageState().unlocked).toBe(false);
+
+    renderScreen();
+    solve(ROOK_POOL[2]);
+
+    // Rendering an overlay is not the gift. The shop/hub tile gates on
+    // `unlocked && !claimed` — without this write the gift is unreachable
+    // forever and the celebration is a lie.
+    expect(getWelcomePackageState().unlocked).toBe(true);
+    expect(getWelcomePackageState().claimed).toBe(false);
+  });
+});

--- a/apps/web/src/components/exercises/__tests__/celebration-order.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/celebration-order.test.tsx
@@ -13,6 +13,7 @@ import {
   pieceProgressStorageKey,
 } from "@/lib/lite-progress-storage";
 import { getDailyStars } from "@/lib/progression/stars";
+import { markMilestonesSeeded } from "@/lib/progression/seed-milestones";
 import { getWelcomePackageState } from "@/lib/welcome-package/storage";
 import type { Exercise } from "@/lib/game/types";
 
@@ -202,6 +203,12 @@ beforeEach(() => {
   localStorage.clear();
   // Skip the first-visit mission briefing so the board is the only surface.
   localStorage.setItem("chesscito:onboarded", "true");
+  // Every player here is ALREADY on the milestone machine: the one-time
+  // migration (Task 15) has run for their profile. Without this marker the
+  // screen would seed them as veterans on mount — correct for a returning
+  // player, but it would stamp the very gates these tests exist to watch
+  // cross, and every celebration below would be (correctly) suppressed.
+  markMilestonesSeeded();
   pushMock.mockClear();
 });
 

--- a/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
@@ -143,7 +143,9 @@ describe("ExerciseDrawer — rotation (visibleExerciseIds set)", () => {
 
 describe("ExerciseDrawer — labyrinth nodes (Slice 3D)", () => {
   const zeros = starsById();
-  const sixStars = starsById(3, 3); // rook-1 + rook-2 at 3★ each → 6★
+  // rook-1 + rook-2 + rook-3 at 2★ each → 6★ over 3 exercises (the floor —
+  // LABYRINTH_MIN_EXERCISES — needs 3+, not the 2 a 3+3 spread would give).
+  const sixStars = starsById(2, 2, 2);
 
   function rookLabNodes(
     stars: Record<string, number>,
@@ -296,6 +298,7 @@ describe("ExerciseDrawer — overlay descriptions (db-content)", () => {
 describe("ExerciseDrawer — quotaState (B2.3b soft gate)", () => {
   const rook1Id = EXERCISES.rook[0].id; // "rook-1"
   const rook2Id = EXERCISES.rook[1].id; // "rook-2"
+  const rook3Id = EXERCISES.rook[2].id; // "rook-3"
 
   const quotaAtLimit = {
     isAtLimit: true,
@@ -377,7 +380,10 @@ describe("ExerciseDrawer — quotaState (B2.3b soft gate)", () => {
   });
 
   describe("labyrinth quota behavior", () => {
-    const sixStars = { [rook1Id]: 3, [rook2Id]: 3 };
+    // 3 exercises at 2★ each → 6★ over 3 exercises, satisfying
+    // LABYRINTH_MIN_EXERCISES (a 3+3 spread over only 2 exercises stays
+    // path-locked under the floor).
+    const sixStars = { [rook1Id]: 2, [rook2Id]: 2, [rook3Id]: 2 };
     function rookLabNodes(starsMap: Record<string, number>, bests: Record<string, number> = {}) {
       return buildTrainingPath({
         piece: "rook",

--- a/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/exercise-drawer.test.tsx
@@ -182,7 +182,9 @@ describe("ExerciseDrawer — labyrinth nodes (Slice 3D)", () => {
         onLabyrinthSelect={onLabyrinthSelect}
       />,
     );
-    expect(screen.getByText("Unlocks at 6★")).toBeInTheDocument();
+    expect(
+      screen.getByText("Unlocks at 6★ and 3 exercises"),
+    ).toBeInTheDocument();
     const locked = screen.getByText("Labyrinth 1").closest("button");
     expect(locked).toHaveAttribute("data-locked", "true");
     if (locked) fireEvent.click(locked);
@@ -250,8 +252,10 @@ describe("ExerciseDrawer — labyrinth nodes (Slice 3D)", () => {
     );
     // Section header is gone — one continuous path.
     expect(screen.queryByText("Labyrinths")).not.toBeInTheDocument();
-    // Labyrinth 1 (unlocks at 6★ → after 2 exercises) renders BEFORE
-    // the third exercise ("Center to edge", rook-3).
+    // Labyrinth 1's anchor is floored to LABYRINTH_MIN_EXERCISES (3), not
+    // the stars-only ceil(6/3)=2 — so it renders AFTER the third exercise
+    // ("Center to edge", rook-3) and BEFORE the fourth ("Corner capture",
+    // rook-4), never earlier than the floor allows.
     const texts = screen
       .getAllByRole("button", { hidden: true })
       .map((b) => b.textContent ?? "");
@@ -259,9 +263,14 @@ describe("ExerciseDrawer — labyrinth nodes (Slice 3D)", () => {
     const thirdExerciseAt = texts.findIndex((t) =>
       t.includes("Center to edge"),
     );
+    const fourthExerciseAt = texts.findIndex((t) =>
+      t.includes("Corner capture"),
+    );
     expect(labAt).toBeGreaterThan(-1);
     expect(thirdExerciseAt).toBeGreaterThan(-1);
-    expect(labAt).toBeLessThan(thirdExerciseAt);
+    expect(fourthExerciseAt).toBeGreaterThan(-1);
+    expect(labAt).toBeGreaterThan(thirdExerciseAt);
+    expect(labAt).toBeLessThan(fourthExerciseAt);
   });
 });
 

--- a/apps/web/src/components/exercises/__tests__/exercises-save-flow-logic.test.ts
+++ b/apps/web/src/components/exercises/__tests__/exercises-save-flow-logic.test.ts
@@ -1,9 +1,84 @@
-import { describe, it, expect } from "vitest";
-import {
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+// The gift is a Lite-only product and `unlockWelcomePackageGift` returns early
+// in Full mode. Tests default to Full, so the writer would be a no-op and every
+// assertion below would pass vacuously. The pure helpers in this file take
+// `liteMode` as a parameter and are untouched by this mock.
+vi.mock("@/lib/feature-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/feature-flags")>();
+  return { ...actual, CHESSCITO_MODE: "learn" as const, CHESSCITO_LITE_MODE: true };
+});
+
+const {
   shouldFireStarsConnectPrompt,
   shouldFireLocalSavedToast,
   shouldShowWPCtaInSlot,
-} from "../exercises-save-flow-logic";
+  unlockWelcomePackageGift,
+} = await import("../exercises-save-flow-logic");
+const { getWelcomePackageState, setWelcomePackageState } = await import(
+  "@/lib/welcome-package/storage"
+);
+
+/**
+ * `unlockWelcomePackageGift()` is the SINGLE writer of `welcomePackage.unlocked`
+ * — `useWelcomePackage().unlock()` was dead code and is gone. Nothing had ever
+ * covered it directly: the idempotence guard it inherited (`if (prev.unlocked)
+ * return`) lost its only test along with the API that used to share it.
+ *
+ * It is called on EVERY resolve where `first-reward` is on disk, not just the
+ * one that earned it. Without the guard, every subsequent solve would re-date
+ * `unlockedAt` — the timestamp would track the player's last exercise instead
+ * of the moment they earned the gift.
+ */
+describe("unlockWelcomePackageGift", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("unlocks a gift that has never been unlocked", () => {
+    unlockWelcomePackageGift();
+
+    const state = getWelcomePackageState();
+    expect(state.unlocked).toBe(true);
+    expect(state.unlockedAt).toBeTruthy();
+  });
+
+  it("is idempotent — a second call does not overwrite unlockedAt", () => {
+    unlockWelcomePackageGift();
+    const first = getWelcomePackageState().unlockedAt;
+
+    unlockWelcomePackageGift();
+
+    expect(getWelcomePackageState().unlockedAt).toBe(first);
+  });
+
+  it("never re-dates an unlock that arrived from somewhere else", () => {
+    const original = "2020-01-01T00:00:00.000Z";
+    setWelcomePackageState({
+      ...getWelcomePackageState(),
+      unlocked: true,
+      unlockedAt: original,
+    });
+
+    unlockWelcomePackageGift();
+
+    expect(getWelcomePackageState().unlockedAt).toBe(original);
+  });
+
+  it("leaves a CLAIMED gift untouched — it cannot un-claim or re-unlock it", () => {
+    unlockWelcomePackageGift();
+    setWelcomePackageState({
+      ...getWelcomePackageState(),
+      claimed: true,
+      claimedAt: new Date().toISOString(),
+    });
+    const before = getWelcomePackageState();
+
+    unlockWelcomePackageGift();
+
+    expect(getWelcomePackageState()).toEqual(before);
+  });
+});
 
 describe("shouldFireStarsConnectPrompt", () => {
   it("returns false in Lite even when disconnected and 3-star (suppressed in Lite)", () => {

--- a/apps/web/src/components/exercises/__tests__/mission-detail-sheet.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/mission-detail-sheet.test.tsx
@@ -22,9 +22,11 @@ function makeProgress(piece: PieceId, stars: number[]): PieceProgress {
   return { piece, currentId: null, stars: map };
 }
 
+/** Capped at 2/exercise (not 3) so a 6★ total naturally spans 3+ exercises —
+ *  matching LABYRINTH_MIN_EXERCISES instead of colliding it on exercise 2. */
 function starsTotaling(piece: PieceId, total: number): number[] {
   return EXERCISES[piece].map(() => {
-    const take = Math.min(3, total);
+    const take = Math.min(2, total);
     total -= take;
     return take;
   });

--- a/apps/web/src/components/exercises/exercise-drawer.tsx
+++ b/apps/web/src/components/exercises/exercise-drawer.tsx
@@ -13,7 +13,11 @@ import {
 } from '@/lib/game/exercises'
 import { useExerciseDescriptions } from '@/lib/content/catalog-context'
 import { PIECE_IMAGES } from '@/lib/content/editorial'
-import { interleaveTrainingRows, type TrainingNode } from '@/lib/training/path'
+import {
+  interleaveTrainingRows,
+  LABYRINTH_MIN_EXERCISES,
+  type TrainingNode,
+} from '@/lib/training/path'
 import { buildContentId } from '@/lib/daily/session-quota'
 import {
   BASE_PIXEL_OFFSET,
@@ -322,6 +326,7 @@ export function ExerciseDrawer({
                   ? node.unlock.type === 'stars'
                     ? tPath('labyrinthLockedStarsFormat', {
                         stars: node.unlock.min,
+                        exercises: LABYRINTH_MIN_EXERCISES,
                       })
                     : tPath('labyrinthLockedChain')
                   : tPath('labyrinthLabelFormat', { number: labIndex + 1 })
@@ -431,6 +436,7 @@ export function ExerciseDrawer({
                             {node.unlock.type === 'stars'
                               ? tPath('labyrinthLockedStarsFormat', {
                                   stars: node.unlock.min,
+                                  exercises: LABYRINTH_MIN_EXERCISES,
                                 })
                               : tPath('labyrinthLockedChain')}
                           </span>

--- a/apps/web/src/components/exercises/exercises-save-flow-logic.ts
+++ b/apps/web/src/components/exercises/exercises-save-flow-logic.ts
@@ -61,8 +61,13 @@ export function hasEarnedMilestone(id: MilestoneId, piece?: PieceId): boolean {
  * (`lib/hub/content-loop.ts`). Nothing in `lib/progression/**` writes that
  * flag — `migration.ts` only READS `welcomeClaimed`. Without this bridge the
  * milestone would render a celebration for a gift that is unreachable
- * forever. Idempotent, Lite-only (the gift does not exist in Full mode,
- * matching `useWelcomePackage().unlock()`).
+ * forever.
+ *
+ * The SINGLE writer of `unlocked` — `useWelcomePackage()` exposes no `unlock()`
+ * (it was dead and is gone); the hook only reads the flag this function sets.
+ * Idempotent: an already-unlocked gift keeps its original `unlockedAt`, so a
+ * re-entry can never re-date the unlock. Lite-only — the gift does not exist in
+ * Full mode, and `useWelcomePackage()` is a no-op there too.
  */
 export function unlockWelcomePackageGift(): void {
   if (!CHESSCITO_LITE_MODE) return;

--- a/apps/web/src/components/exercises/exercises-save-flow-logic.ts
+++ b/apps/web/src/components/exercises/exercises-save-flow-logic.ts
@@ -76,6 +76,24 @@ export function unlockWelcomePackageGift(): void {
 }
 
 /**
+ * Marks the Welcome Package gift as claimed. Same write as
+ * `useWelcomePackage().claim()`, done through storage so the exercises screen
+ * does not mount a SECOND stateful `useWelcomePackage()` in a tree where
+ * `<DailyTacticSlot>` already owns one (the duplicate-stateful-hook desync
+ * trap). Lite-only, matching the hook.
+ */
+export function claimWelcomePackageGift(): void {
+  if (!CHESSCITO_LITE_MODE) return;
+  const prev = getWelcomePackageState();
+  if (prev.claimed) return;
+  setWelcomePackageState({
+    ...prev,
+    claimed: true,
+    claimedAt: new Date().toISOString(),
+  });
+}
+
+/**
  * True when the post-3-stars "Connect to save" prompt should fire.
  * Suppressed in Lite: score-save is local-only and needs no wallet gate.
  */

--- a/apps/web/src/components/exercises/exercises-save-flow-logic.ts
+++ b/apps/web/src/components/exercises/exercises-save-flow-logic.ts
@@ -1,5 +1,79 @@
 import type { ContextAction } from "@/lib/game/context-action";
 import type { WelcomePackTileState } from "@/components/exercises/welcome-pack-tile";
+import type { PieceId, PieceProgress } from "@/lib/game/types";
+import { readPieceStars } from "@/lib/game/exercise-progress";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
+import { milestoneKey, type MilestoneId } from "@/lib/progression/types";
+import { CHESSCITO_LITE_MODE } from "@/lib/feature-flags";
+import {
+  getWelcomePackageState,
+  setWelcomePackageState,
+} from "@/lib/welcome-package/storage";
+
+const PIECES: PieceId[] = ["rook", "bishop", "knight", "pawn", "queen", "king"];
+
+/**
+ * Every piece's persisted best-stars map, shaped for `gatherMilestoneInput`.
+ *
+ * `freshStars` is REQUIRED for the piece under play. `useExerciseProgress`
+ * persists inside a `setProgress` updater, so at the moment the milestone
+ * machine is asked to evaluate (same tick as the solve) the localStorage
+ * write has NOT landed yet. Reading it back would evaluate the milestone
+ * conditions against the board as it was BEFORE the solve — the badge that
+ * the tenth star just earned would only surface on the next completion.
+ */
+export function buildProgressByPiece(
+  piece: PieceId,
+  freshStars: Record<string, number>,
+): Partial<Record<PieceId, PieceProgress>> {
+  const out: Partial<Record<PieceId, PieceProgress>> = {};
+  for (const id of PIECES) {
+    out[id] = {
+      piece: id,
+      currentId: null,
+      stars: id === piece ? freshStars : readPieceStars(id),
+    };
+  }
+  return out;
+}
+
+/** The stars map a solve leaves behind: best-of, sparse, never regressing. */
+export function withBestStars(
+  stars: Record<string, number>,
+  exerciseId: string,
+  earned: number,
+): Record<string, number> {
+  const best = Math.max(stars[exerciseId] ?? 0, earned);
+  if (best <= 0) return stars;
+  return { ...stars, [exerciseId]: best };
+}
+
+/** True when the milestone is already on disk (earned, whether or not it has
+ *  been celebrated). Reads the store, never the live queue. */
+export function hasEarnedMilestone(id: MilestoneId, piece?: PieceId): boolean {
+  return Boolean(getMilestoneStore().events[milestoneKey(id, piece)]);
+}
+
+/**
+ * Bridges the `first-reward` milestone to the Welcome Package gift.
+ *
+ * The gift tile gates on `welcomePackage.unlocked && !claimed`
+ * (`lib/hub/content-loop.ts`). Nothing in `lib/progression/**` writes that
+ * flag — `migration.ts` only READS `welcomeClaimed`. Without this bridge the
+ * milestone would render a celebration for a gift that is unreachable
+ * forever. Idempotent, Lite-only (the gift does not exist in Full mode,
+ * matching `useWelcomePackage().unlock()`).
+ */
+export function unlockWelcomePackageGift(): void {
+  if (!CHESSCITO_LITE_MODE) return;
+  const prev = getWelcomePackageState();
+  if (prev.unlocked) return;
+  setWelcomePackageState({
+    ...prev,
+    unlocked: true,
+    unlockedAt: new Date().toISOString(),
+  });
+}
 
 /**
  * True when the post-3-stars "Connect to save" prompt should fire.

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -44,6 +44,7 @@ import { ASSET_THEME, THEME_CONFIG } from "@/lib/theme";
 import { ContextualActionSlot } from "@/components/exercises/contextual-action-slot";
 import {
   buildProgressByPiece,
+  claimWelcomePackageGift,
   hasEarnedMilestone,
   shouldFireStarsConnectPrompt,
   shouldFireLocalSavedToast,
@@ -53,7 +54,10 @@ import {
 } from "@/components/exercises/exercises-save-flow-logic";
 import { UnlockOverlay } from "@/components/progression/unlock-overlay";
 import { useCelebrationQueue } from "@/lib/progression/use-celebration-queue";
+import type { CelebrationStep } from "@/lib/progression/celebration-queue";
 import { addNetStars, getDailyStars } from "@/lib/progression/stars";
+import { WelcomePackageModal } from "@/components/welcome-package/welcome-package-modal";
+import { useLiteWelcomeGiftClaim } from "@/lib/welcome-package/use-lite-welcome-gift-claim";
 import { PersistentDock } from "@/components/exercises/persistent-dock";
 import { TrophiesSheet } from "@/components/exercises/trophies-sheet";
 import { PurchaseConfirmSheet } from "@/components/exercises/purchase-confirm-sheet";
@@ -675,6 +679,14 @@ export function ExercisesScreen({
    *  the celebration, not the paywall. */
   const celebration = useCelebrationQueue();
 
+  /** The Welcome Package GIFT — the thing `first-reward` actually unlocks.
+   *  NOT `useWelcomePackClaim` (the server shield Welcome Pack): a different
+   *  product, a different endpoint. The gift is claimed exactly the way
+   *  `<DailyTacticSlot>` claims it: `<WelcomePackageModal>` driven by
+   *  `useLiteWelcomeGiftClaim`, writing `claimed` on success. */
+  const [welcomeGiftOpen, setWelcomeGiftOpen] = useState(false);
+  const welcomeGiftClaim = useLiteWelcomeGiftClaim();
+
   // Phase 2b-2: read the active pools from the catalog context (baseline
   // EXERCISES when no provider is mounted → byte-identical flag-off), so
   // this screen's pool reads agree with the hook's. Phase 2c mounts the
@@ -1264,12 +1276,18 @@ export function ExercisesScreen({
    * localStorage write happens inside a `setProgress` updater and has not
    * landed yet when this runs. Omitted by the labyrinth path, which changes
    * no exercise stars (labyrinth stars feed the daily ledger only).
+   *
+   * Returns the queue it just built, so the caller can tell IN THE SAME TICK
+   * which moments the machine now owns (`celebration.current` is state and is
+   * still the pre-resolve value inside this closure).
    */
-  function resolveMilestones(starsForPiece?: Record<string, number>) {
+  function resolveMilestones(
+    starsForPiece?: Record<string, number>,
+  ): CelebrationStep[] {
     // Read BEFORE `resolve` records it — afterwards it is always true.
     const hadGreatSessionBefore = hasEarnedMilestone("first-great-session");
 
-    celebration.resolve({
+    const steps = celebration.resolve({
       piece: selectedPiece,
       progressByPiece: buildProgressByPiece(
         selectedPiece,
@@ -1283,11 +1301,19 @@ export function ExercisesScreen({
         labyrinthCatalog[selectedPiece].map((lab) => lab.id),
       ),
       hadGreatSessionBefore,
+      // The gift is a Lite-only product: `unlockWelcomePackageGift()` and
+      // `useWelcomePackage()` are both no-ops in Full mode. Firing
+      // `first-reward` there would celebrate a gift that cannot exist and
+      // hand the player a CTA that opens an empty modal. Gate the MILESTONE,
+      // not just its side effect.
+      giftAvailable: CHESSCITO_LITE_MODE,
     });
 
     // The gift has no other writer. `resolve` already persisted the event, so
     // reading it back here is a read of committed state, not a guess.
     if (hasEarnedMilestone("first-reward")) unlockWelcomePackageGift();
+
+    return steps;
   }
 
   /** Always-fresh mirror so `handleLabyrinthMove` (a useCallback with a
@@ -1349,6 +1375,7 @@ export function ExercisesScreen({
       // best contributes nothing — and only then evaluate the milestones, so
       // the machine sees today's real numbers. A frozen replay persists
       // nothing, so it credits nothing.
+      let badgeMomentOwnedByQueue = false;
       {
         const earnedStars = computeStars(movesCount, currentExercise.optimalMoves);
         const previousBest = progress.stars[currentExercise.id] ?? 0;
@@ -1356,7 +1383,18 @@ export function ExercisesScreen({
           ? progress.stars
           : withBestStars(progress.stars, currentExercise.id, earnedStars);
         if (!scoringFrozen) addNetStars(previousBest, earnedStars);
-        resolveMilestones(starsAfterSolve);
+        const steps = resolveMilestones(starsAfterSolve);
+        // The badge moment has exactly ONE owner. When this solve made the
+        // machine emit `piece-badge-eligible` (as its own step, or absorbed
+        // into MASTERY), `<UnlockOverlay>` owns it — it carries the claim CTA
+        // the legacy `<BadgeEarnedPrompt>` never had. Priming the legacy
+        // prompt anyway would leave a second celebration ready to pop the
+        // instant the queue drains: the back-to-back this design forbids.
+        badgeMomentOwnedByQueue = steps.some(
+          (step) =>
+            step.id === "piece-badge-eligible" ||
+            step.absorbed.includes("piece-badge-eligible"),
+        );
       }
 
       // Phase 2 nudge: first ★★★ while disconnected → "Connect to save".
@@ -1391,7 +1429,10 @@ export function ExercisesScreen({
         const newTotal = totalStars + starDelta;
 
         if (newTotal >= BADGE_THRESHOLD && !hasClaimedBadge) {
-          setShowBadgeEarned(true);
+          // Only the loser of the ownership contest primes its prompt. The
+          // timers below run either way, so the piece-complete hand-off keeps
+          // its existing 1.5s + 13.5s shape.
+          if (!badgeMomentOwnedByQueue) setShowBadgeEarned(true);
           // Spec: local-save toast fires at t=1500ms (same window as normal path),
           // AFTER the WELL DONE flash. Safety-net schedules 13.5s later so the
           // total auto-dismiss delay from exercise completion stays ~15s.
@@ -1699,15 +1740,20 @@ export function ExercisesScreen({
       // `celebratedAt` on the absorbed events first, `selectPending` would
       // then return nothing, and the release would silently clear the queue
       // to []: a Great Focus Session lost along with the cancelled tx.
-      void handleClaimBadge(step.piece as PieceKey | undefined).then(
-        (claimed) => {
+      void handleClaimBadge(step.piece as PieceKey | undefined)
+        .then((claimed) => {
           if (claimed) {
             celebration.dismissCurrent();
             return;
           }
           celebration.releaseAbsorbed(step);
-        },
-      );
+        })
+        // `run()` never throws, but `handleClaimBadge` can still reject
+        // outside it (a throwing `applyBadgeClaimSuccess`, a failing refetch).
+        // An unhandled rejection would strand `celebration.current` non-null
+        // FOREVER — freezing the queue and, because the daily-limit banner is
+        // gated on `current === null`, permanently hiding the limit too.
+        .catch(() => celebration.releaseAbsorbed(step));
       return;
     }
 
@@ -1715,9 +1761,13 @@ export function ExercisesScreen({
     celebration.dismissCurrent();
 
     if (step.id === "first-reward") {
-      // Straight into the claim the gift overlay just promised.
-      if (welcomePack.state === "connect") welcomePack.onConnect();
-      else void welcomePack.onClaim();
+      // The GIFT the player just won — `welcomePackage.unlocked`, claimed
+      // through `<WelcomePackageModal>`. NOT `welcomePack.onClaim()`: that is
+      // `useWelcomePackClaim`, the server SHIELD Welcome Pack — a different
+      // product with a `personal_sign` → `/api/welcome-pack/claim` round-trip,
+      // never gated on this unlock. The overlay promised the gift; the primary
+      // must open the gift.
+      setWelcomeGiftOpen(true);
       return;
     }
 
@@ -2775,7 +2825,21 @@ export function ExercisesScreen({
           />
         ) : null}
 
-        {showPieceComplete && !showBadgeEarned ? (
+        {/* ── The one-dialog rule ──────────────────────────────────────────
+         *  Every popup below is suppressed while the milestone machine has a
+         *  recognition pending. The machine owns the celebration moment; a
+         *  legacy popup rendering alongside `<UnlockOverlay>` would stack two
+         *  `role="dialog"` shells (both are `VictoryPopupShell`, both
+         *  `z-[70]`) and drop the intensity right after the climax.
+         *
+         *  These are RENDER gates, not state gates: the state survives, so
+         *  each popup resumes the moment the queue drains — which is the
+         *  intended flow for the piece-complete menu, the labyrinth
+         *  score card and the tx result overlay (they are continuations, not
+         *  celebrations). The one popup that must NEVER resurface is the
+         *  legacy badge prompt; it is never primed at all when the queue owns
+         *  the badge moment (see `badgeMomentOwnedByQueue` in `handleMove`). */}
+        {showPieceComplete && !showBadgeEarned && celebration.current === null ? (
           <PieceCompletePrompt
             pieceType={selectedPiece}
             nextPiece={nextPiece ?? null}
@@ -2821,7 +2885,7 @@ export function ExercisesScreen({
           />
         ) : null}
 
-        {labyrinthCompleted ? (
+        {labyrinthCompleted && celebration.current === null ? (
           <LabyrinthCompleteOverlay
             moves={labyrinthCompleted.moves}
             optimalMoves={labyrinthCompleted.optimal}
@@ -2859,7 +2923,27 @@ export function ExercisesScreen({
           />
         ) : null}
 
-        {showBadgeEarned ? (
+        {/* The destination of `first-reward`'s primary. Same modal, same claim
+         *  hook, same `claimed` write `<DailyTacticSlot>` uses — the gift the
+         *  overlay actually promised. */}
+        {welcomeGiftOpen && celebration.current === null ? (
+          <WelcomePackageModal
+            phase={welcomeGiftClaim.claimPhase}
+            onClaim={() => welcomeGiftClaim.handleClaim(claimWelcomePackageGift)}
+            onDismiss={() => {
+              if (welcomeGiftClaim.claimPhase === "signing") return;
+              welcomeGiftClaim.handleSuccess();
+              setWelcomeGiftOpen(false);
+            }}
+            onSuccess={() => {
+              welcomeGiftClaim.handleSuccess();
+              setWelcomeGiftOpen(false);
+            }}
+            onRetry={welcomeGiftClaim.handleRetry}
+          />
+        ) : null}
+
+        {showBadgeEarned && celebration.current === null ? (
           <BadgeEarnedPrompt
             pieceType={selectedPiece}
             totalStars={totalStars}
@@ -2871,7 +2955,10 @@ export function ExercisesScreen({
           />
         ) : null}
 
-        {resultOverlay ? (
+        {/* A failed claim sets this in the SAME tick as `releaseAbsorbed` —
+         *  without the gate the error card would stack on the recognition it
+         *  just released. Recognition first, then the error. */}
+        {resultOverlay && celebration.current === null ? (
           <ResultOverlay
             variant={resultOverlay.variant}
             pieceType={selectedPiece}

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -319,7 +319,7 @@ export function ExercisesScreen({
   const tFooter = useTranslations("FOOTER_CTA_COPY");
   const tResult = useTranslations("RESULT_OVERLAY_COPY");
   const router = useRouter();
-  const { address, isConnected } = useAccount();
+  const { address, isConnected, status: accountStatus } = useAccount();
   const starsConnectPrompt = useConnectPrompt("stars");
   const chainId = useChainId();
   const publicClient = usePublicClient({ chainId });
@@ -1005,7 +1005,6 @@ export function ExercisesScreen({
   const BADGE_LEVEL_IDS = [1n, 2n, 3n, 4n, 5n, 6n] as const;
   const {
     data: allBadgesData,
-    isLoading: isBadgesLoading,
     refetch: refetchAllBadges,
   } = useReadContracts({
     contracts: BADGE_LEVEL_IDS.map((lid) => ({
@@ -1056,7 +1055,16 @@ export function ExercisesScreen({
   }, [labyrinthCatalog]);
 
   useMilestoneSeeding({
-    ready: !isBadgesLoading,
+    // Mirrors the hub's gate (`legacy-hub-client.tsx`). NOT `!isBadgesLoading`:
+    // the badge read is `enabled: Boolean(address && badgesAddress)`, and a
+    // DISABLED TanStack query reports `isLoading === false` — so during
+    // wagmi's reconnect (address still undefined) the screen would call itself
+    // ready, seed the profile with `badgeClaimed: false`, stamp it migrated,
+    // and then fire a retroactive MASTERY overlay on the veteran's next solve.
+    // A disabled read is not the same as "no badges"; only `disconnected` is.
+    ready:
+      accountStatus === "disconnected" ||
+      (accountStatus === "connected" && allBadgesData !== undefined),
     badgeClaimedByPiece: badgesClaimed,
     labyrinthIdsByPiece,
     giftAvailable: CHESSCITO_LITE_MODE,
@@ -1319,6 +1327,12 @@ export function ExercisesScreen({
    */
   function resolveMilestones(
     starsForPiece?: Record<string, number>,
+    /** Forces an input the React closure cannot possibly know yet. The only
+     *  caller is the badge-claim success path: `badgesClaimed` was captured at
+     *  render time and `refetchAllBadges()` has not landed, so BOTH still read
+     *  `false` for the piece the chain just minted. Without this, `mastery`
+     *  cannot be evaluated at the moment it is actually earned. */
+    overrides?: { badgeClaimed?: boolean },
   ): CelebrationStep[] {
     // Read BEFORE `resolve` records it — afterwards it is always true.
     const hadGreatSessionBefore = hasEarnedMilestone("first-great-session");
@@ -1331,7 +1345,8 @@ export function ExercisesScreen({
       ),
       dailyStars: getDailyStars(),
       sessionQuotaExhausted: isSessionOver(getDailySession()),
-      badgeClaimed: badgesClaimed[selectedPiece] === true,
+      badgeClaimed:
+        overrides?.badgeClaimed ?? badgesClaimed[selectedPiece] === true,
       allLabyrinthsComplete: areAllLabyrinthsSolved(
         selectedPiece,
         labyrinthCatalog[selectedPiece].map((lab) => lab.id),
@@ -1429,7 +1444,9 @@ export function ExercisesScreen({
         badgeMomentOwnedByQueue = steps.some(
           (step) =>
             step.id === "piece-badge-eligible" ||
-            step.absorbed.includes("piece-badge-eligible"),
+            step.absorbed.some(
+              (event) => event.id === "piece-badge-eligible",
+            ),
         );
       }
 
@@ -1779,7 +1796,24 @@ export function ExercisesScreen({
       void handleClaimBadge(step.piece as PieceKey | undefined)
         .then((claimed) => {
           if (claimed) {
+            // A solve is otherwise the ONLY trigger of `resolve()`, but
+            // `mastery` needs `badgeClaimed && allLabyrinthsComplete` — a
+            // player who finished every labyrinth first earns the crown HERE,
+            // on the claim, not on a solve. Without this re-resolve the crown
+            // surfaces later, bolted onto an unrelated (possibly replayed)
+            // exercise.
+            //
+            // Dismiss FIRST: `resolve()` REPLACES the queue, so re-resolving
+            // before the dismiss would rebuild a queue whose head is `mastery`
+            // with `piece-badge-eligible` absorbed into it — and the very next
+            // `dismissCurrent()` would stamp the crown celebrated without ever
+            // rendering it. Dismissing first retires the badge step, then the
+            // resolve enqueues the crown alone.
             celebration.dismissCurrent();
+            // `badgesClaimed` is a render-time closure and `refetchAllBadges()`
+            // has not landed; both still say `false`. Force the value the chain
+            // just confirmed.
+            resolveMilestones(undefined, { badgeClaimed: true });
             return;
           }
           celebration.releaseAbsorbed(step);

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -43,10 +43,17 @@ import { MINI_ARENA_SETUPS } from "@/lib/game/mini-arena";
 import { ASSET_THEME, THEME_CONFIG } from "@/lib/theme";
 import { ContextualActionSlot } from "@/components/exercises/contextual-action-slot";
 import {
+  buildProgressByPiece,
+  hasEarnedMilestone,
   shouldFireStarsConnectPrompt,
   shouldFireLocalSavedToast,
   shouldShowWPCtaInSlot,
+  unlockWelcomePackageGift,
+  withBestStars,
 } from "@/components/exercises/exercises-save-flow-logic";
+import { UnlockOverlay } from "@/components/progression/unlock-overlay";
+import { useCelebrationQueue } from "@/lib/progression/use-celebration-queue";
+import { addNetStars, getDailyStars } from "@/lib/progression/stars";
 import { PersistentDock } from "@/components/exercises/persistent-dock";
 import { TrophiesSheet } from "@/components/exercises/trophies-sheet";
 import { PurchaseConfirmSheet } from "@/components/exercises/purchase-confirm-sheet";
@@ -159,6 +166,7 @@ import {
   getDailySession,
   isAtFreeLimit,
   isAtHardMax,
+  isSessionOver,
   shouldFreezeScoring,
 } from "@/lib/daily/session-quota";
 import { subscribeToDailySessionChanges } from "@/lib/daily/session-events";
@@ -661,6 +669,11 @@ export function ExercisesScreen({
     attemptSeq,
     incrementAttemptSeq,
   } = useExerciseProgress(selectedPiece, rotationOptions);
+
+  /** The progression milestone machine. Drained BEFORE the daily-limit guard
+   *  is ever consulted: the player who burns the quota while struggling gets
+   *  the celebration, not the paywall. */
+  const celebration = useCelebrationQueue();
 
   // Phase 2b-2: read the active pools from the catalog context (baseline
   // EXERCISES when no provider is mounted → byte-identical flag-off), so
@@ -1241,6 +1254,48 @@ export function ExercisesScreen({
     timerStart.current = 0;
   }
 
+  /**
+   * Steps 2–4 of the evaluation order: evaluate every milestone condition,
+   * PERSIST every fired event, then build the celebration queue. Called ONLY
+   * after the activity has been recorded (stars, consumed slot) and after the
+   * daily star ledger has taken the net improvement, so it sees fresh numbers.
+   *
+   * `starsForPiece` is the post-solve map for `selectedPiece` — the hook's
+   * localStorage write happens inside a `setProgress` updater and has not
+   * landed yet when this runs. Omitted by the labyrinth path, which changes
+   * no exercise stars (labyrinth stars feed the daily ledger only).
+   */
+  function resolveMilestones(starsForPiece?: Record<string, number>) {
+    // Read BEFORE `resolve` records it — afterwards it is always true.
+    const hadGreatSessionBefore = hasEarnedMilestone("first-great-session");
+
+    celebration.resolve({
+      piece: selectedPiece,
+      progressByPiece: buildProgressByPiece(
+        selectedPiece,
+        starsForPiece ?? progress.stars,
+      ),
+      dailyStars: getDailyStars(),
+      sessionQuotaExhausted: isSessionOver(getDailySession()),
+      badgeClaimed: badgesClaimed[selectedPiece] === true,
+      allLabyrinthsComplete: areAllLabyrinthsSolved(
+        selectedPiece,
+        labyrinthCatalog[selectedPiece].map((lab) => lab.id),
+      ),
+      hadGreatSessionBefore,
+    });
+
+    // The gift has no other writer. `resolve` already persisted the event, so
+    // reading it back here is a read of committed state, not a guess.
+    if (hasEarnedMilestone("first-reward")) unlockWelcomePackageGift();
+  }
+
+  /** Always-fresh mirror so `handleLabyrinthMove` (a useCallback with a
+   *  narrow dep list) can resolve milestones without re-creating itself on
+   *  every render. Same latest-value-ref discipline as `useCelebrationQueue`. */
+  const resolveMilestonesRef = useRef(resolveMilestones);
+  resolveMilestonesRef.current = resolveMilestones;
+
   function handleMove(position: BoardPosition, movesCount: number) {
     const isTarget =
       position.file === currentExercise.targetPos.file &&
@@ -1285,6 +1340,23 @@ export function ExercisesScreen({
       // B2.3a: track extra content consumption (Lite-only; idempotent).
       if (CHESSCITO_LITE_MODE) {
         recordExtraConsumed(buildContentId("exercise", selectedPiece, currentExercise.id));
+      }
+
+      // ── Evaluation order, steps 1 → 4 ────────────────────────────────
+      // The activity is now recorded (stars via completeExercise, the
+      // consumed slot via recordExtraConsumed). Credit the daily star ledger
+      // with the NET improvement — a replay that does not beat the previous
+      // best contributes nothing — and only then evaluate the milestones, so
+      // the machine sees today's real numbers. A frozen replay persists
+      // nothing, so it credits nothing.
+      {
+        const earnedStars = computeStars(movesCount, currentExercise.optimalMoves);
+        const previousBest = progress.stars[currentExercise.id] ?? 0;
+        const starsAfterSolve = scoringFrozen
+          ? progress.stars
+          : withBestStars(progress.stars, currentExercise.id, earnedStars);
+        if (!scoringFrozen) addNetStars(previousBest, earnedStars);
+        resolveMilestones(starsAfterSolve);
       }
 
       // Phase 2 nudge: first ★★★ while disconnected → "Connect to save".
@@ -1522,14 +1594,17 @@ export function ExercisesScreen({
     setShowPieceComplete(true);
   }
 
-  async function handleClaimBadge(piece?: PieceKey) {
+  /** Resolves TRUE only when the badge is confirmed on-chain. The celebration
+   *  queue reads this: a cancelled or failed claim must NOT consume the
+   *  recognition it was opened from. */
+  async function handleClaimBadge(piece?: PieceKey): Promise<boolean> {
     const claimLevelId = piece ? getLevelId(piece) : levelId;
     if (!address || !badgesAddress || !isConnected || !isCorrectChain || claimLevelId <= 0n) {
-      return;
+      return false;
     }
     // Prevent double-claim (stale cache or rapid taps)
     const targetPiece = piece ?? selectedPiece;
-    if (badgesClaimed[targetPiece] || isClaimBusy) return;
+    if (badgesClaimed[targetPiece] || isClaimBusy) return false;
 
     setLastError(null);
     setClaimingPiece(targetPiece);
@@ -1558,11 +1633,11 @@ export function ExercisesScreen({
         confirm: confirmReceipt,
       });
 
-      if (outcome.status === "busy") return;
+      if (outcome.status === "busy") return false;
 
       if (outcome.status === "cancelled") {
         track("badge_claim_tx", { stage: "cancelled", piece: targetPiece });
-        return;
+        return false;
       }
 
       if (outcome.status === "failed") {
@@ -1575,7 +1650,7 @@ export function ExercisesScreen({
           retryAction: () => void handleClaimBadge(piece),
         });
         console.warn("[MiniPayTx] error", { label: "claim-badge", levelId: Number(claimLevelId), error: message });
-        return;
+        return false;
       }
 
       // Verified on-chain from here down. `stage: "success"` now means the tx
@@ -1601,9 +1676,68 @@ export function ExercisesScreen({
         { piece: targetPiece, nextPiece: nextUnlock, txHash: outcome.txHash },
       );
       console.info("[MiniPayTx] result", { label: "claim-badge", txHash: outcome.txHash, levelId: Number(claimLevelId) });
+      return true;
     } finally {
       setClaimingPiece(null);
     }
+  }
+
+  /**
+   * The overlay's primary CTA — takes the player to what they just unlocked.
+   *
+   * `celebration.current` is read ONCE into a local const: every branch below
+   * mutates the queue, so re-reading `celebration.current` after the first
+   * call would see a DIFFERENT step (or null) from the same render closure.
+   */
+  function handleCelebrationPrimary() {
+    const step = celebration.current;
+    if (!step) return;
+
+    if (step.id === "piece-badge-eligible") {
+      // Recognition never depends on signing. On cancel/failure we call
+      // `releaseAbsorbed` and NOTHING else — `dismissCurrent` would stamp
+      // `celebratedAt` on the absorbed events first, `selectPending` would
+      // then return nothing, and the release would silently clear the queue
+      // to []: a Great Focus Session lost along with the cancelled tx.
+      void handleClaimBadge(step.piece as PieceKey | undefined).then(
+        (claimed) => {
+          if (claimed) {
+            celebration.dismissCurrent();
+            return;
+          }
+          celebration.releaseAbsorbed(step);
+        },
+      );
+      return;
+    }
+
+    celebration.openContent(step.id, step.piece);
+    celebration.dismissCurrent();
+
+    if (step.id === "first-reward") {
+      // Straight into the claim the gift overlay just promised.
+      if (welcomePack.state === "connect") welcomePack.onConnect();
+      else void welcomePack.onClaim();
+      return;
+    }
+
+    if (step.id === "first-labyrinth") {
+      const lab = getNextChallenge(trainingPathRef.current);
+      if (lab) {
+        handleLabyrinthSelect(lab.id);
+        resetBoard();
+      }
+      return;
+    }
+
+    if (step.id === "special-training") {
+      // The Special Training tile lives on the hub right-rail.
+      router.push("/hub");
+      return;
+    }
+
+    // mastery / great-focus-session: recognitions, not destinations. The
+    // primary is "Continue" — closing IS returning to the experience.
   }
 
   async function handleSubmitScore(opts?: { silent?: boolean }) {
@@ -2153,6 +2287,17 @@ export function ExercisesScreen({
         isNewBest,
       });
 
+      // The daily star ledger is fed by exercises AND labyrinths, always as
+      // net improvement — without this a player who spends the session in the
+      // mazes never reaches a Great Focus Session. Labyrinth stars stay OUT of
+      // `pieceStars` (gather-input owns that rule); only the ledger sees them.
+      const previousLabStars =
+        previousBest === null
+          ? 0
+          : labyrinthStars(previousBest, activeLabyrinth.optimalMoves);
+      addNetStars(previousLabStars, stars);
+      resolveMilestonesRef.current();
+
       track("labyrinth_complete", {
         labyrinth_id: activeLabyrinth.id,
         piece: selectedPiece,
@@ -2290,7 +2435,11 @@ export function ExercisesScreen({
             }
           />
         </div>
-        {quotaDisplayState?.isAtLimit && (
+        {/* Step 7 of the evaluation order: the session limit is consulted ONLY
+         *  once every pending recognition has drained. The wall never arrives
+         *  before the praise — a player who burns the quota while struggling
+         *  gets the celebration, not the paywall. */}
+        {celebration.current === null && quotaDisplayState?.isAtLimit && (
           <DailyLimitBanner
             isHardMax={quotaDisplayState.isHardMax}
             onBack={() => router.push("/")}
@@ -2697,6 +2846,16 @@ export function ExercisesScreen({
                   }
                 : undefined
             }
+          />
+        ) : null}
+
+        {/* One dialog, always: the queue emits a single step at a time and
+         *  absorbs lower majors into it as lines. */}
+        {celebration.current ? (
+          <UnlockOverlay
+            step={celebration.current}
+            onPrimary={handleCelebrationPrimary}
+            onDismiss={celebration.dismissCurrent}
           />
         ) : null}
 

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -54,7 +54,10 @@ import {
 } from "@/components/exercises/exercises-save-flow-logic";
 import { UnlockOverlay } from "@/components/progression/unlock-overlay";
 import { useCelebrationQueue } from "@/lib/progression/use-celebration-queue";
-import { useMilestoneSeeding } from "@/lib/progression/use-milestone-seeding";
+import {
+  isMilestoneSeedReady,
+  useMilestoneSeeding,
+} from "@/lib/progression/use-milestone-seeding";
 import type { CelebrationStep } from "@/lib/progression/celebration-queue";
 import { addNetStars, getDailyStars } from "@/lib/progression/stars";
 import { WelcomePackageModal } from "@/components/welcome-package/welcome-package-modal";
@@ -72,6 +75,8 @@ import {
   dispatchShieldChange,
   subscribeToShieldChanges,
 } from "@/lib/shop/shield-events";
+import { readPieceStars } from "@/lib/game/exercise-progress";
+import { hasSeededMilestones } from "@/lib/progression/seed-milestones";
 import { useExerciseProgress } from "@/hooks/use-exercise-progress";
 import { useExerciseCatalog, useLabyrinthCatalog } from "@/lib/content/catalog-context";
 import { useRotationSteering } from "@/hooks/use-rotation-steering";
@@ -1055,16 +1060,15 @@ export function ExercisesScreen({
   }, [labyrinthCatalog]);
 
   useMilestoneSeeding({
-    // Mirrors the hub's gate (`legacy-hub-client.tsx`). NOT `!isBadgesLoading`:
-    // the badge read is `enabled: Boolean(address && badgesAddress)`, and a
-    // DISABLED TanStack query reports `isLoading === false` — so during
-    // wagmi's reconnect (address still undefined) the screen would call itself
-    // ready, seed the profile with `badgeClaimed: false`, stamp it migrated,
-    // and then fire a retroactive MASTERY overlay on the veteran's next solve.
-    // A disabled read is not the same as "no badges"; only `disconnected` is.
-    ready:
-      accountStatus === "disconnected" ||
-      (accountStatus === "connected" && allBadgesData !== undefined),
+    // ONE gate, shared with the hub (`legacy-hub-client.tsx`) — see
+    // `isMilestoneSeedReady` for why a disabled read is not "no badges" and
+    // why an unsupported chain never becomes ready. `resolveMilestones`
+    // carries the other half of that contract: it refuses to run while the
+    // profile is unseeded.
+    ready: isMilestoneSeedReady({
+      accountStatus,
+      badgeStateKnown: allBadgesData !== undefined,
+    }),
     badgeClaimedByPiece: badgesClaimed,
     labyrinthIdsByPiece,
     giftAvailable: CHESSCITO_LITE_MODE,
@@ -1327,29 +1331,55 @@ export function ExercisesScreen({
    */
   function resolveMilestones(
     starsForPiece?: Record<string, number>,
-    /** Forces an input the React closure cannot possibly know yet. The only
+    /** Forces inputs the React closure cannot possibly know yet. The only
      *  caller is the badge-claim success path: `badgesClaimed` was captured at
      *  render time and `refetchAllBadges()` has not landed, so BOTH still read
      *  `false` for the piece the chain just minted. Without this, `mastery`
-     *  cannot be evaluated at the moment it is actually earned. */
-    overrides?: { badgeClaimed?: boolean },
+     *  cannot be evaluated at the moment it is actually earned.
+     *
+     *  `piece` travels WITH `badgeClaimed` — they are one fact about one
+     *  piece. The claim is scoped to `step.piece`, which is NOT necessarily
+     *  `selectedPiece`: a `piece-badge-eligible:rook` event persists PENDING
+     *  across a reload, and the player can come back on bishop and claim it
+     *  from the overlay. Forcing `badgeClaimed: true` onto whatever piece
+     *  happened to be selected would evaluate `mastery` (badge + labyrinths,
+     *  no star gate) for a piece whose badge was never minted — a false crown,
+     *  stamped celebrated forever. */
+    overrides?: { piece?: PieceKey; badgeClaimed?: boolean },
   ): CelebrationStep[] {
+    // No seed, no resolve. An unseeded profile is one whose on-chain badge
+    // state is still UNKNOWN (`useMilestoneSeeding` stays un-ready while a
+    // wallet is connected to an unsupported chain — `getBadgesAddress` is
+    // null there, so the read never runs and `allBadgesData` is `undefined`
+    // forever). Resolving in that window hands a veteran the full retroactive
+    // parade — first-reward, first-labyrinth, special-training,
+    // piece-badge-eligible — for history they lived through months ago. The
+    // seed is the ONLY thing that suppresses it, so nothing may fire before
+    // it lands. Milestones are not lost: the seed stamps them on the next
+    // mount with a known badge state, and anything genuinely new is derived
+    // from persisted progress on the next solve.
+    if (!hasSeededMilestones()) return [];
+
+    const piece = overrides?.piece ?? selectedPiece;
+
     // Read BEFORE `resolve` records it — afterwards it is always true.
     const hadGreatSessionBefore = hasEarnedMilestone("first-great-session");
 
     const steps = celebration.resolve({
-      piece: selectedPiece,
+      piece,
       progressByPiece: buildProgressByPiece(
-        selectedPiece,
-        starsForPiece ?? progress.stars,
+        piece,
+        // Fresh stars exist only for the piece under play. When the caller
+        // overrides the piece (the badge claim), its stars come off the disk.
+        starsForPiece ??
+          (piece === selectedPiece ? progress.stars : readPieceStars(piece)),
       ),
       dailyStars: getDailyStars(),
       sessionQuotaExhausted: isSessionOver(getDailySession()),
-      badgeClaimed:
-        overrides?.badgeClaimed ?? badgesClaimed[selectedPiece] === true,
+      badgeClaimed: overrides?.badgeClaimed ?? badgesClaimed[piece] === true,
       allLabyrinthsComplete: areAllLabyrinthsSolved(
-        selectedPiece,
-        labyrinthCatalog[selectedPiece].map((lab) => lab.id),
+        piece,
+        (labyrinthCatalog[piece] ?? []).map((lab) => lab.id),
       ),
       hadGreatSessionBefore,
       // The gift is a Lite-only product: `unlockWelcomePackageGift()` and
@@ -1793,7 +1823,14 @@ export function ExercisesScreen({
       // `celebratedAt` on the absorbed events first, `selectPending` would
       // then return nothing, and the release would silently clear the queue
       // to []: a Great Focus Session lost along with the cancelled tx.
-      void handleClaimBadge(step.piece as PieceKey | undefined)
+      // The piece the CHAIN is about to mint — not the one on screen. A
+      // pending `piece-badge-eligible:rook` survives a reload, and the player
+      // can switch to bishop before tapping CLAIM. `handleClaimBadge` already
+      // resolves the fallback the same way; naming it here keeps the claim and
+      // the re-resolve below reading from ONE scope.
+      const claimedPiece = (step.piece as PieceKey | undefined) ?? selectedPiece;
+
+      void handleClaimBadge(claimedPiece)
         .then((claimed) => {
           if (claimed) {
             // A solve is otherwise the ONLY trigger of `resolve()`, but
@@ -1812,8 +1849,14 @@ export function ExercisesScreen({
             celebration.dismissCurrent();
             // `badgesClaimed` is a render-time closure and `refetchAllBadges()`
             // has not landed; both still say `false`. Force the value the chain
-            // just confirmed.
-            resolveMilestones(undefined, { badgeClaimed: true });
+            // just confirmed — AND the piece it confirmed it FOR. The forced
+            // field and the rest of the input must describe the same piece, or
+            // `mastery` gets evaluated for `selectedPiece` with someone else's
+            // badge.
+            resolveMilestones(undefined, {
+              piece: claimedPiece,
+              badgeClaimed: true,
+            });
             return;
           }
           celebration.releaseAbsorbed(step);

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -2839,7 +2839,23 @@ export function ExercisesScreen({
          *  celebrations). The one popup that must NEVER resurface is the
          *  legacy badge prompt; it is never primed at all when the queue owns
          *  the badge moment (see `badgeMomentOwnedByQueue` in `handleMove`). */}
-        {showPieceComplete && !showBadgeEarned && celebration.current === null ? (
+        {/* `<PieceCompletePrompt>` is the LOWEST-priority modal on this screen:
+         *  it is a continuation menu, not a moment. Its 15s `autoReset` timer
+         *  is armed by the solve and keeps ticking through a MiniPay round
+         *  trip, so on the badge path `showPieceComplete` routinely flips true
+         *  while the player is still signing. When the claim confirms,
+         *  `applyBadgeClaimSuccess` sets `resultOverlay` + `unlockedPiece` and
+         *  the queue drains in the SAME commit — every gate below would open
+         *  at once and stack two `aria-modal` surfaces. Yielding to each of
+         *  them defers the menu; it never swallows it, because none of these
+         *  clears `showPieceComplete`. The player still lands on it, alone,
+         *  once the last one is closed. */}
+        {showPieceComplete &&
+        !showBadgeEarned &&
+        !resultOverlay &&
+        !unlockedPiece &&
+        !welcomeGiftOpen &&
+        celebration.current === null ? (
           <PieceCompletePrompt
             pieceType={selectedPiece}
             nextPiece={nextPiece ?? null}

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/components/exercises/exercises-save-flow-logic";
 import { UnlockOverlay } from "@/components/progression/unlock-overlay";
 import { useCelebrationQueue } from "@/lib/progression/use-celebration-queue";
+import { useMilestoneSeeding } from "@/lib/progression/use-milestone-seeding";
 import type { CelebrationStep } from "@/lib/progression/celebration-queue";
 import { addNetStars, getDailyStars } from "@/lib/progression/stars";
 import { WelcomePackageModal } from "@/components/welcome-package/welcome-package-modal";
@@ -1002,7 +1003,11 @@ export function ExercisesScreen({
 
   // Read hasClaimedBadge for all 6 pieces (batched)
   const BADGE_LEVEL_IDS = [1n, 2n, 3n, 4n, 5n, 6n] as const;
-  const { data: allBadgesData, refetch: refetchAllBadges } = useReadContracts({
+  const {
+    data: allBadgesData,
+    isLoading: isBadgesLoading,
+    refetch: refetchAllBadges,
+  } = useReadContracts({
     contracts: BADGE_LEVEL_IDS.map((lid) => ({
       address: badgesAddress ?? undefined,
       abi: badgesAbi,
@@ -1025,6 +1030,37 @@ export function ExercisesScreen({
     king: allBadgesData?.[5]?.result as boolean | undefined,
   };
   const hasClaimedBadge = badgesClaimed[selectedPiece];
+
+  /**
+   * The one-time milestone migration (Task 15). THIS is the load-bearing mount:
+   * `resolve()` lives on this screen, and a player can deep-link straight to
+   * `/exercises` without ever passing through the hub — so seeding on the hub
+   * alone would hand that player a parade of retroactive overlays on their very
+   * first solve. It runs in a mount effect, which React flushes long before any
+   * click can reach `resolveMilestones`, so the seed is COMMITTED TO DISK
+   * before the queue is ever built. `seedMilestonesOnce` is guarded by a
+   * persistent marker, so the hub's mount and this one are the same no-op after
+   * the first — neither is the single writer of anything.
+   *
+   * Gated on the badge read: seeding a half-known profile would mark it
+   * migrated with `piece-badge-claimed` / `mastery` unseeded, and a badge minted
+   * months ago would still pop an overlay. A disconnected wallet is ready —
+   * `resolve()` would read the same `badgeClaimed: false`.
+   */
+  const labyrinthIdsByPiece = useMemo(() => {
+    const out: Partial<Record<PieceKey, string[]>> = {};
+    for (const [piece, labs] of Object.entries(labyrinthCatalog)) {
+      out[piece as PieceKey] = labs.map((lab) => lab.id);
+    }
+    return out;
+  }, [labyrinthCatalog]);
+
+  useMilestoneSeeding({
+    ready: !isBadgesLoading,
+    badgeClaimedByPiece: badgesClaimed,
+    labyrinthIdsByPiece,
+    giftAvailable: CHESSCITO_LITE_MODE,
+  });
 
   const { isLoading: isShopConfirming } = useWaitForTransactionReceipt({
     chainId,

--- a/apps/web/src/components/hub/__tests__/hub-arena-tile.test.tsx
+++ b/apps/web/src/components/hub/__tests__/hub-arena-tile.test.tsx
@@ -15,6 +15,7 @@ import {
   getMilestoneStore,
   markOpened,
   recordEarned,
+  selectPending,
 } from "@/lib/progression/milestone-storage";
 import { milestoneKey } from "@/lib/progression/types";
 import { MINI_ARENA_SETUPS } from "@/lib/game/mini-arena";
@@ -78,6 +79,43 @@ describe("HubArenaTile NEW dot", () => {
 
     const event = getMilestoneStore().events[SPECIAL_TRAINING_KEY];
     expect(event?.openedAt).toBeDefined();
+  });
+
+  /**
+   * The tap IS the recognition. `recordEarned` writes `earnedAt` and NO
+   * `celebratedAt`, so without the `markCelebrated` in the same gesture the
+   * event stays PENDING and the celebration queue pops "Special Training
+   * Unlocked" on the player's next solve — for content they just opened.
+   */
+  it("stamps the milestone celebrated on tap, so it can never be left pending", () => {
+    const { getByRole } = render(<HubArenaTile setup={setup} unlocked />);
+
+    fireEvent.click(getByRole("button"));
+
+    const store = getMilestoneStore();
+    expect(store.events[SPECIAL_TRAINING_KEY]?.celebratedAt).toBeDefined();
+    // The queue is built from `selectPending` — this is the assertion that
+    // actually says "no overlay will fire for this".
+    expect(selectPending(store).map((event) => event.id)).not.toContain(
+      "special-training",
+    );
+  });
+
+  it("leaves an already-celebrated milestone alone — the tap is idempotent", () => {
+    // A player who saw the overlay first and taps the tile afterwards: the
+    // recognition already happened and must not be re-dated.
+    recordEarned([{ id: "special-training" }]);
+    const { getByRole, unmount } = render(<HubArenaTile setup={setup} unlocked />);
+    fireEvent.click(getByRole("button"));
+    const first = getMilestoneStore().events[SPECIAL_TRAINING_KEY]?.celebratedAt;
+    unmount();
+
+    render(<HubArenaTile setup={setup} unlocked />);
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(getMilestoneStore().events[SPECIAL_TRAINING_KEY]?.celebratedAt).toBe(
+      first,
+    );
   });
 
   it("stays opened after reload once tapped from an empty store", () => {

--- a/apps/web/src/components/hub/__tests__/hub-arena-tile.test.tsx
+++ b/apps/web/src/components/hub/__tests__/hub-arena-tile.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Special Training NEW dot (progression cluster, Task 12).
+ *
+ * The tile used to carry a permanently-lit `HubTileStatusChip
+ * kind="ready"` — the dot meant "this button exists", not "something
+ * new is here". Contract under test: the dot is driven by the
+ * milestone machine's `openedAt` and clears the first time the player
+ * opens Special Training.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderWithIntl as render, screen, fireEvent } from "@/test-utils/render-with-intl";
+
+import { HubArenaTile } from "../hub-arena-tile";
+import { markOpened, recordEarned } from "@/lib/progression/milestone-storage";
+import { MINI_ARENA_SETUPS } from "@/lib/game/mini-arena";
+
+const setup = MINI_ARENA_SETUPS[0];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("HubArenaTile NEW dot", () => {
+  it("shows NEW while the unlocked content has never been opened", () => {
+    recordEarned([{ id: "special-training" }]);
+    render(<HubArenaTile setup={setup} unlocked />);
+    expect(screen.getByTestId("hub-tile-new")).toBeInTheDocument();
+  });
+
+  it("drops the dot once the player has opened it", () => {
+    recordEarned([{ id: "special-training" }]);
+    markOpened("special-training");
+    render(<HubArenaTile setup={setup} unlocked />);
+    expect(screen.queryByTestId("hub-tile-new")).not.toBeInTheDocument();
+  });
+
+  it("clears on tap and stays cleared", () => {
+    recordEarned([{ id: "special-training" }]);
+    render(<HubArenaTile setup={setup} unlocked />);
+    expect(screen.getByTestId("hub-tile-new")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.queryByTestId("hub-tile-new")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/hub/__tests__/hub-arena-tile.test.tsx
+++ b/apps/web/src/components/hub/__tests__/hub-arena-tile.test.tsx
@@ -11,8 +11,15 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { renderWithIntl as render, screen, fireEvent } from "@/test-utils/render-with-intl";
 
 import { HubArenaTile } from "../hub-arena-tile";
-import { markOpened, recordEarned } from "@/lib/progression/milestone-storage";
+import {
+  getMilestoneStore,
+  markOpened,
+  recordEarned,
+} from "@/lib/progression/milestone-storage";
+import { milestoneKey } from "@/lib/progression/types";
 import { MINI_ARENA_SETUPS } from "@/lib/game/mini-arena";
+
+const SPECIAL_TRAINING_KEY = milestoneKey("special-training");
 
 const setup = MINI_ARENA_SETUPS[0];
 
@@ -40,6 +47,45 @@ describe("HubArenaTile NEW dot", () => {
     expect(screen.getByTestId("hub-tile-new")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.queryByTestId("hub-tile-new")).not.toBeInTheDocument();
+  });
+
+  it("does not flash a stale NEW dot for a veteran whose migration seed lands after mount", () => {
+    // Mount BEFORE the store has anything — matches the real tile, which
+    // sits unconditionally in HubScaffold while `unlocked` is still false.
+    const { rerender } = render(<HubArenaTile setup={setup} unlocked={false} />);
+
+    // Simulate the migration effect (seedExistingPlayer, wired in a later
+    // task) landing AFTER mount and seeding "special-training" WITH
+    // `openedAt` already set — exactly what a veteran player, long past
+    // 12 rook stars, gets so they never see a retroactive NEW dot.
+    recordEarned([{ id: "special-training" }]);
+    markOpened("special-training");
+
+    // Only now does `unlocked` flip true (rook stars arrive via a
+    // post-hydration effect too) — the render where a mount-time snapshot
+    // would already be frozen stale.
+    rerender(<HubArenaTile setup={setup} unlocked />);
+
+    expect(screen.queryByTestId("hub-tile-new")).not.toBeInTheDocument();
+  });
+
+  it("persists openedAt to the store on tap, even when the milestone was never recorded", () => {
+    const { getByRole } = render(<HubArenaTile setup={setup} unlocked />);
+
+    fireEvent.click(getByRole("button"));
+
+    const event = getMilestoneStore().events[SPECIAL_TRAINING_KEY];
+    expect(event?.openedAt).toBeDefined();
+  });
+
+  it("stays opened after reload once tapped from an empty store", () => {
+    const { unmount, getByRole } = render(<HubArenaTile setup={setup} unlocked />);
+    fireEvent.click(getByRole("button"));
+    unmount();
+
+    render(<HubArenaTile setup={setup} unlocked />);
 
     expect(screen.queryByTestId("hub-tile-new")).not.toBeInTheDocument();
   });

--- a/apps/web/src/components/hub/__tests__/hub-tile-availability.test.tsx
+++ b/apps/web/src/components/hub/__tests__/hub-tile-availability.test.tsx
@@ -78,12 +78,16 @@ describe("HubDailyTile availability signal", () => {
 });
 
 describe("HubArenaTile (Mate) availability signal", () => {
-  it("unlocked tile shows the static ready dot, no timers", () => {
+  // The dot used to be a permanently-lit "ready" chip (no invented
+  // logic behind it). It is now driven by the milestone machine's
+  // `openedAt` — see hub-arena-tile.test.tsx for the full NEW-dot
+  // contract. This test only confirms the timer discipline still holds.
+  it("unlocked, never-opened tile shows the NEW dot, no timers", () => {
     const spy = vi.spyOn(window, "setInterval");
     render(<HubArenaTile setup={MINI_ARENA_SETUPS[0]} unlocked />);
-    expect(screen.getByTestId("hub-tile-status")).toHaveAttribute(
+    expect(screen.getByTestId("hub-tile-new")).toHaveAttribute(
       "data-status",
-      "ready",
+      "new",
     );
     expect(appIntervalCalls(spy)).toHaveLength(0);
     spy.mockRestore();

--- a/apps/web/src/components/hub/hub-arena-tile.tsx
+++ b/apps/web/src/components/hub/hub-arena-tile.tsx
@@ -6,7 +6,11 @@ import { useTranslations } from "next-intl";
 
 import { HubActionTile } from "@/components/hub/hub-action-tile";
 import { HubTileStatusChip } from "@/components/hub/hub-tile-status-chip";
+import { getMilestoneStore, markOpened } from "@/lib/progression/milestone-storage";
+import { milestoneKey } from "@/lib/progression/types";
 import type { MiniArenaSetup } from "@/lib/game/mini-arena";
+
+const SPECIAL_TRAINING_KEY = milestoneKey("special-training");
 
 // The sheet subtree drags chess.js + js-chess-engine (~29KB gz); loading
 // it on first tap keeps both engines out of /hub's first-load bundle.
@@ -34,6 +38,17 @@ export function HubArenaTile({ setup, unlocked }: Props) {
   // Sheet mounts on first tap (dynamic chunk fetch) and STAYS mounted so
   // Radix exit animations work on subsequent closes.
   const [everOpened, setEverOpened] = useState(false);
+  // NEW dot mirrors the milestone machine's `openedAt`: unset means the
+  // player has never opened Special Training since it unlocked. Lazy
+  // initializer reads localStorage once at mount — safe here because
+  // this component only ever mounts client-side, after `unlocked` (fed
+  // by rook stars, which start at 0/false and flip via a post-hydration
+  // effect in use-hub-data.ts) has already gone true; it is never part
+  // of the SSR/hydration pass. `getMilestoneStore()` itself no-ops when
+  // `window` is undefined, so this is also safe if that ever changes.
+  const [isNew, setIsNew] = useState(
+    () => getMilestoneStore().events[SPECIAL_TRAINING_KEY]?.openedAt === undefined,
+  );
 
   if (!unlocked) return null;
 
@@ -45,12 +60,16 @@ export function HubArenaTile({ setup, unlocked }: Props) {
           label={t("mateLabel")}
           ariaLabel={t("arenaUnlockedAriaFormat", { name: setup.name })}
           onClick={() => {
+            markOpened("special-training");
+            setIsNew(false);
             setEverOpened(true);
             setOpen(true);
           }}
-          // Mate has no real cooldown yet — static "ready" dot only,
-          // no invented logic (founder micro-block 2026-06-11).
-          badge={<HubTileStatusChip kind="ready" />}
+          // Replaces the old permanently-lit "ready" dot (founder
+          // micro-block 2026-06-11 admitted it was invented logic — no
+          // real cooldown behind it). The dot now means "you have not
+          // opened this since it unlocked" and clears on first tap.
+          badge={isNew ? <HubTileStatusChip kind="new" /> : null}
         />
       </div>
       {everOpened ? <MiniArenaSheet open={open} onOpenChange={setOpen} setup={setup} /> : null}

--- a/apps/web/src/components/hub/hub-arena-tile.tsx
+++ b/apps/web/src/components/hub/hub-arena-tile.tsx
@@ -8,6 +8,7 @@ import { HubActionTile } from "@/components/hub/hub-action-tile";
 import { HubTileStatusChip } from "@/components/hub/hub-tile-status-chip";
 import {
   getMilestoneStore,
+  markCelebrated,
   markOpened,
   recordEarned,
 } from "@/lib/progression/milestone-storage";
@@ -97,6 +98,13 @@ export function HubArenaTile({ setup, unlocked }: Props) {
             if (!getMilestoneStore().events[SPECIAL_TRAINING_KEY]) {
               recordEarned([{ id: "special-training" }]);
             }
+            // `recordEarned` writes `earnedAt` and NO `celebratedAt`, which
+            // leaves the event PENDING — the celebration queue would then pop
+            // "SPECIAL TRAINING UNLOCKED" on the player's next solve, for
+            // content they are opening RIGHT NOW. The tap IS the recognition:
+            // stamp it celebrated in the same gesture. Idempotent, so a tile
+            // opened after the overlay already ran is a no-op.
+            markCelebrated("special-training");
             markOpened("special-training");
             setIsNew(false);
             setEverOpened(true);

--- a/apps/web/src/components/hub/hub-arena-tile.tsx
+++ b/apps/web/src/components/hub/hub-arena-tile.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 
 import { HubActionTile } from "@/components/hub/hub-action-tile";
 import { HubTileStatusChip } from "@/components/hub/hub-tile-status-chip";
-import { getMilestoneStore, markOpened } from "@/lib/progression/milestone-storage";
+import {
+  getMilestoneStore,
+  markOpened,
+  recordEarned,
+} from "@/lib/progression/milestone-storage";
 import { milestoneKey } from "@/lib/progression/types";
 import type { MiniArenaSetup } from "@/lib/game/mini-arena";
 
@@ -39,16 +43,36 @@ export function HubArenaTile({ setup, unlocked }: Props) {
   // Radix exit animations work on subsequent closes.
   const [everOpened, setEverOpened] = useState(false);
   // NEW dot mirrors the milestone machine's `openedAt`: unset means the
-  // player has never opened Special Training since it unlocked. Lazy
-  // initializer reads localStorage once at mount — safe here because
-  // this component only ever mounts client-side, after `unlocked` (fed
-  // by rook stars, which start at 0/false and flip via a post-hydration
-  // effect in use-hub-data.ts) has already gone true; it is never part
-  // of the SSR/hydration pass. `getMilestoneStore()` itself no-ops when
-  // `window` is undefined, so this is also safe if that ever changes.
-  const [isNew, setIsNew] = useState(
-    () => getMilestoneStore().events[SPECIAL_TRAINING_KEY]?.openedAt === undefined,
-  );
+  // player has never opened Special Training since it unlocked. This
+  // tile IS server-rendered — it sits unconditionally inside
+  // `HubScaffold`. It stays SSR-safe because `unlocked` is false on
+  // both the server render and the initial client (hydration) render
+  // — it only flips true via a post-hydration effect that reads
+  // `starsPerPiece` — so both passes emit `null` and there is no
+  // markup to mismatch. `getMilestoneStore()` additionally no-ops
+  // when `window` is undefined.
+  //
+  // `isNew` starts `false` and is deliberately NOT a lazy-initializer
+  // read of the store: every writer to the store (the veteran-player
+  // migration seed, `recordEarned` via the celebration queue) runs in
+  // an EFFECT, strictly AFTER this component's first commit. A mount-time
+  // snapshot would freeze `isNew` before those writes land and never
+  // re-read, so a veteran player whose migration seeds `openedAt` up
+  // front would still flash a NEW dot they never earned. Instead this
+  // re-reads the store in an effect keyed on `unlocked`: it re-evaluates
+  // every time the tile transitions to unlocked (including "arrives
+  // already unlocked"), which is the render where a veteran's seeded
+  // store is guaranteed to already be on disk. The milestone store has
+  // no change-event bus to subscribe to, so `unlocked` is the next best
+  // signal available; it does not catch a `recordEarned` for
+  // "special-training" that lands while the tile is already unlocked
+  // and mounted, but nothing in this flow does that today.
+  const [isNew, setIsNew] = useState(false);
+
+  useEffect(() => {
+    if (!unlocked) return;
+    setIsNew(getMilestoneStore().events[SPECIAL_TRAINING_KEY]?.openedAt === undefined);
+  }, [unlocked]);
 
   if (!unlocked) return null;
 
@@ -60,6 +84,19 @@ export function HubArenaTile({ setup, unlocked }: Props) {
           label={t("mateLabel")}
           ariaLabel={t("arenaUnlockedAriaFormat", { name: setup.name })}
           onClick={() => {
+            // `computeMarkOpened` refuses to write `openedAt` onto a
+            // milestone that is not yet recorded on disk (guard stays
+            // intact: it still refuses non-navigable milestones). The
+            // tile only renders once `unlocked` is true, i.e. the
+            // player HAS earned "special-training", so recording it
+            // here (if some earlier `recordEarned` pass has not
+            // already) is correct, not an invention — it just makes
+            // sure the event exists before we mark it opened, so the
+            // tap is durable across reload instead of a local-only,
+            // silently-dropped no-op.
+            if (!getMilestoneStore().events[SPECIAL_TRAINING_KEY]) {
+              recordEarned([{ id: "special-training" }]);
+            }
             markOpened("special-training");
             setIsNew(false);
             setEverOpened(true);

--- a/apps/web/src/components/hub/hub-daily-tile.tsx
+++ b/apps/web/src/components/hub/hub-daily-tile.tsx
@@ -152,7 +152,6 @@ export function HubDailyTile({
     // Detect first Focus Day before recording completion
     if (CHESSCITO_LITE_MODE && prev.totalCompleted === 0) {
       firstFocusDayJustEarned.current = true;
-      welcomePackage.unlock();
     }
     const next = recordDailyCompletion(today);
     setProgress(next);

--- a/apps/web/src/components/hub/hub-tile-status-chip.tsx
+++ b/apps/web/src/components/hub/hub-tile-status-chip.tsx
@@ -11,6 +11,7 @@
 
 type Props =
   | { kind: "ready" }
+  | { kind: "new" }
   | { kind: "label"; text: string };
 
 export function HubTileStatusChip(props: Props) {
@@ -20,6 +21,21 @@ export function HubTileStatusChip(props: Props) {
         aria-hidden="true"
         data-testid="hub-tile-status"
         data-status="ready"
+        className="hub-tile-status-dot"
+      />
+    );
+  }
+  if (props.kind === "new") {
+    // Reuses the SAME dot token as `ready` — this is not a new visual
+    // family, just a different meaning gated by milestone `openedAt`
+    // instead of a static "this exists" flag. Own testid because it
+    // answers a different question than `hub-tile-status` ("has this
+    // never been opened") and callers need to assert it independently.
+    return (
+      <span
+        aria-hidden="true"
+        data-testid="hub-tile-new"
+        data-status="new"
         className="hub-tile-status-dot"
       />
     );

--- a/apps/web/src/components/hub/hub-tile-status-chip.tsx
+++ b/apps/web/src/components/hub/hub-tile-status-chip.tsx
@@ -3,10 +3,12 @@
  * right-rail tiles (founder micro-block 2026-06-11).
  *
  * STATIC by contract: rendered once from mount-time state, no timers,
- * no live countdown, no costly animation. Two forms:
- *  - dot   → tiny green sphere, "this is ready for you".
- *  - label → one short word/phrase pill ("Next 6h", "Tomorrow",
- *            "PRO", "Ask").
+ * no live countdown, no costly animation. Three forms:
+ *  - dot ("ready") → tiny green sphere, "this is ready for you".
+ *  - dot ("new")   → same visual token, reused for "you have not
+ *                    opened this since it unlocked" (milestone-driven).
+ *  - label         → one short word/phrase pill ("Next 6h", "Tomorrow",
+ *                    "PRO", "Ask").
  */
 
 type Props =

--- a/apps/web/src/components/hub/legacy-hub-client.tsx
+++ b/apps/web/src/components/hub/legacy-hub-client.tsx
@@ -41,7 +41,10 @@ import { useAccount } from "wagmi";
 import type { PieceId } from "@/lib/game/types";
 import { useLabyrinthCatalog } from "@/lib/content/catalog-context";
 import { SPECIAL_TRAINING_ROOK_STARS } from "@/lib/progression/milestones";
-import { useMilestoneSeeding } from "@/lib/progression/use-milestone-seeding";
+import {
+  isMilestoneSeedReady,
+  useMilestoneSeeding,
+} from "@/lib/progression/use-milestone-seeding";
 import { track } from "@/lib/telemetry";
 import { deriveRewardTiles } from "@/lib/hub/derive-reward-tiles";
 import { CHESSCITO_LITE_MODE } from "@/lib/feature-flags";
@@ -202,6 +205,15 @@ export function LegacyHubClient({
    * Ready when the badge state is KNOWN: `disconnected` reads as "no badges",
    * exactly what a resolve would see; `connecting` / `reconnecting` waits, so
    * we never mark a profile migrated with `piece-badge-claimed` unseeded.
+   *
+   * An UNSUPPORTED chain never becomes ready — `getBadgesAddress` is null
+   * there, the batched read stays disabled and `badgesClaimed` stays empty, so
+   * this gate holds false for as long as the player stays on that chain. That
+   * is deliberate and it matches the exercises screen: an unknown badge state
+   * is NOT "no badges". The other half of the contract lives where `resolve()`
+   * does — `resolveMilestones` refuses to run while the profile is unseeded,
+   * so an unseeded player cannot be handed a retroactive parade in the
+   * meantime. The hub never resolves; it only seeds.
    */
   const { status: accountStatus } = useAccount();
   const labyrinthCatalog = useLabyrinthCatalog();
@@ -213,9 +225,13 @@ export function LegacyHubClient({
     return out;
   }, [labyrinthCatalog]);
   useMilestoneSeeding({
-    ready:
-      accountStatus === "disconnected" ||
-      (accountStatus === "connected" && Object.keys(badgesClaimed).length > 0),
+    // The SAME gate the exercises screen uses. `badgesClaimed` is empty until
+    // the batched on-chain read answers — and on an unsupported chain it never
+    // does, which is precisely when we must not seed.
+    ready: isMilestoneSeedReady({
+      accountStatus,
+      badgeStateKnown: Object.keys(badgesClaimed).length > 0,
+    }),
     badgeClaimedByPiece: badgesClaimed,
     labyrinthIdsByPiece,
     giftAvailable: CHESSCITO_LITE_MODE,

--- a/apps/web/src/components/hub/legacy-hub-client.tsx
+++ b/apps/web/src/components/hub/legacy-hub-client.tsx
@@ -40,6 +40,7 @@ import { useShieldSync } from "@/lib/shop/use-shield-sync";
 import { useAccount } from "wagmi";
 import type { PieceId } from "@/lib/game/types";
 import { useLabyrinthCatalog } from "@/lib/content/catalog-context";
+import { SPECIAL_TRAINING_ROOK_STARS } from "@/lib/progression/milestones";
 import { useMilestoneSeeding } from "@/lib/progression/use-milestone-seeding";
 import { track } from "@/lib/telemetry";
 import { deriveRewardTiles } from "@/lib/hub/derive-reward-tiles";
@@ -458,7 +459,12 @@ export function LegacyHubClient({
           },
         }}
         onArenaPress={handleArenaPress}
-        miniArenaUnlocked={(starsPerPiece.rook ?? 0) >= 12}
+        // Single-sourced with the milestone that celebrates this exact tile.
+        // A hardcoded 12 here would let the threshold and its own celebration
+        // drift apart the day the milestone moves.
+        miniArenaUnlocked={
+          (starsPerPiece.rook ?? 0) >= SPECIAL_TRAINING_ROOK_STARS
+        }
       />
       )}
       {process.env.NODE_ENV === "development" &&

--- a/apps/web/src/components/hub/legacy-hub-client.tsx
+++ b/apps/web/src/components/hub/legacy-hub-client.tsx
@@ -37,6 +37,10 @@ import { useProSheetState } from "@/lib/pro/use-pro-sheet-state";
 import { daysRemaining } from "@/lib/pro/days-remaining";
 import { applyDevUnlock } from "@/lib/daily/session-quota";
 import { useShieldSync } from "@/lib/shop/use-shield-sync";
+import { useAccount } from "wagmi";
+import type { PieceId } from "@/lib/game/types";
+import { useLabyrinthCatalog } from "@/lib/content/catalog-context";
+import { useMilestoneSeeding } from "@/lib/progression/use-milestone-seeding";
 import { track } from "@/lib/telemetry";
 import { deriveRewardTiles } from "@/lib/hub/derive-reward-tiles";
 import { CHESSCITO_LITE_MODE } from "@/lib/feature-flags";
@@ -184,6 +188,37 @@ export function LegacyHubClient({
   // credited-cache via /api/shields/me. Mounted at the scaffold root
   // so the chip sees server-confirmed state on every connect.
   useShieldSync();
+
+  /**
+   * The one-time milestone migration (Task 15). Mounted here AND on the
+   * exercises screen — never here alone. `resolve()` lives on the exercises
+   * screen and a player can deep-link straight to it, so the hub can never be
+   * the only seeding surface (that is the single-writer shape that produced the
+   * shield credited-cache bug, PR #213). `seedMilestonesOnce` is guarded by a
+   * persistent marker, so whichever surface mounts first pays for it and the
+   * other is a no-op.
+   *
+   * Ready when the badge state is KNOWN: `disconnected` reads as "no badges",
+   * exactly what a resolve would see; `connecting` / `reconnecting` waits, so
+   * we never mark a profile migrated with `piece-badge-claimed` unseeded.
+   */
+  const { status: accountStatus } = useAccount();
+  const labyrinthCatalog = useLabyrinthCatalog();
+  const labyrinthIdsByPiece = useMemo(() => {
+    const out: Partial<Record<PieceId, string[]>> = {};
+    for (const [piece, labs] of Object.entries(labyrinthCatalog)) {
+      out[piece as PieceId] = labs.map((lab) => lab.id);
+    }
+    return out;
+  }, [labyrinthCatalog]);
+  useMilestoneSeeding({
+    ready:
+      accountStatus === "disconnected" ||
+      (accountStatus === "connected" && Object.keys(badgesClaimed).length > 0),
+    badgeClaimedByPiece: badgesClaimed,
+    labyrinthIdsByPiece,
+    giftAvailable: CHESSCITO_LITE_MODE,
+  });
 
   const pro = useMemo(() => deriveProShape(proStatus, Date.now()), [proStatus]);
 

--- a/apps/web/src/components/progression/__tests__/unlock-overlay.test.tsx
+++ b/apps/web/src/components/progression/__tests__/unlock-overlay.test.tsx
@@ -28,7 +28,9 @@ describe("UnlockOverlay", () => {
         step={{
           id: "mastery",
           piece: "rook",
-          absorbed: ["great-focus-session", "first-great-session"],
+          // Global events absorbed under a piece-scoped closer: they carry NO
+          // piece, and must not inherit the closer's.
+          absorbed: [{ id: "great-focus-session" }, { id: "first-great-session" }],
         }}
         onPrimary={vi.fn()}
         onDismiss={onDismiss}

--- a/apps/web/src/components/progression/__tests__/unlock-overlay.test.tsx
+++ b/apps/web/src/components/progression/__tests__/unlock-overlay.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { UnlockOverlay } from "@/components/progression/unlock-overlay";
+
+describe("UnlockOverlay", () => {
+  it("names what was unlocked and offers a way in", () => {
+    render(
+      <UnlockOverlay
+        step={{ id: "special-training", absorbed: [] }}
+        onPrimary={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Special Training Unlocked")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start Training" })).toBeInTheDocument();
+  });
+
+  it("renders an absorbed recognition as a line, never as a second modal", () => {
+    render(
+      <UnlockOverlay
+        step={{
+          id: "mastery",
+          piece: "rook",
+          absorbed: ["great-focus-session", "first-great-session"],
+        }}
+        onPrimary={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Piece Mastered")).toBeInTheDocument();
+    expect(screen.getByText("Great Focus Session recognized.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Badge unlocked: First Great Session"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+  });
+});

--- a/apps/web/src/components/progression/__tests__/unlock-overlay.test.tsx
+++ b/apps/web/src/components/progression/__tests__/unlock-overlay.test.tsx
@@ -1,21 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { UnlockOverlay } from "@/components/progression/unlock-overlay";
+import { renderWithIntl as render, screen } from "@/test-utils/render-with-intl";
 
 describe("UnlockOverlay", () => {
   it("names what was unlocked and offers a way in", () => {
+    const onPrimary = vi.fn();
     render(
       <UnlockOverlay
         step={{ id: "special-training", absorbed: [] }}
-        onPrimary={vi.fn()}
+        onPrimary={onPrimary}
         onDismiss={vi.fn()}
       />,
     );
     expect(screen.getByText("Special Training Unlocked")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Start Training" })).toBeInTheDocument();
+    const cta = screen.getByRole("button", { name: "Start Training" });
+    expect(cta).toBeInTheDocument();
+
+    fireEvent.click(cta);
+    expect(onPrimary).toHaveBeenCalledTimes(1);
   });
 
   it("renders an absorbed recognition as a line, never as a second modal", () => {
+    const onDismiss = vi.fn();
     render(
       <UnlockOverlay
         step={{
@@ -24,7 +31,7 @@ describe("UnlockOverlay", () => {
           absorbed: ["great-focus-session", "first-great-session"],
         }}
         onPrimary={vi.fn()}
-        onDismiss={vi.fn()}
+        onDismiss={onDismiss}
       />,
     );
     expect(screen.getByText("Piece Mastered")).toBeInTheDocument();
@@ -33,5 +40,26 @@ describe("UnlockOverlay", () => {
       screen.getByText("Badge unlocked: First Great Session"),
     ).toBeInTheDocument();
     expect(screen.getAllByRole("dialog")).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    onDismiss.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders in Spanish when the locale is es", () => {
+    render(
+      <UnlockOverlay
+        step={{ id: "special-training", absorbed: [] }}
+        onPrimary={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+      { locale: "es" },
+    );
+    expect(
+      screen.getByText("Entrenamiento Especial Desbloqueado"),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/progression/unlock-overlay.tsx
+++ b/apps/web/src/components/progression/unlock-overlay.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { VictoryPopupShell } from "@/components/arena/victory-popup-shell";
+import { PrincipalButton } from "@/components/scene-rooted/principal-button";
+import { PROGRESSION_COPY } from "@/lib/content/editorial";
+import type { CelebrationStep } from "@/lib/progression/celebration-queue";
+import type { MilestoneId } from "@/lib/progression/types";
+
+/** Canonical existing assets that best represent each earned artifact.
+ *  The earned thing replaces the wolf mascot as the central icon so the
+ *  player sees WHAT they won, not a generic mascot. Verified against
+ *  apps/web/public/art/** before wiring — no new art was created. */
+const ICONS: Partial<Record<MilestoneId, string>> = {
+  "first-reward": "/art/welcome-package/focus-stamp-day1",
+  "first-labyrinth": "/art/new-icons-chesscito/laberinto",
+  "special-training": "/art/new-icons-chesscito/training-icon-v1",
+  "piece-badge-eligible": "/art/new-icons-chesscito/badge-claim-icon",
+  mastery: "/art/redesign/icons/crown",
+  "great-focus-session": "/art/achievements/1day-focus",
+};
+
+type Props = {
+  step: CelebrationStep;
+  onPrimary: () => void;
+  onDismiss: () => void;
+};
+
+/**
+ * Shared unlock overlay for the progression milestone machine.
+ *
+ * One dialog, always. A lower major absorbed into this step (e.g. Great
+ * Focus Session firing alongside Piece Mastered) renders as a line INSIDE
+ * this overlay, never as a second modal stacked after it — showing
+ * MASTERY! and then GREAT FOCUS SESSION! would drop the intensity right
+ * after the climax.
+ */
+export function UnlockOverlay({ step, onPrimary, onDismiss }: Props) {
+  const copy = PROGRESSION_COPY[step.id as keyof typeof PROGRESSION_COPY];
+  if (!copy || !("title" in copy)) return null;
+
+  const icon = ICONS[step.id];
+
+  return (
+    <VictoryPopupShell
+      onClose={onDismiss}
+      ariaLabel={copy.title}
+      closeLabel={copy.dismiss}
+    >
+      {icon ? (
+        <div className="progression-overlay-icon">
+          <picture>
+            <source srcSet={`${icon}.avif`} type="image/avif" />
+            <source srcSet={`${icon}.webp`} type="image/webp" />
+            <img
+              src={`${icon}.png`}
+              alt=""
+              aria-hidden="true"
+              className="h-20 w-20 object-contain"
+              draggable={false}
+            />
+          </picture>
+        </div>
+      ) : null}
+
+      <h2 className="language-modal-title">{copy.title}</h2>
+      <p className="progression-overlay-body">{copy.body}</p>
+
+      {step.absorbed.map((id) => {
+        const line =
+          PROGRESSION_COPY.absorbed[
+            id as keyof typeof PROGRESSION_COPY.absorbed
+          ];
+        return line ? (
+          <p key={id} className="progression-overlay-absorbed">
+            {line}
+          </p>
+        ) : null;
+      })}
+
+      <PrincipalButton onClick={onPrimary} className="self-center">
+        {copy.primary}
+      </PrincipalButton>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="progression-overlay-dismiss"
+      >
+        {copy.dismiss}
+      </button>
+    </VictoryPopupShell>
+  );
+}

--- a/apps/web/src/components/progression/unlock-overlay.tsx
+++ b/apps/web/src/components/progression/unlock-overlay.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { VictoryPopupShell } from "@/components/arena/victory-popup-shell";
 import { PrincipalButton } from "@/components/scene-rooted/principal-button";
-import { PROGRESSION_COPY } from "@/lib/content/editorial";
 import type { CelebrationStep } from "@/lib/progression/celebration-queue";
 import type { MilestoneId } from "@/lib/progression/types";
 
@@ -35,16 +35,16 @@ type Props = {
  * after the climax.
  */
 export function UnlockOverlay({ step, onPrimary, onDismiss }: Props) {
-  const copy = PROGRESSION_COPY[step.id as keyof typeof PROGRESSION_COPY];
-  if (!copy || !("title" in copy)) return null;
+  const t = useTranslations("PROGRESSION_COPY");
+  if (!t.has(`${step.id}.title`)) return null;
 
   const icon = ICONS[step.id];
 
   return (
     <VictoryPopupShell
       onClose={onDismiss}
-      ariaLabel={copy.title}
-      closeLabel={copy.dismiss}
+      ariaLabel={t(`${step.id}.title`)}
+      closeLabel="Close dialog"
     >
       {icon ? (
         <div className="progression-overlay-icon">
@@ -62,30 +62,27 @@ export function UnlockOverlay({ step, onPrimary, onDismiss }: Props) {
         </div>
       ) : null}
 
-      <h2 className="language-modal-title">{copy.title}</h2>
-      <p className="progression-overlay-body">{copy.body}</p>
+      <h2 className="language-modal-title">{t(`${step.id}.title`)}</h2>
+      <p className="progression-overlay-body">{t(`${step.id}.body`)}</p>
 
       {step.absorbed.map((id) => {
-        const line =
-          PROGRESSION_COPY.absorbed[
-            id as keyof typeof PROGRESSION_COPY.absorbed
-          ];
-        return line ? (
+        const key = `absorbed.${id}`;
+        return t.has(key) ? (
           <p key={id} className="progression-overlay-absorbed">
-            {line}
+            {t(key)}
           </p>
         ) : null;
       })}
 
       <PrincipalButton onClick={onPrimary} className="self-center">
-        {copy.primary}
+        {t(`${step.id}.primary`)}
       </PrincipalButton>
       <button
         type="button"
         onClick={onDismiss}
         className="progression-overlay-dismiss"
       >
-        {copy.dismiss}
+        {t(`${step.id}.dismiss`)}
       </button>
     </VictoryPopupShell>
   );

--- a/apps/web/src/components/progression/unlock-overlay.tsx
+++ b/apps/web/src/components/progression/unlock-overlay.tsx
@@ -65,10 +65,10 @@ export function UnlockOverlay({ step, onPrimary, onDismiss }: Props) {
       <h2 className="language-modal-title">{t(`${step.id}.title`)}</h2>
       <p className="progression-overlay-body">{t(`${step.id}.body`)}</p>
 
-      {step.absorbed.map((id) => {
-        const key = `absorbed.${id}`;
+      {step.absorbed.map((event) => {
+        const key = `absorbed.${event.id}`;
         return t.has(key) ? (
-          <p key={id} className="progression-overlay-absorbed">
+          <p key={event.id} className="progression-overlay-absorbed">
             {t(key)}
           </p>
         ) : null;

--- a/apps/web/src/components/progression/unlock-overlay.tsx
+++ b/apps/web/src/components/progression/unlock-overlay.tsx
@@ -44,7 +44,7 @@ export function UnlockOverlay({ step, onPrimary, onDismiss }: Props) {
     <VictoryPopupShell
       onClose={onDismiss}
       ariaLabel={t(`${step.id}.title`)}
-      closeLabel="Close dialog"
+      closeLabel={t("closeLabel")}
     >
       {icon ? (
         <div className="progression-overlay-icon">

--- a/apps/web/src/components/trophies/__tests__/lite-achievements.test.tsx
+++ b/apps/web/src/components/trophies/__tests__/lite-achievements.test.tsx
@@ -9,39 +9,40 @@ function progress(overrides: Partial<DailyProgress> = {}): DailyProgress {
 }
 
 describe("<AchievementsGrid> Lite achievements", () => {
-  it("renders 3 achievement tiles when progress is zero (all unearned)", () => {
-    const achievements = deriveLiteAchievements(progress());
+  it("renders 4 achievement tiles when progress is zero (all unearned)", () => {
+    const achievements = deriveLiteAchievements(progress(), false);
     render(<AchievementsGrid achievements={achievements} />);
     expect(screen.getByText("First Focus Day")).toBeInTheDocument();
+    expect(screen.getByText("First Great Session")).toBeInTheDocument();
     expect(screen.getByText("3-Day Rhythm")).toBeInTheDocument();
     expect(screen.getByText("7-Day Focus")).toBeInTheDocument();
   });
 
   it("marks First Focus Day as earned when totalCompleted=1", () => {
-    const achievements = deriveLiteAchievements(progress({ totalCompleted: 1, streak: 1 }));
+    const achievements = deriveLiteAchievements(progress({ totalCompleted: 1, streak: 1 }), false);
     const { container } = render(<AchievementsGrid achievements={achievements} />);
     // Unearned tiles with progress bars show .achievement-tile--locked class
-    expect(container.querySelectorAll(".achievement-tile--locked")).toHaveLength(2);
+    expect(container.querySelectorAll(".achievement-tile--locked")).toHaveLength(3);
     // Earned chip is a <span> from CandyChip (not the section header h3)
     expect(screen.getAllByText("Earned", { selector: "span" })).toHaveLength(1);
   });
 
   it("marks first + rhythm as earned when streak=3", () => {
-    const achievements = deriveLiteAchievements(progress({ totalCompleted: 3, streak: 3 }));
+    const achievements = deriveLiteAchievements(progress({ totalCompleted: 3, streak: 3 }), false);
     const { container } = render(<AchievementsGrid achievements={achievements} />);
-    expect(container.querySelectorAll(".achievement-tile--locked")).toHaveLength(1);
+    expect(container.querySelectorAll(".achievement-tile--locked")).toHaveLength(2);
     expect(screen.getAllByText("Earned", { selector: "span" })).toHaveLength(2);
   });
 
-  it("marks all 3 earned when streak=7", () => {
-    const achievements = deriveLiteAchievements(progress({ totalCompleted: 7, streak: 7 }));
+  it("marks all 4 earned when streak=7 and hadGreatSession=true", () => {
+    const achievements = deriveLiteAchievements(progress({ totalCompleted: 7, streak: 7 }), true);
     const { container } = render(<AchievementsGrid achievements={achievements} />);
     expect(container.querySelectorAll(".achievement-tile--locked")).toHaveLength(0);
-    expect(screen.getAllByText("Earned", { selector: "span" })).toHaveLength(3);
+    expect(screen.getAllByText("Earned", { selector: "span" })).toHaveLength(4);
   });
 
   it("copy contains no prohibited terms", () => {
-    const achievements = deriveLiteAchievements(progress());
+    const achievements = deriveLiteAchievements(progress(), false);
     render(<AchievementsGrid achievements={achievements} />);
     const container = screen.getByRole("button", { name: /first focus day/i }).closest(".flex");
     const text = container?.textContent ?? document.body.textContent ?? "";

--- a/apps/web/src/components/trophies/__tests__/trophies-body-lite-regression.test.tsx
+++ b/apps/web/src/components/trophies/__tests__/trophies-body-lite-regression.test.tsx
@@ -58,6 +58,13 @@ vi.mock("@/lib/daily/progress", () => ({
   getDailyProgress: () => mockProgress,
 }));
 
+// This suite never earns first-great-session — it exercises the
+// first-focus-day / streak-driven achievements only. An empty store keeps
+// deriveLiteAchievements' 4th slot unearned across every case here.
+vi.mock("@/lib/progression/milestone-storage", () => ({
+  getMilestoneStore: () => ({ version: 1, events: {}, dailyDate: null }),
+}));
+
 import { TrophiesBody, TrophiesHeroBand } from "../trophies-body";
 
 // ---------------------------------------------------------------------------
@@ -68,18 +75,19 @@ describe("TrophiesBody — Lite without victories contract", () => {
     mockProgress = { streak: 0, lastCompletedDate: null, totalCompleted: 0 };
   });
 
-  it("renders the 3 Lite achievement titles", () => {
+  it("renders the 4 Lite achievement titles", () => {
     render(<TrophiesBody />);
     expect(screen.getByText("First Focus Day")).toBeInTheDocument();
+    expect(screen.getByText("First Great Session")).toBeInTheDocument();
     expect(screen.getByText("3-Day Rhythm")).toBeInTheDocument();
     expect(screen.getByText("7-Day Focus")).toBeInTheDocument();
   });
 
-  it("shows '0/3 ACHIEVEMENTS' in the hero band when there is no daily progress", () => {
+  it("shows '0/4 ACHIEVEMENTS' in the hero band when there is no daily progress", () => {
     render(<TrophiesBody />);
     // Exact string match avoids collision with the '0/3' progress bar inside
     // the three-day-rhythm tile (progress.current/progress.goal).
-    expect(screen.getByText("0/3 ACHIEVEMENTS")).toBeInTheDocument();
+    expect(screen.getByText("0/4 ACHIEVEMENTS")).toBeInTheDocument();
   });
 
   it("does NOT render the legacy 'Trophies are offline' fallback", () => {
@@ -96,35 +104,35 @@ describe("TrophiesHeroBand — Lite hero achievement count", () => {
     mockProgress = { streak: 0, lastCompletedDate: null, totalCompleted: 0 };
   });
 
-  it("shows '0/3 ACHIEVEMENTS' when no daily progress", async () => {
+  it("shows '0/4 ACHIEVEMENTS' when no daily progress", async () => {
     render(<TrophiesHeroBand />);
     // Use findByText to let the getDailyProgress useEffect flush.
-    expect(await screen.findByText("0/3 ACHIEVEMENTS")).toBeInTheDocument();
+    expect(await screen.findByText("0/4 ACHIEVEMENTS")).toBeInTheDocument();
   });
 
-  it("shows '1/3 ACHIEVEMENTS' when totalCompleted=1 (first day done)", async () => {
+  it("shows '1/4 ACHIEVEMENTS' when totalCompleted=1 (first day done)", async () => {
     mockProgress = { streak: 1, lastCompletedDate: null, totalCompleted: 1 };
     render(<TrophiesHeroBand />);
-    expect(await screen.findByText("1/3 ACHIEVEMENTS")).toBeInTheDocument();
+    expect(await screen.findByText("1/4 ACHIEVEMENTS")).toBeInTheDocument();
     expect(screen.getByText("1 SESSIONS")).toBeInTheDocument();
   });
 
-  it("shows '2/3 ACHIEVEMENTS' when streak=3 (first + rhythm done)", async () => {
+  it("shows '2/4 ACHIEVEMENTS' when streak=3 (first + rhythm done)", async () => {
     mockProgress = { streak: 3, lastCompletedDate: null, totalCompleted: 3 };
     render(<TrophiesHeroBand />);
-    expect(await screen.findByText("2/3 ACHIEVEMENTS")).toBeInTheDocument();
+    expect(await screen.findByText("2/4 ACHIEVEMENTS")).toBeInTheDocument();
   });
 
-  it("shows '3/3 ACHIEVEMENTS' when streak=7 (all 3 done)", async () => {
+  it("shows '3/4 ACHIEVEMENTS' when streak=7 (first + rhythm + week done, great session not tracked here)", async () => {
     mockProgress = { streak: 7, lastCompletedDate: null, totalCompleted: 7 };
     render(<TrophiesHeroBand />);
-    expect(await screen.findByText("3/3 ACHIEVEMENTS")).toBeInTheDocument();
+    expect(await screen.findByText("3/4 ACHIEVEMENTS")).toBeInTheDocument();
   });
 
   it("uses the Lite hero copy from the Spanish bundle", async () => {
     render(<TrophiesHeroBand />, { locale: "es" });
     expect(await screen.findByText("TU PROGRESO")).toBeInTheDocument();
-    expect(screen.getByText("0/3 LOGROS")).toBeInTheDocument();
+    expect(screen.getByText("0/4 LOGROS")).toBeInTheDocument();
     expect(screen.getByText("Completa sesiones diarias de enfoque para avanzar.")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/trophies/achievements-grid.tsx
+++ b/apps/web/src/components/trophies/achievements-grid.tsx
@@ -19,6 +19,7 @@ const ACHIEVEMENT_ICONS: Record<string, CandyIconName> = {
   "five-crowns": "star",
   dedication: "refresh",
   "first-focus-day": "star",
+  "first-great-session": "star",
   "three-day-rhythm": "refresh",
   "seven-day-focus": "crown",
 };
@@ -26,6 +27,7 @@ const ACHIEVEMENT_ICONS: Record<string, CandyIconName> = {
 /** Real badge art assets — used when available, falling back to ACHIEVEMENT_ICONS. */
 const ACHIEVEMENT_ASSETS: Partial<Record<string, string>> = {
   "first-focus-day": "/art/achievements/1day-focus",
+  "first-great-session": "/art/achievements/1day-focus",
   "three-day-rhythm": "/art/achievements/3day-focus",
   "seven-day-focus": "/art/achievements/7day-focus",
 };

--- a/apps/web/src/components/trophies/trophies-body.tsx
+++ b/apps/web/src/components/trophies/trophies-body.tsx
@@ -15,6 +15,7 @@ import { getVictoryAddress } from "@/lib/game/victory-events";
 import { computeAchievements } from "@/lib/achievements/compute";
 import { deriveLiteAchievements } from "@/lib/achievements/lite";
 import { getDailyProgress, type DailyProgress } from "@/lib/daily/progress";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
 import { useCoachHistoryCount } from "@/lib/coach/use-coach-history-count";
 import type { VictoryEntry } from "@/lib/game/victory-events";
 import { CHESSCITO_LITE_MODE } from "@/lib/feature-flags";
@@ -63,10 +64,16 @@ export function TrophiesHeroBand({ showAchievements = true }: { showAchievements
     lastCompletedDate: null,
     totalCompleted: 0,
   });
+  const [hadGreatSession, setHadGreatSession] = useState(false);
   useEffect(() => {
-    if (CHESSCITO_LITE_MODE) setDailyProgress(getDailyProgress());
+    if (CHESSCITO_LITE_MODE) {
+      setDailyProgress(getDailyProgress());
+      setHadGreatSession(getMilestoneStore().events["first-great-session"] !== undefined);
+    }
   }, []);
-  const liteAchievements = CHESSCITO_LITE_MODE ? deriveLiteAchievements(dailyProgress) : [];
+  const liteAchievements = CHESSCITO_LITE_MODE
+    ? deriveLiteAchievements(dailyProgress, hadGreatSession)
+    : [];
   const summary = CHESSCITO_LITE_MODE
     ? {
         list: liteAchievements,
@@ -170,8 +177,12 @@ export function TrophiesBody({
     lastCompletedDate: null,
     totalCompleted: 0,
   });
+  const [hadGreatSession, setHadGreatSession] = useState(false);
   useEffect(() => {
-    if (CHESSCITO_LITE_MODE) setDailyProgress(getDailyProgress());
+    if (CHESSCITO_LITE_MODE) {
+      setDailyProgress(getDailyProgress());
+      setHadGreatSession(getMilestoneStore().events["first-great-session"] !== undefined);
+    }
   }, []);
 
   const configured = getVictoryAddress() !== null;
@@ -233,7 +244,9 @@ export function TrophiesBody({
   const hasVictories = (myVictories?.length ?? 0) > 0;
   const isChampion = isConnected && hasVictories;
   const isEmptyConnected = isConnected && myVictories?.length === 0 && !myLoading && !myError;
-  const liteAchievements = CHESSCITO_LITE_MODE ? deriveLiteAchievements(dailyProgress) : [];
+  const liteAchievements = CHESSCITO_LITE_MODE
+    ? deriveLiteAchievements(dailyProgress, hadGreatSession)
+    : [];
   const summary = CHESSCITO_LITE_MODE
     ? {
         list: liteAchievements,

--- a/apps/web/src/lib/achievements/__tests__/lite.test.ts
+++ b/apps/web/src/lib/achievements/__tests__/lite.test.ts
@@ -7,53 +7,56 @@ function progress(overrides: Partial<DailyProgress> = {}): DailyProgress {
 }
 
 describe("deriveLiteAchievements", () => {
-  it("returns 3 achievements, all unearned, when totalCompleted=0 streak=0", () => {
-    const result = deriveLiteAchievements(progress());
-    expect(result).toHaveLength(3);
+  it("returns 4 achievements, all unearned, when totalCompleted=0 streak=0", () => {
+    const result = deriveLiteAchievements(progress(), false);
+    expect(result).toHaveLength(4);
     expect(result.every((a) => !a.earned)).toBe(true);
     expect(result.map((a) => a.id)).toEqual([
       "first-focus-day",
+      "first-great-session",
       "three-day-rhythm",
       "seven-day-focus",
     ]);
   });
 
   it("earns only first-focus-day when totalCompleted=1 streak=1", () => {
-    const result = deriveLiteAchievements(progress({ totalCompleted: 1, streak: 1 }));
+    const result = deriveLiteAchievements(progress({ totalCompleted: 1, streak: 1 }), false);
     expect(result.find((a) => a.id === "first-focus-day")?.earned).toBe(true);
+    expect(result.find((a) => a.id === "first-great-session")?.earned).toBe(false);
     expect(result.find((a) => a.id === "three-day-rhythm")?.earned).toBe(false);
     expect(result.find((a) => a.id === "seven-day-focus")?.earned).toBe(false);
   });
 
   it("earns first-focus-day + 3-day-rhythm when streak=3", () => {
-    const result = deriveLiteAchievements(progress({ totalCompleted: 3, streak: 3 }));
+    const result = deriveLiteAchievements(progress({ totalCompleted: 3, streak: 3 }), false);
     expect(result.find((a) => a.id === "first-focus-day")?.earned).toBe(true);
     expect(result.find((a) => a.id === "three-day-rhythm")?.earned).toBe(true);
     expect(result.find((a) => a.id === "seven-day-focus")?.earned).toBe(false);
   });
 
-  it("earns all 3 when streak=7", () => {
-    const result = deriveLiteAchievements(progress({ totalCompleted: 7, streak: 7 }));
+  it("earns all 4 when streak=7 and hadGreatSession=true", () => {
+    const result = deriveLiteAchievements(progress({ totalCompleted: 7, streak: 7 }), true);
     expect(result.every((a) => a.earned)).toBe(true);
     expect(result.every((a) => a.progress === undefined)).toBe(true);
   });
 
-  it("earns all 3 when streak=10 (no overflow, progress undefined when earned)", () => {
-    const result = deriveLiteAchievements(progress({ totalCompleted: 10, streak: 10 }));
+  it("earns all 4 when streak=10 and hadGreatSession=true (no overflow, progress undefined when earned)", () => {
+    const result = deriveLiteAchievements(progress({ totalCompleted: 10, streak: 10 }), true);
     expect(result.every((a) => a.earned)).toBe(true);
     expect(result.every((a) => a.progress === undefined)).toBe(true);
   });
 
   it("shows correct progress bars for each unearned achievement", () => {
-    const result = deriveLiteAchievements(progress({ totalCompleted: 0, streak: 2 }));
+    const result = deriveLiteAchievements(progress({ totalCompleted: 0, streak: 2 }), false);
     expect(result.find((a) => a.id === "first-focus-day")?.progress).toEqual({ current: 0, goal: 1 });
+    expect(result.find((a) => a.id === "first-great-session")?.progress).toEqual({ current: 0, goal: 1 });
     expect(result.find((a) => a.id === "three-day-rhythm")?.progress).toEqual({ current: 2, goal: 3 });
     expect(result.find((a) => a.id === "seven-day-focus")?.progress).toEqual({ current: 2, goal: 7 });
   });
 
   it("clamps progress.current to the goal maximum when unearned", () => {
     // streak=6 → three-day-rhythm earned, seven-day-focus not earned yet; progress capped at 7
-    const result = deriveLiteAchievements(progress({ totalCompleted: 6, streak: 6 }));
+    const result = deriveLiteAchievements(progress({ totalCompleted: 6, streak: 6 }), false);
     const weekFocus = result.find((a) => a.id === "seven-day-focus");
     expect(weekFocus?.earned).toBe(false);
     expect(weekFocus?.progress).toEqual({ current: 6, goal: 7 });
@@ -61,7 +64,7 @@ describe("deriveLiteAchievements", () => {
 
   describe("copy guard — no prohibited terms in IDs", () => {
     it("IDs contain no on-chain / medical jargon", () => {
-      const result = deriveLiteAchievements(progress());
+      const result = deriveLiteAchievements(progress(), false);
       const prohibited = ["verified", "on-chain", "proof", "nft", "mint", "brain", "memory", "focus-improves"];
       for (const a of result) {
         for (const term of prohibited) {
@@ -69,5 +72,27 @@ describe("deriveLiteAchievements", () => {
         }
       }
     });
+  });
+});
+
+describe("first-great-session", () => {
+  const sample = progress({ streak: 1, lastCompletedDate: "2026-07-11", totalCompleted: 1 });
+
+  it("is unearned before any deep session", () => {
+    const achievements = deriveLiteAchievements(sample, false);
+    const great = achievements.find((a) => a.id === "first-great-session");
+    expect(great?.earned).toBe(false);
+  });
+
+  it("is earned once a great focus session has happened", () => {
+    const achievements = deriveLiteAchievements(sample, true);
+    const great = achievements.find((a) => a.id === "first-great-session");
+    expect(great?.earned).toBe(true);
+  });
+
+  it("leaves first-focus-day exactly as it was", () => {
+    const achievements = deriveLiteAchievements(sample, false);
+    const day = achievements.find((a) => a.id === "first-focus-day");
+    expect(day?.earned).toBe(true);
   });
 });

--- a/apps/web/src/lib/achievements/lite.ts
+++ b/apps/web/src/lib/achievements/lite.ts
@@ -2,11 +2,20 @@ import type { DailyProgress } from "@/lib/daily/progress";
 import type { Achievement } from "./compute";
 
 /**
- * Derives the 3 Lite achievements from DailyProgress.
+ * Derives the 4 Lite achievements from DailyProgress.
  * Pure, synchronous, side-effect free — safe to run on every render.
  * Only Daily Focus counts (no Exercises, no Labyrinths).
+ *
+ * `first-focus-day` measures CONTINUITY (did you show up today?).
+ * `first-great-session` measures DEPTH (was the session substantial?) — a
+ * separate badge, not a rename, so a player who already earned
+ * first-focus-day never has it silently revoked by a re-derivation from a
+ * counter they don't have.
  */
-export function deriveLiteAchievements(progress: DailyProgress): Achievement[] {
+export function deriveLiteAchievements(
+  progress: DailyProgress,
+  hadGreatSession: boolean,
+): Achievement[] {
   const { streak, totalCompleted } = progress;
   const firstDone = totalCompleted >= 1;
   const rhythmDone = streak >= 3;
@@ -16,6 +25,11 @@ export function deriveLiteAchievements(progress: DailyProgress): Achievement[] {
       id: "first-focus-day",
       earned: firstDone,
       progress: firstDone ? undefined : { current: Math.min(totalCompleted, 1), goal: 1 },
+    },
+    {
+      id: "first-great-session",
+      earned: hadGreatSession,
+      progress: hadGreatSession ? undefined : { current: 0, goal: 1 },
     },
     {
       id: "three-day-rhythm",

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -3555,3 +3555,51 @@ export const WELCOME_PACKAGE_COPY = {
   errorBody: "Something went wrong. Tap to try again.",
   retryCta: "Try again",
 } as const;
+
+/** Shared unlock overlay copy for the progression milestone machine.
+ *  Keyed by MilestoneId. `absorbed` holds the recognition lines that
+ *  render INSIDE a closer overlay for lower majors that fired in the
+ *  same drain, never as a second modal. */
+export const PROGRESSION_COPY = {
+  "first-reward": {
+    title: "First Reward Earned",
+    body: "Practice pays. Open your gift.",
+    primary: "Open Gift",
+    dismiss: "Later",
+  },
+  "first-labyrinth": {
+    title: "First Maze Unlocked",
+    body: "Guide the rook through it.",
+    primary: "Enter Maze",
+    dismiss: "Later",
+  },
+  "special-training": {
+    title: "Special Training Unlocked",
+    body: "Coordinate the rook and the king.",
+    primary: "Start Training",
+    dismiss: "Later",
+  },
+  "piece-badge-eligible": {
+    title: "Badge Ready to Claim",
+    body: "Ten stars. The badge is yours.",
+    primary: "Claim Badge",
+    dismiss: "Later",
+  },
+  mastery: {
+    title: "Piece Mastered",
+    body: "Every exercise, every maze.",
+    primary: "Continue",
+    dismiss: "Close",
+  },
+  "great-focus-session": {
+    title: "Great Focus Session",
+    body: "A deep session, done.",
+    primary: "Continue",
+    dismiss: "Close",
+  },
+  absorbed: {
+    "great-focus-session": "Great Focus Session recognized.",
+    "first-great-session": "Badge unlocked: First Great Session",
+    "piece-badge-eligible": "Your badge is ready to claim.",
+  },
+} as const;

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -1018,6 +1018,10 @@ export const ACHIEVEMENTS_COPY = {
       title: "First Focus Day",
       description: "Complete your first Daily Focus.",
     },
+    "first-great-session": {
+      title: "First Great Session",
+      description: "Earn 8 stars in one day, or finish your daily quota.",
+    },
     "three-day-rhythm": {
       title: "3-Day Rhythm",
       description: "Keep your focus streak for 3 days.",

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -3606,4 +3606,7 @@ export const PROGRESSION_COPY = {
     "first-great-session": "Badge unlocked: First Great Session",
     "piece-badge-eligible": "Your badge is ready to claim.",
   },
+  /** a11y label for the overlay's X. Flat key (not per-milestone): the
+   *  shell renders one close affordance regardless of which step is up. */
+  closeLabel: "Close dialog",
 } as const;

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -111,7 +111,11 @@ export const TRAINING_PATH_COPY = {
   exerciseChipFormat: "Exercise {number}: {stars} of 3 stars",
   labyrinthLabelFormat: "Labyrinth {number}",
   labyrinthOpenAriaFormat: "Open Labyrinth {number}",
-  labyrinthLockedStarsFormat: "Unlocks at {stars}★",
+  /** The first labyrinth's unlock is a compound gate: stars AND an
+   *  exercise floor (LABYRINTH_MIN_EXERCISES). A stars-only message lets
+   *  a player with enough stars but too few solves read "unlocked" and
+   *  stay locked with no explanation — this format names both halves. */
+  labyrinthLockedStarsFormat: "Unlocks at {stars}★ and {exercises} exercises",
   labyrinthLockedChain: "Beat previous lab",
   ready: "Ready",
   starsFormat: "{stars}★",

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -2406,6 +2406,7 @@ const messages = {
       primary: "Continuar",
       dismiss: "Cerrar",
     },
+    closeLabel: "Cerrar diálogo",
     absorbed: {
       "great-focus-session": "Gran Sesión de Enfoque reconocida.",
       "first-great-session": "Insignia desbloqueada: Primera Gran Sesión",

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -1014,6 +1014,10 @@ const messages = {
         title: "Primer Focus Day",
         description: "Completa tu primer Daily Focus.",
       },
+      "first-great-session": {
+        title: "Primera Gran Sesión",
+        description: "Gana 8 estrellas en un día o agota tu cupo diario.",
+      },
       "three-day-rhythm": {
         title: "Ritmo de 3 días",
         description: "Mantén tu racha de foco por 3 días.",

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -807,7 +807,7 @@ const messages = {
     exerciseChipFormat: "Ejercicio {number}: {stars} de 3 estrellas",
     labyrinthLabelFormat: "Laberinto {number}",
     labyrinthOpenAriaFormat: "Abrir Laberinto {number}",
-    labyrinthLockedStarsFormat: "Se abre con {stars}★",
+    labyrinthLockedStarsFormat: "Se abre con {stars}★ y {exercises} ejercicios",
     labyrinthLockedChain: "Supera el anterior",
     ready: "Listo",
     starsFormat: "{stars}★",

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -2369,6 +2369,49 @@ const messages = {
     loadError: "No se pudo cargar el Salón de la Fama. Intenta de nuevo.",
     retry: "Reintentar",
   },
+  PROGRESSION_COPY: {
+    "first-reward": {
+      title: "Primera Recompensa Obtenida",
+      body: "La práctica da frutos. Abre tu regalo.",
+      primary: "Abrir Regalo",
+      dismiss: "Después",
+    },
+    "first-labyrinth": {
+      title: "Primer Laberinto Desbloqueado",
+      body: "Guía a la torre a través de él.",
+      primary: "Entrar al Laberinto",
+      dismiss: "Después",
+    },
+    "special-training": {
+      title: "Entrenamiento Especial Desbloqueado",
+      body: "Coordina la torre y el rey.",
+      primary: "Iniciar Entrenamiento",
+      dismiss: "Después",
+    },
+    "piece-badge-eligible": {
+      title: "Insignia Lista para Reclamar",
+      body: "Diez estrellas. La insignia es tuya.",
+      primary: "Reclamar Insignia",
+      dismiss: "Después",
+    },
+    mastery: {
+      title: "Pieza Dominada",
+      body: "Cada ejercicio, cada laberinto.",
+      primary: "Continuar",
+      dismiss: "Cerrar",
+    },
+    "great-focus-session": {
+      title: "Gran Sesión de Enfoque",
+      body: "Una sesión profunda, completada.",
+      primary: "Continuar",
+      dismiss: "Cerrar",
+    },
+    absorbed: {
+      "great-focus-session": "Gran Sesión de Enfoque reconocida.",
+      "first-great-session": "Insignia desbloqueada: Primera Gran Sesión",
+      "piece-badge-eligible": "Tu insignia está lista para reclamar.",
+    },
+  },
 };
 
 export default messages;

--- a/apps/web/src/lib/lite-progress-storage.ts
+++ b/apps/web/src/lib/lite-progress-storage.ts
@@ -35,6 +35,10 @@ export function dailyStarsStorageKey(): string {
   return `${progressPrefix()}daily-stars`;
 }
 
+export function milestoneStorageKey(): string {
+  return `${progressPrefix()}milestones`;
+}
+
 /** Only application-owned values are eligible for the hidden QA reset. */
 export function isChesscitoStorageKey(key: string | null): boolean {
   return key?.startsWith(LEGACY_PREFIX) ?? false;

--- a/apps/web/src/lib/lite-progress-storage.ts
+++ b/apps/web/src/lib/lite-progress-storage.ts
@@ -31,6 +31,10 @@ export function dailySessionStorageKey(): string {
   return `${progressPrefix()}daily-session`;
 }
 
+export function dailyStarsStorageKey(): string {
+  return `${progressPrefix()}daily-stars`;
+}
+
 /** Only application-owned values are eligible for the hidden QA reset. */
 export function isChesscitoStorageKey(key: string | null): boolean {
   return key?.startsWith(LEGACY_PREFIX) ?? false;

--- a/apps/web/src/lib/lite-progress-storage.ts
+++ b/apps/web/src/lib/lite-progress-storage.ts
@@ -39,6 +39,19 @@ export function milestoneStorageKey(): string {
   return `${progressPrefix()}milestones`;
 }
 
+/** "The milestone migration already ran for this profile."
+ *
+ *  The milestone store has no `seededAt` field, and its idempotence is
+ *  "this key already exists" — NOT "the migration already ran". Those are
+ *  different claims: a milestone that was legitimately EARNED and is still
+ *  waiting for its celebration looks exactly like a milestone that was never
+ *  seeded. Re-running the seed at such a moment would stamp `celebratedAt` on
+ *  it and silently EAT the celebration. This marker is what makes seeding a
+ *  genuine one-time upgrade path instead of something that re-fires forever. */
+export function milestoneSeedStorageKey(): string {
+  return `${progressPrefix()}milestones-seeded`;
+}
+
 /** Only application-owned values are eligible for the hidden QA reset. */
 export function isChesscitoStorageKey(key: string | null): boolean {
   return key?.startsWith(LEGACY_PREFIX) ?? false;

--- a/apps/web/src/lib/progression/__tests__/celebration-queue.test.ts
+++ b/apps/web/src/lib/progression/__tests__/celebration-queue.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { buildCelebrationQueue } from "@/lib/progression/celebration-queue";
+
+describe("buildCelebrationQueue", () => {
+  it("returns nothing when nothing fired", () => {
+    expect(buildCelebrationQueue([])).toEqual([]);
+  });
+
+  it("shows incremental unlocks in ladder order, each its own overlay", () => {
+    const queue = buildCelebrationQueue([
+      { id: "special-training" },
+      { id: "first-reward" },
+      { id: "first-labyrinth", piece: "rook" },
+    ]);
+    expect(queue.map((step) => step.id)).toEqual([
+      "first-reward",
+      "first-labyrinth",
+      "special-training",
+    ]);
+  });
+
+  it("closes with the great focus session when it is the only major", () => {
+    const queue = buildCelebrationQueue([
+      { id: "first-reward" },
+      { id: "great-focus-session" },
+    ]);
+    expect(queue.map((step) => step.id)).toEqual([
+      "first-reward",
+      "great-focus-session",
+    ]);
+  });
+
+  it("renders exactly one closer and absorbs the lower major into it", () => {
+    const queue = buildCelebrationQueue([
+      { id: "great-focus-session" },
+      { id: "mastery", piece: "rook" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("mastery");
+    expect(queue[0].absorbed).toEqual(["great-focus-session"]);
+  });
+
+  it("lets the claim flow close and absorb the session", () => {
+    const queue = buildCelebrationQueue([
+      { id: "great-focus-session" },
+      { id: "piece-badge-eligible", piece: "rook" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("piece-badge-eligible");
+    expect(queue[0].absorbed).toEqual(["great-focus-session"]);
+  });
+
+  it("always renders first-great-session inside the closer, never alone", () => {
+    const queue = buildCelebrationQueue([
+      { id: "great-focus-session" },
+      { id: "first-great-session" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("great-focus-session");
+    expect(queue[0].absorbed).toContain("first-great-session");
+  });
+
+  it("shows the incremental unlock before the closer when both fire", () => {
+    const queue = buildCelebrationQueue([
+      { id: "mastery", piece: "rook" },
+      { id: "special-training" },
+    ]);
+    expect(queue.map((step) => step.id)).toEqual(["special-training", "mastery"]);
+  });
+
+  it("never renders two majors back to back", () => {
+    const queue = buildCelebrationQueue([
+      { id: "mastery", piece: "rook" },
+      { id: "piece-badge-eligible", piece: "rook" },
+      { id: "great-focus-session" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("mastery");
+    expect(queue[0].absorbed).toEqual([
+      "piece-badge-eligible",
+      "great-focus-session",
+    ]);
+  });
+
+  it("drops piece-badge-claimed from the queue — the claim flow owns that moment", () => {
+    const queue = buildCelebrationQueue([
+      { id: "piece-badge-claimed", piece: "rook" },
+    ]);
+    expect(queue).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/celebration-queue.test.ts
+++ b/apps/web/src/lib/progression/__tests__/celebration-queue.test.ts
@@ -37,7 +37,10 @@ describe("buildCelebrationQueue", () => {
     ]);
     expect(queue).toHaveLength(1);
     expect(queue[0].id).toBe("mastery");
-    expect(queue[0].absorbed).toEqual(["great-focus-session"]);
+    // Carries the absorbed event WHOLE — a global event keeps its undefined
+    // piece instead of inheriting the closer's, which would build the key
+    // `great-focus-session:rook` and mark nothing celebrated.
+    expect(queue[0].absorbed).toEqual([{ id: "great-focus-session" }]);
   });
 
   it("lets the claim flow close and absorb the session", () => {
@@ -47,7 +50,7 @@ describe("buildCelebrationQueue", () => {
     ]);
     expect(queue).toHaveLength(1);
     expect(queue[0].id).toBe("piece-badge-eligible");
-    expect(queue[0].absorbed).toEqual(["great-focus-session"]);
+    expect(queue[0].absorbed).toEqual([{ id: "great-focus-session" }]);
   });
 
   it("always renders first-great-session inside the closer, never alone", () => {
@@ -57,7 +60,7 @@ describe("buildCelebrationQueue", () => {
     ]);
     expect(queue).toHaveLength(1);
     expect(queue[0].id).toBe("great-focus-session");
-    expect(queue[0].absorbed).toContain("first-great-session");
+    expect(queue[0].absorbed).toContainEqual({ id: "first-great-session" });
   });
 
   it("shows the incremental unlock before the closer when both fire", () => {
@@ -77,8 +80,8 @@ describe("buildCelebrationQueue", () => {
     expect(queue).toHaveLength(1);
     expect(queue[0].id).toBe("mastery");
     expect(queue[0].absorbed).toEqual([
-      "piece-badge-eligible",
-      "great-focus-session",
+      { id: "piece-badge-eligible", piece: "rook" },
+      { id: "great-focus-session" },
     ]);
   });
 

--- a/apps/web/src/lib/progression/__tests__/gather-input.test.ts
+++ b/apps/web/src/lib/progression/__tests__/gather-input.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { gatherMilestoneInput } from "@/lib/progression/gather-input";
+import type { PieceProgress } from "@/lib/game/types";
+
+const rook: PieceProgress = {
+  piece: "rook",
+  currentId: null,
+  stars: { "rook-1": 3, "rook-2": 2, "rook-3": 0 },
+};
+
+const bishop: PieceProgress = {
+  piece: "bishop",
+  currentId: null,
+  stars: { "bishop-1": 1 },
+};
+
+describe("gatherMilestoneInput", () => {
+  it("sums lifetime stars across every piece", () => {
+    const input = gatherMilestoneInput({
+      piece: "rook",
+      progressByPiece: { rook, bishop },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false,
+    });
+    expect(input.lifetimeStars).toBe(6);
+  });
+
+  it("counts only exercises solved at least once — a 0-star entry is not completed", () => {
+    const input = gatherMilestoneInput({
+      piece: "rook",
+      progressByPiece: { rook, bishop },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false,
+    });
+    expect(input.completedExercises).toBe(3);
+    expect(input.pieceCompletedExercises).toBe(2);
+  });
+
+  it("scopes piece stars to the piece under play and exposes rook stars separately", () => {
+    const input = gatherMilestoneInput({
+      piece: "bishop",
+      progressByPiece: { rook, bishop },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false,
+    });
+    expect(input.pieceStars).toBe(1);
+    expect(input.rookStars).toBe(5);
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/migration-integration.test.tsx
+++ b/apps/web/src/lib/progression/__tests__/migration-integration.test.tsx
@@ -1,0 +1,233 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+
+import { renderWithAppProviders } from "@/test-utils/render-with-app-providers";
+import { ContentCatalogProvider } from "@/lib/content/catalog-context";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
+import {
+  labyrinthBestStorageKey,
+  pieceProgressStorageKey,
+} from "@/lib/lite-progress-storage";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
+import { hasSeededMilestones } from "@/lib/progression/seed-milestones";
+import { setWelcomePackageState, DEFAULT_STATE } from "@/lib/welcome-package/storage";
+import type { Exercise } from "@/lib/game/types";
+
+/**
+ * Task 15 — THE migration.
+ *
+ * `seedExistingPlayer` was fully built, fully tested and had ZERO production
+ * callers. Task 13 wired the celebration queue into the exercises screen, so
+ * until this ran, a veteran player's very FIRST solve resolved against their
+ * entire history and fired a parade of overlays for milestones they passed
+ * months ago.
+ *
+ * The invariant proved here: a returning player sees ZERO dialogs on first
+ * launch after the upgrade, on EVERY path — including the one that skips the
+ * hub entirely and deep-links straight to `/exercises`.
+ *
+ * Harness conventions borrowed from `components/exercises/__tests__/
+ * celebration-order.test.tsx`.
+ */
+
+vi.mock("@/lib/feature-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/feature-flags")>();
+  return {
+    ...actual,
+    CHESSCITO_MODE: "learn" as const,
+    CHESSCITO_LITE_MODE: true,
+    isLearnMode: () => true,
+    isPlayMode: () => false,
+    isFullMode: () => false,
+  };
+});
+
+const pushMock = vi.fn();
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    back: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+  usePathname: () => "/exercises",
+  redirect: (path: string) => path,
+  getPathname: ({ href }: { href: string }) => href,
+}));
+
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+  root = null;
+  rootMargin = "";
+  thresholds: number[] = [];
+}
+vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+
+const { ExercisesScreen } = await import("@/components/exercises/exercises-screen");
+const { LegacyHubClient } = await import("@/components/hub/legacy-hub-client");
+
+/** Five trivial one-move rook slides — every solve is a clean 3★. */
+const ROOK_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
+  id: `t-rook-${n}`,
+  startPos: { file: 0, rank: n - 1 },
+  targetPos: { file: 7, rank: n - 1 },
+  optimalMoves: 1,
+}));
+
+const ROOK_LAB: Exercise = {
+  id: "t-lab-1",
+  startPos: { file: 3, rank: 0 },
+  targetPos: { file: 3, rank: 7 },
+  optimalMoves: 1,
+  obstacles: [],
+};
+
+function renderExercises() {
+  return renderWithAppProviders(
+    <ContentCatalogProvider
+      value={{
+        exercises: { ...EXERCISES, rook: ROOK_POOL },
+        labyrinths: { ...LABYRINTHS, rook: [ROOK_LAB] },
+        descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
+      }}
+    >
+      <ExercisesScreen />
+    </ContentCatalogProvider>,
+  );
+}
+
+function renderHub() {
+  return renderWithAppProviders(<LegacyHubClient />);
+}
+
+/** Every celebration overlay is a `VictoryPopupShell` with `aria-modal="true"`.
+ *  Some pass `role="alert"` (the labyrinth score card) instead of
+ *  `role="dialog"`, so counting by role alone would miss a stacked popup. */
+function modalCount(): number {
+  return document.querySelectorAll('[aria-modal="true"]').length;
+}
+
+function seedPieceStars(piece: "rook" | "bishop", stars: Record<string, number>) {
+  localStorage.setItem(
+    pieceProgressStorageKey(piece),
+    JSON.stringify({ piece, currentId: null, stars }),
+  );
+}
+
+/**
+ * A player from BEFORE the milestone machine existed: 14 rook stars over five
+ * exercises, every labyrinth solved, the welcome gift claimed. Their profile
+ * has raw progress on disk and an EMPTY milestone store — every gate in the
+ * ladder is already behind them.
+ */
+function seedLegacyProgress() {
+  seedPieceStars("rook", {
+    "t-rook-1": 3,
+    "t-rook-2": 3,
+    "t-rook-3": 3,
+    "t-rook-4": 3,
+    "t-rook-5": 2,
+  });
+  localStorage.setItem(
+    labyrinthBestStorageKey("rook"),
+    JSON.stringify({ [ROOK_LAB.id]: 1 }),
+  );
+  setWelcomePackageState({
+    ...DEFAULT_STATE,
+    unlocked: true,
+    unlockedAt: "2026-01-01T00:00:00.000Z",
+    claimed: true,
+    claimedAt: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem("chesscito:onboarded", "true");
+  pushMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the milestone migration runs for a returning player", () => {
+  it("seeds every already-passed milestone on hub mount, with no overlay", async () => {
+    seedLegacyProgress();
+    renderHub();
+
+    await waitFor(() => {
+      expect(hasSeededMilestones()).toBe(true);
+    });
+
+    const store = getMilestoneStore();
+    expect(store.events["first-reward"].celebratedAt).toBeDefined();
+    // A claimed gift is also OPENED — no stale NEW dot on a reward the player
+    // collected months ago.
+    expect(store.events["first-reward"].openedAt).toBeDefined();
+    expect(store.events["first-labyrinth:rook"].celebratedAt).toBeDefined();
+    expect(store.events["special-training"].celebratedAt).toBeDefined();
+    expect(store.events["piece-badge-eligible:rook"].celebratedAt).toBeDefined();
+
+    expect(modalCount()).toBe(0);
+  });
+
+  /** THE hazard. `resolve()` lives on the exercises screen, and a player can
+   *  deep-link straight to `/exercises` without ever passing through the hub.
+   *  Seeding on the hub alone would hand that player the whole parade. */
+  it("seeds the player who deep-links straight to /exercises, before resolve() runs", async () => {
+    seedLegacyProgress();
+    renderExercises();
+
+    await waitFor(() => {
+      expect(hasSeededMilestones()).toBe(true);
+    });
+
+    const store = getMilestoneStore();
+    expect(store.events["first-reward"].celebratedAt).toBeDefined();
+    expect(store.events["first-labyrinth:rook"].celebratedAt).toBeDefined();
+    expect(store.events["special-training"].celebratedAt).toBeDefined();
+    expect(store.events["piece-badge-eligible:rook"].celebratedAt).toBeDefined();
+
+    // The whole point: state preserved, overlay suppressed.
+    expect(modalCount()).toBe(0);
+    expect(screen.queryByText("First Reward Earned")).not.toBeInTheDocument();
+    expect(screen.queryByText("Badge Ready to Claim")).not.toBeInTheDocument();
+  });
+
+  /** Today's session is NOT history. A migration that stamped the daily
+   *  milestones would silently rob the player of the session they are in. */
+  it("never seeds today's session milestones", async () => {
+    seedLegacyProgress();
+    renderExercises();
+
+    await waitFor(() => {
+      expect(hasSeededMilestones()).toBe(true);
+    });
+
+    const store = getMilestoneStore();
+    expect(store.events["great-focus-session"]).toBeUndefined();
+    expect(store.events["first-great-session"]).toBeUndefined();
+  });
+
+  /** A brand-new player is stamped as migrated too — the marker means "the
+   *  migration ran", not "the player had history". Nothing is celebrated. */
+  it("leaves a brand-new player with an empty store", async () => {
+    renderExercises();
+
+    await waitFor(() => {
+      expect(hasSeededMilestones()).toBe(true);
+    });
+    expect(getMilestoneStore().events).toEqual({});
+    expect(modalCount()).toBe(0);
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/migration.test.ts
+++ b/apps/web/src/lib/progression/__tests__/migration.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { seedExistingPlayer } from "@/lib/progression/migration";
+import { EMPTY_STORE } from "@/lib/progression/types";
+import type { MilestoneInput } from "@/lib/progression/milestones";
+
+const NOW = "2026-07-11T10:00:00.000Z";
+
+function input(overrides: Partial<MilestoneInput> = {}): MilestoneInput {
+  return {
+    piece: "rook",
+    lifetimeStars: 0,
+    completedExercises: 0,
+    pieceStars: 0,
+    pieceCompletedExercises: 0,
+    rookStars: 0,
+    dailyStars: 0,
+    sessionQuotaExhausted: false,
+    badgeClaimed: false,
+    allLabyrinthsComplete: false,
+    hadGreatSessionBefore: false,
+    ...overrides,
+  };
+}
+
+describe("seedExistingPlayer", () => {
+  it("leaves a brand new player untouched", () => {
+    const seeded = seedExistingPlayer(EMPTY_STORE, input(), false, NOW);
+    expect(seeded.events).toEqual({});
+  });
+
+  it("suppresses the overlay for a player already past 12 rook stars", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ rookStars: 12, lifetimeStars: 12, completedExercises: 5 }),
+      true,
+      NOW,
+    );
+    expect(seeded.events["special-training"].celebratedAt).toBe(NOW);
+  });
+
+  it("marks a claimed gift as opened so no NEW dot reappears", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ lifetimeStars: 6, completedExercises: 3 }),
+      true,
+      NOW,
+    );
+    expect(seeded.events["first-reward"].celebratedAt).toBe(NOW);
+    expect(seeded.events["first-reward"].openedAt).toBe(NOW);
+  });
+
+  it("keeps the NEW dot for a gift earned but never claimed", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ lifetimeStars: 6, completedExercises: 3 }),
+      false,
+      NOW,
+    );
+    expect(seeded.events["first-reward"].celebratedAt).toBe(NOW);
+    expect(seeded.events["first-reward"].openedAt).toBeUndefined();
+  });
+
+  it("never seeds a daily milestone — today's session is still up for grabs", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ dailyStars: 8 }),
+      false,
+      NOW,
+    );
+    expect(seeded.events["great-focus-session"]).toBeUndefined();
+    expect(seeded.events["first-great-session"]).toBeUndefined();
+  });
+
+  it("is a no-op on a store that was already seeded", () => {
+    const first = seedExistingPlayer(EMPTY_STORE, input({ rookStars: 12 }), true, NOW);
+    const second = seedExistingPlayer(
+      first,
+      input({ rookStars: 12 }),
+      true,
+      "2026-07-12T10:00:00.000Z",
+    );
+    expect(second).toBe(first);
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/migration.test.ts
+++ b/apps/web/src/lib/progression/__tests__/migration.test.ts
@@ -81,4 +81,48 @@ describe("seedExistingPlayer", () => {
     );
     expect(second).toBe(first);
   });
+
+  it("stamps EVERY milestone celebratedAt on a full returning player", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({
+        rookStars: 14,
+        lifetimeStars: 14,
+        completedExercises: 6,
+        pieceStars: 14,
+        pieceCompletedExercises: 6,
+        badgeClaimed: true,
+        allLabyrinthsComplete: true,
+        hadGreatSessionBefore: true,
+      }),
+      true,
+      NOW,
+    );
+
+    // Every seeded event must have celebratedAt
+    expect(Object.values(seeded.events).every((event) => event.celebratedAt)).toBe(true);
+
+    // Guard against vacuous pass — verify the expected milestones are present
+    expect(seeded.events["first-reward"]).toBeDefined();
+    expect(seeded.events["first-labyrinth:rook"]).toBeDefined();
+    expect(seeded.events["special-training"]).toBeDefined();
+    expect(seeded.events["piece-badge-eligible:rook"]).toBeDefined();
+    expect(seeded.events["piece-badge-claimed:rook"]).toBeDefined();
+    expect(seeded.events["mastery:rook"]).toBeDefined();
+  });
+
+  it("never seeds daily milestones even when sessionQuotaExhausted is true", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({
+        sessionQuotaExhausted: true,
+        dailyStars: 0,
+        hadGreatSessionBefore: false,
+      }),
+      false,
+      NOW,
+    );
+    expect(seeded.events["great-focus-session"]).toBeUndefined();
+    expect(seeded.events["first-great-session"]).toBeUndefined();
+  });
 });

--- a/apps/web/src/lib/progression/__tests__/milestone-storage.test.ts
+++ b/apps/web/src/lib/progression/__tests__/milestone-storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   computeMarkCelebrated,
   computeMarkOpened,
@@ -9,6 +9,7 @@ import {
   selectPending,
 } from "@/lib/progression/milestone-storage";
 import { EMPTY_STORE, type MilestoneStore } from "@/lib/progression/types";
+import { milestoneStorageKey } from "@/lib/lite-progress-storage";
 
 const NOW = "2026-07-11T10:00:00.000Z";
 const TODAY = "2026-07-11";
@@ -73,15 +74,29 @@ describe("parseMilestoneStore", () => {
 
   it("regression: great-focus-session survives a record → celebrate → "
     + "re-read round trip on the SAME day instead of celebrating twice", () => {
-    localStorage.clear();
-    recordEarned([{ id: "great-focus-session" }], NOW);
-    markCelebrated("great-focus-session", undefined, NOW);
-    const reread = parseMilestoneStore(
-      localStorage.getItem("chesscito:milestones"),
-      TODAY,
-    );
-    expect(reread.events["great-focus-session"]?.celebratedAt).toBe(NOW);
-    expect(selectPending(reread)).toEqual([]);
+    // recordEarned/markCelebrated read the store through
+    // parseMilestoneStore's default `today = todayUtc()`, i.e. the REAL
+    // clock — they take no `today` param of their own. Freeze the clock to
+    // NOW so the `dailyDate` they persist matches the hardcoded TODAY this
+    // test re-parses with below; otherwise this test is only correct on
+    // 2026-07-11 UTC and silently starts failing the day after (the
+    // mismatch triggers the daily reset and wipes the very event under
+    // test before the assertion runs).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+    try {
+      localStorage.clear();
+      recordEarned([{ id: "great-focus-session" }], NOW);
+      markCelebrated("great-focus-session", undefined, NOW);
+      const reread = parseMilestoneStore(
+        localStorage.getItem(milestoneStorageKey()),
+        TODAY,
+      );
+      expect(reread.events["great-focus-session"]?.celebratedAt).toBe(NOW);
+      expect(selectPending(reread)).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("deletes a hypothetical per-piece daily entry by id-prefix, not just "

--- a/apps/web/src/lib/progression/__tests__/milestone-storage.test.ts
+++ b/apps/web/src/lib/progression/__tests__/milestone-storage.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeMarkCelebrated,
+  computeMarkOpened,
+  computeRecordEarned,
+  parseMilestoneStore,
+  selectPending,
+} from "@/lib/progression/milestone-storage";
+import { EMPTY_STORE, type MilestoneStore } from "@/lib/progression/types";
+
+const NOW = "2026-07-11T10:00:00.000Z";
+const TODAY = "2026-07-11";
+
+describe("parseMilestoneStore", () => {
+  it("returns an empty store for corrupt input", () => {
+    expect(parseMilestoneStore("{{{", TODAY)).toEqual(EMPTY_STORE);
+  });
+
+  it("clears daily milestones when the stored date is not today", () => {
+    const stored: MilestoneStore = {
+      version: 1,
+      dailyDate: "2026-07-10",
+      events: {
+        "great-focus-session": {
+          id: "great-focus-session",
+          earnedAt: "2026-07-10T09:00:00.000Z",
+          celebratedAt: "2026-07-10T09:00:00.000Z",
+        },
+        "first-reward": { id: "first-reward", earnedAt: "2026-07-10T08:00:00.000Z" },
+      },
+    };
+    const parsed = parseMilestoneStore(JSON.stringify(stored), TODAY);
+    expect(parsed.events["great-focus-session"]).toBeUndefined();
+    expect(parsed.events["first-reward"]).toBeDefined();
+    expect(parsed.dailyDate).toBe(TODAY);
+  });
+
+  it("keeps first-great-session across days — it never resets", () => {
+    const stored: MilestoneStore = {
+      version: 1,
+      dailyDate: "2026-07-10",
+      events: {
+        "first-great-session": {
+          id: "first-great-session",
+          earnedAt: "2026-07-10T09:00:00.000Z",
+        },
+      },
+    };
+    const parsed = parseMilestoneStore(JSON.stringify(stored), TODAY);
+    expect(parsed.events["first-great-session"]).toBeDefined();
+  });
+});
+
+describe("computeRecordEarned", () => {
+  it("records a new event with its earnedAt", () => {
+    const next = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    expect(next.events["first-reward"]).toEqual({
+      id: "first-reward",
+      earnedAt: NOW,
+    });
+  });
+
+  it("scopes per-piece events by their idempotency key", () => {
+    const next = computeRecordEarned(
+      EMPTY_STORE,
+      [{ id: "piece-badge-eligible", piece: "bishop" }],
+      NOW,
+    );
+    expect(next.events["piece-badge-eligible:bishop"]?.piece).toBe("bishop");
+  });
+
+  it("is idempotent — re-deriving a recorded event returns the same reference", () => {
+    const first = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    const second = computeRecordEarned(first, [{ id: "first-reward" }], NOW);
+    expect(second).toBe(first);
+  });
+
+  it("never overwrites earnedAt on a re-derive", () => {
+    const first = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    const later = computeRecordEarned(
+      first,
+      [{ id: "first-reward" }],
+      "2026-07-12T10:00:00.000Z",
+    );
+    expect(later.events["first-reward"].earnedAt).toBe(NOW);
+  });
+});
+
+describe("selectPending", () => {
+  it("returns events that have never been celebrated", () => {
+    const store = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    expect(selectPending(store)).toEqual([{ id: "first-reward", piece: undefined }]);
+  });
+
+  it("excludes an already celebrated event", () => {
+    const earned = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    const celebrated = computeMarkCelebrated(earned, "first-reward", undefined, NOW);
+    expect(selectPending(celebrated)).toEqual([]);
+  });
+});
+
+describe("computeMarkOpened", () => {
+  it("clears the NEW dot on a navigable milestone", () => {
+    const earned = computeRecordEarned(EMPTY_STORE, [{ id: "special-training" }], NOW);
+    const opened = computeMarkOpened(earned, "special-training", undefined, NOW);
+    expect(opened.events["special-training"].openedAt).toBe(NOW);
+  });
+
+  it("refuses to write openedAt on a recognition — it has no destination", () => {
+    const earned = computeRecordEarned(
+      EMPTY_STORE,
+      [{ id: "great-focus-session" }],
+      NOW,
+    );
+    const opened = computeMarkOpened(earned, "great-focus-session", undefined, NOW);
+    expect(opened.events["great-focus-session"].openedAt).toBeUndefined();
+    expect(opened).toBe(earned);
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/milestone-storage.test.ts
+++ b/apps/web/src/lib/progression/__tests__/milestone-storage.test.ts
@@ -3,7 +3,9 @@ import {
   computeMarkCelebrated,
   computeMarkOpened,
   computeRecordEarned,
+  markCelebrated,
   parseMilestoneStore,
+  recordEarned,
   selectPending,
 } from "@/lib/progression/milestone-storage";
 import { EMPTY_STORE, type MilestoneStore } from "@/lib/progression/types";
@@ -12,8 +14,91 @@ const NOW = "2026-07-11T10:00:00.000Z";
 const TODAY = "2026-07-11";
 
 describe("parseMilestoneStore", () => {
-  it("returns an empty store for corrupt input", () => {
-    expect(parseMilestoneStore("{{{", TODAY)).toEqual(EMPTY_STORE);
+  it("stamps dailyDate on a fresh store instead of leaving it null — a null "
+    + "dailyDate makes the very next daily-reset wipe an event that was just "
+    + "recorded but never celebrated", () => {
+    expect(parseMilestoneStore(null, TODAY)).toEqual({
+      ...EMPTY_STORE,
+      dailyDate: TODAY,
+    });
+  });
+
+  it("returns an empty store stamped with today for corrupt JSON", () => {
+    expect(parseMilestoneStore("{{{", TODAY)).toEqual({
+      ...EMPTY_STORE,
+      dailyDate: TODAY,
+    });
+  });
+
+  it("does not throw on JSON.parse(\"null\") and returns a stamped empty store", () => {
+    expect(parseMilestoneStore("null", TODAY)).toEqual({
+      ...EMPTY_STORE,
+      dailyDate: TODAY,
+    });
+  });
+
+  it("does not throw on a bad shape (array) and returns a stamped empty store", () => {
+    expect(parseMilestoneStore("[1,2,3]", TODAY)).toEqual({
+      ...EMPTY_STORE,
+      dailyDate: TODAY,
+    });
+  });
+
+  it("drops a partially-written entry instead of surviving into selectPending "
+    + "and crashing on event.celebratedAt", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      dailyDate: TODAY,
+      events: { "first-reward": null },
+    });
+    const parsed = parseMilestoneStore(raw, TODAY);
+    expect(parsed.events["first-reward"]).toBeUndefined();
+    expect(() => selectPending(parsed)).not.toThrow();
+  });
+
+  it("drops an entry missing a string id or earnedAt", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      dailyDate: TODAY,
+      events: {
+        "bad-1": { id: "first-reward" }, // missing earnedAt
+        "bad-2": { earnedAt: NOW }, // missing id
+        "bad-3": "not-an-object",
+        "good": { id: "first-reward", earnedAt: NOW },
+      },
+    });
+    const parsed = parseMilestoneStore(raw, TODAY);
+    expect(Object.keys(parsed.events)).toEqual(["good"]);
+  });
+
+  it("regression: great-focus-session survives a record → celebrate → "
+    + "re-read round trip on the SAME day instead of celebrating twice", () => {
+    localStorage.clear();
+    recordEarned([{ id: "great-focus-session" }], NOW);
+    markCelebrated("great-focus-session", undefined, NOW);
+    const reread = parseMilestoneStore(
+      localStorage.getItem("chesscito:milestones"),
+      TODAY,
+    );
+    expect(reread.events["great-focus-session"]?.celebratedAt).toBe(NOW);
+    expect(selectPending(reread)).toEqual([]);
+  });
+
+  it("deletes a hypothetical per-piece daily entry by id-prefix, not just "
+    + "the bare key", () => {
+    const stored: MilestoneStore = {
+      version: 1,
+      dailyDate: "2026-07-10",
+      events: {
+        "great-focus-session:rook": {
+          id: "great-focus-session",
+          piece: "rook",
+          earnedAt: "2026-07-10T09:00:00.000Z",
+        },
+      },
+    };
+    const parsed = parseMilestoneStore(JSON.stringify(stored), TODAY);
+    expect(parsed.events["great-focus-session:rook"]).toBeUndefined();
   });
 
   it("clears daily milestones when the stored date is not today", () => {
@@ -99,6 +184,14 @@ describe("selectPending", () => {
   });
 });
 
+describe("computeMarkCelebrated", () => {
+  it("returns the SAME reference for an event that was never recorded", () => {
+    expect(computeMarkCelebrated(EMPTY_STORE, "first-reward", undefined, NOW)).toBe(
+      EMPTY_STORE,
+    );
+  });
+});
+
 describe("computeMarkOpened", () => {
   it("clears the NEW dot on a navigable milestone", () => {
     const earned = computeRecordEarned(EMPTY_STORE, [{ id: "special-training" }], NOW);
@@ -114,6 +207,34 @@ describe("computeMarkOpened", () => {
     );
     const opened = computeMarkOpened(earned, "great-focus-session", undefined, NOW);
     expect(opened.events["great-focus-session"].openedAt).toBeUndefined();
+    expect(opened).toBe(earned);
+  });
+
+  it("returns the SAME reference for an unrecorded navigable milestone", () => {
+    expect(computeMarkOpened(EMPTY_STORE, "special-training", undefined, NOW)).toBe(
+      EMPTY_STORE,
+    );
+  });
+
+  it("refuses to write openedAt on piece-badge-claimed — a recognition, not a destination", () => {
+    const earned = computeRecordEarned(
+      EMPTY_STORE,
+      [{ id: "piece-badge-claimed", piece: "rook" }],
+      NOW,
+    );
+    const opened = computeMarkOpened(earned, "piece-badge-claimed", "rook", NOW);
+    expect(opened.events["piece-badge-claimed:rook"].openedAt).toBeUndefined();
+    expect(opened).toBe(earned);
+  });
+
+  it("refuses to write openedAt on mastery — a recognition, not a destination", () => {
+    const earned = computeRecordEarned(
+      EMPTY_STORE,
+      [{ id: "mastery", piece: "rook" }],
+      NOW,
+    );
+    const opened = computeMarkOpened(earned, "mastery", "rook", NOW);
+    expect(opened.events["mastery:rook"].openedAt).toBeUndefined();
     expect(opened).toBe(earned);
   });
 });

--- a/apps/web/src/lib/progression/__tests__/milestones.test.ts
+++ b/apps/web/src/lib/progression/__tests__/milestones.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveEarnedMilestones,
+  type MilestoneInput,
+} from "@/lib/progression/milestones";
+
+function input(overrides: Partial<MilestoneInput> = {}): MilestoneInput {
+  return {
+    piece: "rook",
+    lifetimeStars: 0,
+    completedExercises: 0,
+    pieceStars: 0,
+    pieceCompletedExercises: 0,
+    rookStars: 0,
+    dailyStars: 0,
+    sessionQuotaExhausted: false,
+    badgeClaimed: false,
+    allLabyrinthsComplete: false,
+    hadGreatSessionBefore: false,
+    ...overrides,
+  };
+}
+
+function ids(result: ReturnType<typeof deriveEarnedMilestones>): string[] {
+  return result.map((event) => event.id);
+}
+
+describe("first-reward", () => {
+  it("does not fire on a single perfect solve — the exercise floor is not met", () => {
+    const earned = deriveEarnedMilestones(
+      input({ lifetimeStars: 3, completedExercises: 1 }),
+    );
+    expect(ids(earned)).not.toContain("first-reward");
+  });
+
+  it("fires at 4 stars across 2 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ lifetimeStars: 4, completedExercises: 2 }),
+    );
+    expect(ids(earned)).toContain("first-reward");
+  });
+
+  it("fires for a struggling player at 1 star across 4 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ lifetimeStars: 4, completedExercises: 4 }),
+    );
+    expect(ids(earned)).toContain("first-reward");
+  });
+});
+
+describe("first-labyrinth", () => {
+  it("does not fire at 6 piece stars across only 2 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 6, pieceCompletedExercises: 2 }),
+    );
+    expect(ids(earned)).not.toContain("first-labyrinth");
+  });
+
+  it("fires at 6 piece stars across 3 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 6, pieceCompletedExercises: 3 }),
+    );
+    expect(ids(earned)).toContain("first-labyrinth");
+  });
+});
+
+describe("piece badge", () => {
+  it("is eligible at 10 piece stars but not claimed", () => {
+    const earned = deriveEarnedMilestones(input({ pieceStars: 10 }));
+    expect(ids(earned)).toContain("piece-badge-eligible");
+    expect(ids(earned)).not.toContain("piece-badge-claimed");
+  });
+
+  it("is claimed once the transaction confirms", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 10, badgeClaimed: true }),
+    );
+    expect(ids(earned)).toContain("piece-badge-claimed");
+  });
+});
+
+describe("mastery", () => {
+  it("stays locked when every labyrinth is done but the badge was never claimed", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 10, allLabyrinthsComplete: true, badgeClaimed: false }),
+    );
+    expect(ids(earned)).not.toContain("mastery");
+  });
+
+  it("fires when the badge is claimed and every labyrinth is done", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 10, allLabyrinthsComplete: true, badgeClaimed: true }),
+    );
+    expect(ids(earned)).toContain("mastery");
+  });
+});
+
+describe("special-training", () => {
+  it("fires at 12 rook stars", () => {
+    expect(ids(deriveEarnedMilestones(input({ rookStars: 12 })))).toContain(
+      "special-training",
+    );
+  });
+
+  it("does not fire at 11 rook stars", () => {
+    expect(ids(deriveEarnedMilestones(input({ rookStars: 11 })))).not.toContain(
+      "special-training",
+    );
+  });
+});
+
+describe("great-focus-session", () => {
+  it("fires at 8 daily stars", () => {
+    expect(ids(deriveEarnedMilestones(input({ dailyStars: 8 })))).toContain(
+      "great-focus-session",
+    );
+  });
+
+  it("fires on an exhausted quota even at 7 daily stars — the wall never beats the praise", () => {
+    const earned = deriveEarnedMilestones(
+      input({ dailyStars: 7, sessionQuotaExhausted: true }),
+    );
+    expect(ids(earned)).toContain("great-focus-session");
+  });
+
+  it("grants first-great-session only the first time", () => {
+    const first = deriveEarnedMilestones(input({ dailyStars: 8 }));
+    expect(ids(first)).toContain("first-great-session");
+
+    const later = deriveEarnedMilestones(
+      input({ dailyStars: 8, hadGreatSessionBefore: true }),
+    );
+    expect(ids(later)).toContain("great-focus-session");
+    expect(ids(later)).not.toContain("first-great-session");
+  });
+});
+
+describe("per-piece scoping", () => {
+  it("scopes piece milestones to the piece under play", () => {
+    const earned = deriveEarnedMilestones(
+      input({ piece: "bishop", pieceStars: 10 }),
+    );
+    const badge = earned.find((event) => event.id === "piece-badge-eligible");
+    expect(badge?.piece).toBe("bishop");
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/seed-milestones.test.ts
+++ b/apps/web/src/lib/progression/__tests__/seed-milestones.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  labyrinthBestStorageKey,
+  milestoneSeedStorageKey,
+  milestoneStorageKey,
+  pieceProgressStorageKey,
+} from "@/lib/lite-progress-storage";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
+import {
+  hasSeededMilestones,
+  markMilestonesSeeded,
+  seedMilestonesOnce,
+  type SeedMilestonesArgs,
+} from "@/lib/progression/seed-milestones";
+import { setWelcomePackageState, DEFAULT_STATE } from "@/lib/welcome-package/storage";
+import type { PieceId } from "@/lib/game/types";
+
+const NOW = "2026-07-12T10:00:00.000Z";
+
+function args(overrides: Partial<SeedMilestonesArgs> = {}): SeedMilestonesArgs {
+  return {
+    badgeClaimedByPiece: {},
+    labyrinthIdsByPiece: {},
+    giftAvailable: true,
+    ...overrides,
+  };
+}
+
+function seedStars(piece: PieceId, stars: Record<string, number>) {
+  localStorage.setItem(
+    pieceProgressStorageKey(piece),
+    JSON.stringify({ piece, currentId: null, stars }),
+  );
+}
+
+/** Five 3★ exercises = 15★ — past every star gate in the ladder. */
+const VETERAN_STARS = { e1: 3, e2: 3, e3: 3, e4: 3, e5: 3 };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("seedMilestonesOnce", () => {
+  it("stamps every already-passed milestone as celebrated", () => {
+    seedStars("rook", VETERAN_STARS);
+    seedMilestonesOnce(args(), NOW);
+
+    const events = getMilestoneStore().events;
+    expect(events["first-reward"].celebratedAt).toBe(NOW);
+    expect(events["first-labyrinth:rook"].celebratedAt).toBe(NOW);
+    expect(events["special-training"].celebratedAt).toBe(NOW);
+    expect(events["piece-badge-eligible:rook"].celebratedAt).toBe(NOW);
+  });
+
+  /** HAZARD 3. `seedExistingPlayer` is scoped to ONE piece: its
+   *  `MilestoneInput.piece` scopes `first-labyrinth`, `piece-badge-*` and
+   *  `mastery`. Seeding only for rook would hand a second-piece veteran a
+   *  retroactive parade the day a second piece ships. */
+  it("seeds EVERY piece the player has progress on, not just rook", () => {
+    seedStars("rook", VETERAN_STARS);
+    seedStars("bishop", VETERAN_STARS);
+
+    seedMilestonesOnce(args(), NOW);
+
+    const events = getMilestoneStore().events;
+    expect(events["first-labyrinth:bishop"].celebratedAt).toBe(NOW);
+    expect(events["piece-badge-eligible:bishop"].celebratedAt).toBe(NOW);
+    // A piece never played stays untouched — nothing to suppress.
+    expect(events["first-labyrinth:knight"]).toBeUndefined();
+  });
+
+  it("seeds mastery only when the badge is claimed AND every maze is solved", () => {
+    seedStars("rook", VETERAN_STARS);
+    localStorage.setItem(
+      labyrinthBestStorageKey("rook"),
+      JSON.stringify({ "rook-lab-1": 4, "rook-lab-2": 6 }),
+    );
+
+    seedMilestonesOnce(
+      args({
+        badgeClaimedByPiece: { rook: true },
+        labyrinthIdsByPiece: { rook: ["rook-lab-1", "rook-lab-2"] },
+      }),
+      NOW,
+    );
+
+    const events = getMilestoneStore().events;
+    expect(events["piece-badge-claimed:rook"].celebratedAt).toBe(NOW);
+    expect(events["mastery:rook"].celebratedAt).toBe(NOW);
+  });
+
+  it("marks a claimed gift as opened so no NEW dot reappears", () => {
+    seedStars("rook", VETERAN_STARS);
+    setWelcomePackageState({ ...DEFAULT_STATE, unlocked: true, claimed: true });
+
+    seedMilestonesOnce(args(), NOW);
+
+    expect(getMilestoneStore().events["first-reward"].openedAt).toBe(NOW);
+  });
+
+  it("keeps the NEW dot on a gift that was earned but never claimed", () => {
+    seedStars("rook", VETERAN_STARS);
+
+    seedMilestonesOnce(args(), NOW);
+
+    const gift = getMilestoneStore().events["first-reward"];
+    expect(gift.celebratedAt).toBe(NOW);
+    expect(gift.openedAt).toBeUndefined();
+  });
+
+  it("never seeds today's session milestones", () => {
+    seedStars("rook", VETERAN_STARS);
+    seedMilestonesOnce(args(), NOW);
+
+    const events = getMilestoneStore().events;
+    expect(events["great-focus-session"]).toBeUndefined();
+    expect(events["first-great-session"]).toBeUndefined();
+  });
+
+  it("does not celebrate a gift that a Full build can never deliver", () => {
+    seedStars("rook", VETERAN_STARS);
+    seedMilestonesOnce(args({ giftAvailable: false }), NOW);
+
+    expect(getMilestoneStore().events["first-reward"]).toBeUndefined();
+  });
+
+  /** HAZARD 4. Idempotence on disk is "this key exists", NOT "the migration
+   *  ran". A milestone that was legitimately EARNED and is still awaiting its
+   *  celebration is indistinguishable from one that was never seeded — a
+   *  second seeding pass would stamp it celebrated and EAT the overlay. The
+   *  marker is what makes this a one-time upgrade path. */
+  it("refuses to run twice, so it can never eat a pending celebration", () => {
+    seedStars("rook", VETERAN_STARS);
+    markMilestonesSeeded(NOW);
+
+    // The player earns a milestone the normal way: recorded, not yet celebrated.
+    localStorage.setItem(
+      milestoneStorageKey(),
+      JSON.stringify({
+        version: 1,
+        events: {
+          "special-training": { id: "special-training", earnedAt: NOW },
+        },
+        dailyDate: NOW.slice(0, 10),
+      }),
+    );
+
+    expect(seedMilestonesOnce(args(), NOW)).toBeNull();
+    const event = getMilestoneStore().events["special-training"];
+    expect(event.celebratedAt).toBeUndefined();
+    // And no milestone was invented behind the player's back.
+    expect(getMilestoneStore().events["first-reward"]).toBeUndefined();
+  });
+
+  it("stamps a brand-new player as migrated without celebrating anything", () => {
+    expect(hasSeededMilestones()).toBe(false);
+
+    seedMilestonesOnce(args(), NOW);
+
+    expect(getMilestoneStore().events).toEqual({});
+    expect(hasSeededMilestones()).toBe(true);
+    expect(localStorage.getItem(milestoneSeedStorageKey())).toBe(NOW);
+  });
+
+  /** An event already on disk is the player's, not the migration's. Seeding
+   *  must never overwrite `earnedAt` — or a pending celebration's timestamp. */
+  it("leaves an existing event untouched", () => {
+    seedStars("rook", VETERAN_STARS);
+    localStorage.setItem(
+      milestoneStorageKey(),
+      JSON.stringify({
+        version: 1,
+        events: {
+          "first-reward": { id: "first-reward", earnedAt: "2026-01-01T00:00:00.000Z" },
+        },
+        dailyDate: NOW.slice(0, 10),
+      }),
+    );
+
+    seedMilestonesOnce(args(), NOW);
+
+    const gift = getMilestoneStore().events["first-reward"];
+    expect(gift.earnedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(gift.celebratedAt).toBeUndefined();
+    // The rest of the ladder still got seeded around it.
+    expect(getMilestoneStore().events["special-training"].celebratedAt).toBe(NOW);
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/stars.test.ts
+++ b/apps/web/src/lib/progression/__tests__/stars.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeAddNetStars,
+  netStars,
+  parseDailyStars,
+  type DailyStarLedger,
+} from "@/lib/progression/stars";
+
+describe("netStars", () => {
+  it("counts only the improvement over the previous best", () => {
+    expect(netStars(1, 3)).toBe(2);
+  });
+
+  it("is zero when a replay does not beat the previous best", () => {
+    expect(netStars(3, 3)).toBe(0);
+  });
+
+  it("is zero when a replay is worse than the previous best", () => {
+    expect(netStars(3, 1)).toBe(0);
+  });
+
+  it("counts the full result for a never-played exercise", () => {
+    expect(netStars(0, 2)).toBe(2);
+  });
+});
+
+describe("parseDailyStars", () => {
+  it("returns a zeroed ledger for a stored date that is not today", () => {
+    const raw = JSON.stringify({ date: "2026-07-10", stars: 8 });
+    expect(parseDailyStars(raw, "2026-07-11")).toEqual({
+      date: "2026-07-11",
+      stars: 0,
+    });
+  });
+
+  it("returns a zeroed ledger for corrupt input", () => {
+    expect(parseDailyStars("{{{", "2026-07-11")).toEqual({
+      date: "2026-07-11",
+      stars: 0,
+    });
+  });
+
+  it("keeps today's ledger", () => {
+    const raw = JSON.stringify({ date: "2026-07-11", stars: 5 });
+    expect(parseDailyStars(raw, "2026-07-11")).toEqual({
+      date: "2026-07-11",
+      stars: 5,
+    });
+  });
+});
+
+describe("computeAddNetStars", () => {
+  it("adds the net gain and leaves the reference untouched on a no-op", () => {
+    const state: DailyStarLedger = { date: "2026-07-11", stars: 5 };
+    expect(computeAddNetStars(state, 0)).toBe(state);
+    expect(computeAddNetStars(state, 2)).toEqual({
+      date: "2026-07-11",
+      stars: 7,
+    });
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
+++ b/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
@@ -133,7 +133,10 @@ describe("useCelebrationQueue", () => {
     });
 
     expect(result.current.current?.id).toBe("mastery");
-    expect(result.current.current?.absorbed).toContain("piece-badge-eligible");
+    expect(result.current.current?.absorbed).toContainEqual({
+      id: "piece-badge-eligible",
+      piece: "rook",
+    });
 
     act(() => {
       result.current.dismissCurrent();
@@ -143,6 +146,54 @@ describe("useCelebrationQueue", () => {
     expect(
       getMilestoneStore().events["piece-badge-eligible:rook"].celebratedAt,
     ).toBeDefined();
+  });
+
+  /** REGRESSION (final review C1). The closer is piece-scoped, the absorbed
+   *  events are GLOBAL. Re-attaching the closer's piece to them built the key
+   *  `great-focus-session:rook`, which matches no event — so `markCelebrated`
+   *  wrote NOTHING and the praise re-fired as a stray overlay on the next
+   *  solve, right after the climax it had been absorbed into. */
+  it("marks a GLOBAL absorbed event celebrated under a piece-scoped closer", () => {
+    const badgeAndGreatSessionArgs: GatherArgs = {
+      piece: "rook",
+      progressByPiece: {
+        rook: { piece: "rook", currentId: null, stars: { "rook-1": 10 } },
+      },
+      dailyStars: 8, // → great-focus-session, a GLOBAL event
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false, // → first-great-session, also GLOBAL
+    };
+
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(badgeAndGreatSessionArgs);
+    });
+
+    // One dialog: the badge closes, the praise rides inside it.
+    expect(result.current.current?.id).toBe("piece-badge-eligible");
+    expect(result.current.current?.absorbed).toContainEqual({
+      id: "great-focus-session",
+    });
+
+    act(() => {
+      result.current.dismissCurrent();
+    });
+
+    const events = getMilestoneStore().events;
+    expect(events["piece-badge-eligible:rook"].celebratedAt).toBeDefined();
+    expect(events["great-focus-session"].celebratedAt).toBeDefined();
+    expect(events["first-great-session"].celebratedAt).toBeDefined();
+    // The bare global keys are the ONLY ones written — no piece-scoped ghost.
+    expect(events["great-focus-session:rook"]).toBeUndefined();
+
+    // The next solve must not resurrect the praise as a second overlay.
+    act(() => {
+      result.current.resolve(badgeAndGreatSessionArgs);
+    });
+    expect(result.current.current).toBeNull();
   });
 
   it("re-queues a still-pending absorbed event when a claim is cancelled", () => {
@@ -171,7 +222,9 @@ describe("useCelebrationQueue", () => {
     });
 
     expect(result.current.current?.id).toBe("piece-badge-eligible");
-    expect(result.current.current?.absorbed).toContain("great-focus-session");
+    expect(result.current.current?.absorbed).toContainEqual({
+      id: "great-focus-session",
+    });
     const step = result.current.current!;
 
     // Cancellation path: release BEFORE dismissing, per the doc comment on

--- a/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
+++ b/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
@@ -64,4 +64,152 @@ describe("useCelebrationQueue", () => {
 
     expect(getMilestoneStore().events["first-reward"].openedAt).toBeDefined();
   });
+
+  it("does not drop the second step on a rapid double-dismiss in the same tick", () => {
+    const twoIncrementalArgs: GatherArgs = {
+      piece: "rook",
+      progressByPiece: {
+        rook: {
+          piece: "rook",
+          currentId: null,
+          stars: { "rook-1": 2, "rook-2": 2, "rook-3": 2 },
+        },
+      },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false,
+    };
+
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(twoIncrementalArgs);
+    });
+
+    // Two steps queued: first-reward, then first-labyrinth.
+    expect(result.current.current?.id).toBe("first-reward");
+
+    // Both calls happen before React commits — the ref must advance
+    // synchronously so the second call reads step B, not step A again.
+    act(() => {
+      result.current.dismissCurrent();
+      result.current.dismissCurrent();
+    });
+
+    expect(result.current.current).toBeNull();
+    expect(getMilestoneStore().events["first-reward"].celebratedAt).toBeDefined();
+    expect(
+      getMilestoneStore().events["first-labyrinth:rook"].celebratedAt,
+    ).toBeDefined();
+  });
+
+  it("marks every absorbed milestone celebrated, not just the closer", () => {
+    // A single exercise carries all 10 stars: `completedExercises` stays at 1
+    // (< 2) and `pieceCompletedExercises` stays at 1 (< 3), so neither
+    // first-reward nor first-labyrinth fire — the queue holds only the
+    // closer, keeping this test's assertions unambiguous.
+    const masteryArgs: GatherArgs = {
+      piece: "rook",
+      progressByPiece: {
+        rook: {
+          piece: "rook",
+          currentId: null,
+          stars: { "rook-1": 10 },
+        },
+      },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: true,
+      allLabyrinthsComplete: true,
+      hadGreatSessionBefore: true,
+    };
+
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(masteryArgs);
+    });
+
+    expect(result.current.current?.id).toBe("mastery");
+    expect(result.current.current?.absorbed).toContain("piece-badge-eligible");
+
+    act(() => {
+      result.current.dismissCurrent();
+    });
+
+    expect(getMilestoneStore().events["mastery:rook"].celebratedAt).toBeDefined();
+    expect(
+      getMilestoneStore().events["piece-badge-eligible:rook"].celebratedAt,
+    ).toBeDefined();
+  });
+
+  it("re-queues a still-pending absorbed event when a claim is cancelled", () => {
+    // Same single-exercise trick as above: keeps first-reward and
+    // first-labyrinth from firing, so the queue holds only the closer.
+    const claimArgs: GatherArgs = {
+      piece: "rook",
+      progressByPiece: {
+        rook: {
+          piece: "rook",
+          currentId: null,
+          stars: { "rook-1": 10 },
+        },
+      },
+      dailyStars: 8,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: true,
+    };
+
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(claimArgs);
+    });
+
+    expect(result.current.current?.id).toBe("piece-badge-eligible");
+    expect(result.current.current?.absorbed).toContain("great-focus-session");
+    const step = result.current.current!;
+
+    // Cancellation path: release BEFORE dismissing, per the doc comment on
+    // `releaseAbsorbed` — dismissing first would already have stamped
+    // `celebratedAt` on the absorbed event, erasing it from `selectPending`.
+    act(() => {
+      result.current.releaseAbsorbed(step);
+    });
+
+    expect(result.current.current?.id).toBe("great-focus-session");
+    expect(getMilestoneStore().events["great-focus-session"].celebratedAt).toBeUndefined();
+  });
+
+  it("refuses to write openedAt for a non-navigable milestone", () => {
+    const greatSessionArgs: GatherArgs = {
+      piece: "rook",
+      progressByPiece: {
+        rook: { piece: "rook", currentId: null, stars: { "rook-1": 2 } },
+      },
+      dailyStars: 8,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: true,
+    };
+
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(greatSessionArgs);
+    });
+
+    expect(result.current.current?.id).toBe("great-focus-session");
+
+    act(() => {
+      result.current.openContent("great-focus-session");
+    });
+
+    expect(getMilestoneStore().events["great-focus-session"].openedAt).toBeUndefined();
+  });
 });

--- a/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
+++ b/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useCelebrationQueue } from "@/lib/progression/use-celebration-queue";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
+import type { GatherArgs } from "@/lib/progression/gather-input";
+
+const solveArgs: GatherArgs = {
+  piece: "rook",
+  progressByPiece: {
+    rook: { piece: "rook", currentId: null, stars: { "rook-1": 2, "rook-2": 2 } },
+  },
+  dailyStars: 4,
+  sessionQuotaExhausted: false,
+  badgeClaimed: false,
+  allLabyrinthsComplete: false,
+  hadGreatSessionBefore: false,
+};
+
+describe("useCelebrationQueue", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists the event BEFORE it exposes the overlay", () => {
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+
+    // On disk already — an app killed right now loses nothing.
+    expect(getMilestoneStore().events["first-reward"]).toBeDefined();
+    expect(result.current.current?.id).toBe("first-reward");
+  });
+
+  it("stamps celebratedAt on dismiss and does not replay the overlay", () => {
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+    act(() => {
+      result.current.dismissCurrent();
+    });
+
+    expect(result.current.current).toBeNull();
+    expect(getMilestoneStore().events["first-reward"].celebratedAt).toBeDefined();
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+    expect(result.current.current).toBeNull();
+  });
+
+  it("clears the NEW dot when the content is opened", () => {
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+    act(() => {
+      result.current.openContent("first-reward");
+    });
+
+    expect(getMilestoneStore().events["first-reward"].openedAt).toBeDefined();
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/use-milestone-seeding.test.ts
+++ b/apps/web/src/lib/progression/__tests__/use-milestone-seeding.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { isMilestoneSeedReady } from "../use-milestone-seeding";
+
+/**
+ * The seeding gate — the single thing standing between a veteran player and a
+ * retroactive parade of overlays for history they lived months ago.
+ *
+ * The gate shipped bare in the previous fix: the expression lived inline in two
+ * components, so nothing could go red if one of them drifted. It is a pure
+ * function now, used by BOTH `exercises-screen.tsx` and `legacy-hub-client.tsx`.
+ */
+describe("isMilestoneSeedReady", () => {
+  it("waits while wagmi is connecting — the badge read is DISABLED, not empty", () => {
+    // The trap the old `!isBadgesLoading` gate fell into: a disabled TanStack
+    // query reports `isLoading === false`, so "not loading" read as "answered".
+    // `badgeStateKnown: false` is the honest signal, and it must dominate.
+    expect(
+      isMilestoneSeedReady({ accountStatus: "connecting", badgeStateKnown: false }),
+    ).toBe(false);
+    // Even a stale answer from a previous session must not unblock a connect
+    // that has not landed: the address it was read for may not be this one.
+    expect(
+      isMilestoneSeedReady({ accountStatus: "connecting", badgeStateKnown: true }),
+    ).toBe(false);
+  });
+
+  it("waits while wagmi is reconnecting — the mainline MiniPay boot state", () => {
+    expect(
+      isMilestoneSeedReady({ accountStatus: "reconnecting", badgeStateKnown: false }),
+    ).toBe(false);
+    expect(
+      isMilestoneSeedReady({ accountStatus: "reconnecting", badgeStateKnown: true }),
+    ).toBe(false);
+  });
+
+  it("seeds a DISCONNECTED, wallet-less player — no wallet means no badges", () => {
+    // `resolve()` would read exactly the same `badgeClaimed: false`. Refusing to
+    // seed here would strand every wallet-less player unmigrated forever.
+    expect(
+      isMilestoneSeedReady({ accountStatus: "disconnected", badgeStateKnown: false }),
+    ).toBe(true);
+  });
+
+  it("seeds a connected player only once the badge read has ANSWERED", () => {
+    expect(
+      isMilestoneSeedReady({ accountStatus: "connected", badgeStateKnown: false }),
+    ).toBe(false);
+    expect(
+      isMilestoneSeedReady({ accountStatus: "connected", badgeStateKnown: true }),
+    ).toBe(true);
+  });
+
+  it("never seeds on an unsupported chain, where the badge state is unknowable", () => {
+    // `getBadgesAddress()` returns null off the configured chain, so the read
+    // stays disabled and `badgeStateKnown` is false FOREVER. Treating that as
+    // "no badges" would stamp the profile migrated with `piece-badge-claimed`
+    // and `mastery` unseeded — and the veteran's real badges would fire as
+    // fresh overlays the moment they switched back.
+    expect(
+      isMilestoneSeedReady({ accountStatus: "connected", badgeStateKnown: false }),
+    ).toBe(false);
+  });
+
+  it("is not ready before wagmi reports any status at all", () => {
+    expect(
+      isMilestoneSeedReady({ accountStatus: undefined, badgeStateKnown: true }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/progression/celebration-queue.ts
+++ b/apps/web/src/lib/progression/celebration-queue.ts
@@ -22,8 +22,16 @@ const CLOSER_ORDER: MilestoneId[] = [
 export type CelebrationStep = {
   id: MilestoneId;
   piece?: PieceId;
-  /** Lower majors rendered as lines inside this overlay, never as modals. */
-  absorbed: MilestoneId[];
+  /** Lower majors rendered as lines inside this overlay, never as modals.
+   *
+   *  Carries the FULL event, piece and all — not a bare id. The absorbed
+   *  events do not necessarily share the closer's scope: a piece-scoped
+   *  closer (`mastery:rook`) routinely absorbs GLOBAL events
+   *  (`great-focus-session`). Storing only the id forced the dismiss path to
+   *  re-attach the closer's piece, building the key `great-focus-session:rook`
+   *  — which matches no event, so the absorbed event was never marked
+   *  celebrated and popped again as a stray overlay on the next solve. */
+  absorbed: EarnedMilestone[];
 };
 
 export function buildCelebrationQueue(
@@ -43,10 +51,15 @@ export function buildCelebrationQueue(
 
   const [closerId, ...absorbedClosers] = firedClosers;
   const closer = find(closerId);
-  const absorbed: MilestoneId[] = [...absorbedClosers];
+  // `absorbedClosers` only holds ids `find` already resolved, so every lookup
+  // below is guaranteed to hit — the filter is for the type, not for safety.
+  const absorbed: EarnedMilestone[] = absorbedClosers
+    .map((id) => find(id))
+    .filter((event): event is EarnedMilestone => Boolean(event));
 
   // first-great-session is an achievement, never an overlay of its own.
-  if (find("first-great-session")) absorbed.push("first-great-session");
+  const firstGreatSession = find("first-great-session");
+  if (firstGreatSession) absorbed.push(firstGreatSession);
 
   steps.push({ id: closerId, piece: closer?.piece, absorbed });
   return steps;

--- a/apps/web/src/lib/progression/celebration-queue.ts
+++ b/apps/web/src/lib/progression/celebration-queue.ts
@@ -1,0 +1,53 @@
+import type { PieceId } from "@/lib/game/types";
+import type { EarnedMilestone } from "./milestones";
+import type { MilestoneId } from "./types";
+
+/** Incremental unlocks. Each gets its own overlay because each carries a CTA
+ *  to different content. None of them concludes anything — they invite action. */
+const INCREMENTAL_ORDER: MilestoneId[] = [
+  "first-reward",
+  "first-labyrinth",
+  "special-training",
+];
+
+/** Majors, highest hierarchy first. Exactly ONE renders per drain; every
+ *  other major that fired is absorbed as a line inside it. Showing MASTERY!
+ *  and then GREAT FOCUS SESSION! drops the intensity after the climax. */
+const CLOSER_ORDER: MilestoneId[] = [
+  "mastery",
+  "piece-badge-eligible",
+  "great-focus-session",
+];
+
+export type CelebrationStep = {
+  id: MilestoneId;
+  piece?: PieceId;
+  /** Lower majors rendered as lines inside this overlay, never as modals. */
+  absorbed: MilestoneId[];
+};
+
+export function buildCelebrationQueue(
+  pending: readonly EarnedMilestone[],
+): CelebrationStep[] {
+  const find = (id: MilestoneId) => pending.find((event) => event.id === id);
+
+  const steps: CelebrationStep[] = [];
+
+  for (const id of INCREMENTAL_ORDER) {
+    const event = find(id);
+    if (event) steps.push({ id, piece: event.piece, absorbed: [] });
+  }
+
+  const firedClosers = CLOSER_ORDER.filter((id) => find(id));
+  if (firedClosers.length === 0) return steps;
+
+  const [closerId, ...absorbedClosers] = firedClosers;
+  const closer = find(closerId);
+  const absorbed: MilestoneId[] = [...absorbedClosers];
+
+  // first-great-session is an achievement, never an overlay of its own.
+  if (find("first-great-session")) absorbed.push("first-great-session");
+
+  steps.push({ id: closerId, piece: closer?.piece, absorbed });
+  return steps;
+}

--- a/apps/web/src/lib/progression/gather-input.ts
+++ b/apps/web/src/lib/progression/gather-input.ts
@@ -10,6 +10,8 @@ export type GatherArgs = {
   badgeClaimed: boolean;
   allLabyrinthsComplete: boolean;
   hadGreatSessionBefore: boolean;
+  /** Lite-only gift. Omitted = available. See `MilestoneInput.giftAvailable`. */
+  giftAvailable?: boolean;
 };
 
 function sumStars(progress: PieceProgress | undefined): number {
@@ -45,5 +47,6 @@ export function gatherMilestoneInput(args: GatherArgs): MilestoneInput {
     badgeClaimed: args.badgeClaimed,
     allLabyrinthsComplete: args.allLabyrinthsComplete,
     hadGreatSessionBefore: args.hadGreatSessionBefore,
+    giftAvailable: args.giftAvailable,
   };
 }

--- a/apps/web/src/lib/progression/gather-input.ts
+++ b/apps/web/src/lib/progression/gather-input.ts
@@ -1,0 +1,49 @@
+import type { PieceId, PieceProgress } from "@/lib/game/types";
+import type { MilestoneInput } from "./milestones";
+
+export type GatherArgs = {
+  piece: PieceId;
+  /** Every piece's persisted progress. Missing pieces read as zero. */
+  progressByPiece: Partial<Record<PieceId, PieceProgress>>;
+  dailyStars: number;
+  sessionQuotaExhausted: boolean;
+  badgeClaimed: boolean;
+  allLabyrinthsComplete: boolean;
+  hadGreatSessionBefore: boolean;
+};
+
+function sumStars(progress: PieceProgress | undefined): number {
+  if (!progress) return 0;
+  return Object.values(progress.stars).reduce((sum, value) => sum + value, 0);
+}
+
+/** An exercise counts as completed once it has been solved at least once.
+ *  A sparse 0 means "played and scored nothing", which is not a completion. */
+function countCompleted(progress: PieceProgress | undefined): number {
+  if (!progress) return 0;
+  return Object.values(progress.stars).filter((value) => value > 0).length;
+}
+
+/** Adapter: reads already-persisted progress and shapes it for the pure core.
+ *  Introduces NO new source of truth for stars. */
+export function gatherMilestoneInput(args: GatherArgs): MilestoneInput {
+  const pieces = Object.values(args.progressByPiece) as PieceProgress[];
+  const current = args.progressByPiece[args.piece];
+
+  return {
+    piece: args.piece,
+    lifetimeStars: pieces.reduce((sum, progress) => sum + sumStars(progress), 0),
+    completedExercises: pieces.reduce(
+      (sum, progress) => sum + countCompleted(progress),
+      0,
+    ),
+    pieceStars: sumStars(current),
+    pieceCompletedExercises: countCompleted(current),
+    rookStars: sumStars(args.progressByPiece.rook),
+    dailyStars: args.dailyStars,
+    sessionQuotaExhausted: args.sessionQuotaExhausted,
+    badgeClaimed: args.badgeClaimed,
+    allLabyrinthsComplete: args.allLabyrinthsComplete,
+    hadGreatSessionBefore: args.hadGreatSessionBefore,
+  };
+}

--- a/apps/web/src/lib/progression/migration.ts
+++ b/apps/web/src/lib/progression/migration.ts
@@ -1,0 +1,55 @@
+import { deriveEarnedMilestones, type MilestoneInput } from "./milestones";
+import {
+  milestoneKey,
+  NAVIGABLE_MILESTONES,
+  type MilestoneEvent,
+  type MilestoneId,
+  type MilestoneStore,
+} from "./types";
+
+/** Daily milestones are never seeded: today's session is still live and the
+ *  player deserves the chance to earn it. */
+const NEVER_SEEDED: readonly MilestoneId[] = [
+  "great-focus-session",
+  "first-great-session",
+];
+
+/** Stamps every milestone an existing player already passed as celebrated,
+ *  so upgrading the app never fires a retroactive parade. State preserved,
+ *  overlay suppressed. Idempotent: returns the same reference once seeded. */
+export function seedExistingPlayer(
+  store: MilestoneStore,
+  input: MilestoneInput,
+  welcomeClaimed: boolean,
+  now: string,
+): MilestoneStore {
+  const earned = deriveEarnedMilestones(input).filter(
+    (event) => !NEVER_SEEDED.includes(event.id),
+  );
+  const fresh = earned.filter(
+    (event) => !store.events[milestoneKey(event.id, event.piece)],
+  );
+  if (fresh.length === 0) return store;
+
+  const events = { ...store.events };
+  for (const event of fresh) {
+    const record: MilestoneEvent = {
+      id: event.id,
+      earnedAt: now,
+      celebratedAt: now,
+    };
+    if (event.piece) record.piece = event.piece;
+
+    if (NAVIGABLE_MILESTONES.includes(event.id)) {
+      // The gift is the ONE navigable milestone with a pre-existing claim
+      // state, so it is the only one that can still owe the player a NEW dot.
+      // An unclaimed gift keeps its dot; a claimed gift and every other
+      // milestone the player has already lived through count as opened.
+      const opened = event.id === "first-reward" ? welcomeClaimed : true;
+      if (opened) record.openedAt = now;
+    }
+
+    events[milestoneKey(event.id, event.piece)] = record;
+  }
+  return { ...store, events };
+}

--- a/apps/web/src/lib/progression/milestone-storage.ts
+++ b/apps/web/src/lib/progression/milestone-storage.ts
@@ -1,0 +1,154 @@
+import type { PieceId } from "@/lib/game/types";
+import { todayUtc } from "@/lib/daily/progress";
+import { milestoneStorageKey } from "@/lib/lite-progress-storage";
+import type { EarnedMilestone } from "./milestones";
+import {
+  EMPTY_STORE,
+  milestoneKey,
+  NAVIGABLE_MILESTONES,
+  type MilestoneEvent,
+  type MilestoneId,
+  type MilestoneStore,
+} from "./types";
+
+/** Resets with the UTC day. Everything else is cumulative and permanent. */
+const DAILY_MILESTONES: readonly MilestoneId[] = ["great-focus-session"];
+
+export function parseMilestoneStore(
+  raw: string | null,
+  today: string = todayUtc(),
+): MilestoneStore {
+  if (!raw) return EMPTY_STORE;
+  let parsed: Partial<MilestoneStore>;
+  try {
+    parsed = JSON.parse(raw) as Partial<MilestoneStore>;
+  } catch {
+    return EMPTY_STORE;
+  }
+  if (parsed.version !== 1 || typeof parsed.events !== "object" || !parsed.events) {
+    return EMPTY_STORE;
+  }
+
+  const events = { ...parsed.events };
+  if (parsed.dailyDate !== today) {
+    for (const id of DAILY_MILESTONES) {
+      delete events[id];
+    }
+  }
+  return { version: 1, events, dailyDate: today };
+}
+
+/** Records every earned milestone that is not already on disk. Returns the
+ *  SAME reference when nothing is new, so callers can skip the write. */
+export function computeRecordEarned(
+  store: MilestoneStore,
+  earned: readonly EarnedMilestone[],
+  now: string,
+): MilestoneStore {
+  const fresh = earned.filter(
+    (event) => !store.events[milestoneKey(event.id, event.piece)],
+  );
+  if (fresh.length === 0) return store;
+
+  const events = { ...store.events };
+  for (const event of fresh) {
+    const record: MilestoneEvent = { id: event.id, earnedAt: now };
+    if (event.piece) record.piece = event.piece;
+    events[milestoneKey(event.id, event.piece)] = record;
+  }
+  return { ...store, events };
+}
+
+export function computeMarkCelebrated(
+  store: MilestoneStore,
+  id: MilestoneId,
+  piece: PieceId | undefined,
+  now: string,
+): MilestoneStore {
+  const key = milestoneKey(id, piece);
+  const event = store.events[key];
+  if (!event || event.celebratedAt) return store;
+  return {
+    ...store,
+    events: { ...store.events, [key]: { ...event, celebratedAt: now } },
+  };
+}
+
+/** Only a navigable milestone has somewhere to go. Writing `openedAt` on a
+ *  recognition would invent a state with no meaning, so it is refused. */
+export function computeMarkOpened(
+  store: MilestoneStore,
+  id: MilestoneId,
+  piece: PieceId | undefined,
+  now: string,
+): MilestoneStore {
+  if (!NAVIGABLE_MILESTONES.includes(id)) return store;
+  const key = milestoneKey(id, piece);
+  const event = store.events[key];
+  if (!event || event.openedAt) return store;
+  return {
+    ...store,
+    events: { ...store.events, [key]: { ...event, openedAt: now } },
+  };
+}
+
+/** Earned but never celebrated. This is what the queue drains. */
+export function selectPending(store: MilestoneStore): EarnedMilestone[] {
+  return Object.values(store.events)
+    .filter((event) => !event.celebratedAt)
+    .map((event) => ({ id: event.id, piece: event.piece }));
+}
+
+// ─── localStorage I/O ────────────────────────────────────────────────────
+
+export function getMilestoneStore(): MilestoneStore {
+  if (typeof window === "undefined") return parseMilestoneStore(null);
+  try {
+    return parseMilestoneStore(localStorage.getItem(milestoneStorageKey()));
+  } catch {
+    return parseMilestoneStore(null);
+  }
+}
+
+function persist(store: MilestoneStore): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(milestoneStorageKey(), JSON.stringify(store));
+  } catch {
+    // Quota or privacy mode — the caller still gets the correct state back.
+  }
+}
+
+/** Persists BEFORE anything is rendered. If the app dies mid-overlay the
+ *  event is already on disk, so it neither replays nor gets lost. */
+export function recordEarned(
+  earned: readonly EarnedMilestone[],
+  now: string = new Date().toISOString(),
+): MilestoneStore {
+  const current = getMilestoneStore();
+  const next = computeRecordEarned(current, earned, now);
+  if (next !== current) persist(next);
+  return next;
+}
+
+export function markCelebrated(
+  id: MilestoneId,
+  piece?: PieceId,
+  now: string = new Date().toISOString(),
+): MilestoneStore {
+  const current = getMilestoneStore();
+  const next = computeMarkCelebrated(current, id, piece, now);
+  if (next !== current) persist(next);
+  return next;
+}
+
+export function markOpened(
+  id: MilestoneId,
+  piece?: PieceId,
+  now: string = new Date().toISOString(),
+): MilestoneStore {
+  const current = getMilestoneStore();
+  const next = computeMarkOpened(current, id, piece, now);
+  if (next !== current) persist(next);
+  return next;
+}

--- a/apps/web/src/lib/progression/milestone-storage.ts
+++ b/apps/web/src/lib/progression/milestone-storage.ts
@@ -31,7 +31,13 @@ export function parseMilestoneStore(
   // `null` makes the very next daily-reset comparison see `null !== today`
   // and wipe an event that was just recorded, before it was ever
   // celebrated (the "double celebration" bug).
-  const empty = { ...EMPTY_STORE, dailyDate: today };
+  //
+  // Built as its own literal (not `{ ...EMPTY_STORE, dailyDate: today }`) so
+  // `events` is a fresh object per call. `EMPTY_STORE.events` is frozen but
+  // that freeze is shallow — spreading EMPTY_STORE would still alias its
+  // `events` reference into every fresh store, so a future in-place mutation
+  // on one parse-fresh store would poison the shared singleton.
+  const empty: MilestoneStore = { version: 1, events: {}, dailyDate: today };
   if (!raw) return empty;
 
   let parsed: unknown;

--- a/apps/web/src/lib/progression/milestone-storage.ts
+++ b/apps/web/src/lib/progression/milestone-storage.ts
@@ -14,25 +14,59 @@ import {
 /** Resets with the UTC day. Everything else is cumulative and permanent. */
 const DAILY_MILESTONES: readonly MilestoneId[] = ["great-focus-session"];
 
+/** Narrows an unknown `events` entry to a well-formed `MilestoneEvent`. A
+ *  partially-written or corrupted entry (e.g. `null`) is silently dropped
+ *  rather than crashing the reader that dereferences it downstream. */
+function isValidMilestoneEvent(value: unknown): value is MilestoneEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<MilestoneEvent>;
+  return typeof candidate.id === "string" && typeof candidate.earnedAt === "string";
+}
+
 export function parseMilestoneStore(
   raw: string | null,
   today: string = todayUtc(),
 ): MilestoneStore {
-  if (!raw) return EMPTY_STORE;
-  let parsed: Partial<MilestoneStore>;
+  // A fresh store must still stamp `dailyDate` to `today` — leaving it
+  // `null` makes the very next daily-reset comparison see `null !== today`
+  // and wipe an event that was just recorded, before it was ever
+  // celebrated (the "double celebration" bug).
+  const empty = { ...EMPTY_STORE, dailyDate: today };
+  if (!raw) return empty;
+
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(raw) as Partial<MilestoneStore>;
+    parsed = JSON.parse(raw);
   } catch {
-    return EMPTY_STORE;
-  }
-  if (parsed.version !== 1 || typeof parsed.events !== "object" || !parsed.events) {
-    return EMPTY_STORE;
+    return empty;
   }
 
-  const events = { ...parsed.events };
-  if (parsed.dailyDate !== today) {
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as Partial<MilestoneStore>).version !== 1 ||
+    typeof (parsed as Partial<MilestoneStore>).events !== "object" ||
+    !(parsed as Partial<MilestoneStore>).events
+  ) {
+    return empty;
+  }
+
+  const rawEvents = (parsed as MilestoneStore).events;
+  const events: Record<string, MilestoneEvent> = {};
+  for (const [key, event] of Object.entries(rawEvents)) {
+    if (isValidMilestoneEvent(event)) {
+      events[key] = event;
+    }
+  }
+
+  const storedDailyDate = (parsed as Partial<MilestoneStore>).dailyDate ?? null;
+  if (storedDailyDate !== today) {
     for (const id of DAILY_MILESTONES) {
-      delete events[id];
+      for (const key of Object.keys(events)) {
+        if (key === id || key.startsWith(`${id}:`)) {
+          delete events[key];
+        }
+      }
     }
   }
   return { version: 1, events, dailyDate: today };

--- a/apps/web/src/lib/progression/milestone-storage.ts
+++ b/apps/web/src/lib/progression/milestone-storage.ts
@@ -150,7 +150,10 @@ export function getMilestoneStore(): MilestoneStore {
   }
 }
 
-function persist(store: MilestoneStore): void {
+/** The single write path for a WHOLE store. Exported for the one-time
+ *  migration, which rewrites many events at once and must not reach into
+ *  localStorage on its own. */
+export function persistMilestoneStore(store: MilestoneStore): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(milestoneStorageKey(), JSON.stringify(store));
@@ -158,6 +161,8 @@ function persist(store: MilestoneStore): void {
     // Quota or privacy mode — the caller still gets the correct state back.
   }
 }
+
+const persist = persistMilestoneStore;
 
 /** Persists BEFORE anything is rendered. If the app dies mid-overlay the
  *  event is already on disk, so it neither replays nor gets lost. */

--- a/apps/web/src/lib/progression/milestones.ts
+++ b/apps/web/src/lib/progression/milestones.ts
@@ -37,6 +37,14 @@ export type MilestoneInput = {
   allLabyrinthsComplete: boolean;
   /** Whether a Great Focus Session was ever recognized before today. */
   hadGreatSessionBefore: boolean;
+  /**
+   * Whether the Welcome Package gift can actually be delivered in this build.
+   * The gift is a Lite-only product — `useWelcomePackage()` and
+   * `unlockWelcomePackageGift()` are both no-ops in Full mode — so a Full
+   * build must not celebrate an unlock it can never hand over. Defaults to
+   * `true`: the gift is assumed available unless the caller says otherwise.
+   */
+  giftAvailable?: boolean;
 };
 
 export type EarnedMilestone = {
@@ -51,6 +59,7 @@ export function deriveEarnedMilestones(input: MilestoneInput): EarnedMilestone[]
   const { piece } = input;
 
   if (
+    (input.giftAvailable ?? true) &&
     input.lifetimeStars >= GIFT_STARS &&
     input.completedExercises >= GIFT_EXERCISES
   ) {

--- a/apps/web/src/lib/progression/milestones.ts
+++ b/apps/web/src/lib/progression/milestones.ts
@@ -1,6 +1,9 @@
 import type { PieceId } from "@/lib/game/types";
 import { BADGE_THRESHOLD } from "@/lib/game/exercises";
-import { LABYRINTH_UNLOCK_THRESHOLD } from "@/lib/training/path";
+import {
+  LABYRINTH_MIN_EXERCISES,
+  LABYRINTH_UNLOCK_THRESHOLD,
+} from "@/lib/training/path";
 import type { MilestoneId } from "./types";
 
 /** The gift is a once-ever event, so it reads once-ever counters. A daily
@@ -8,10 +11,6 @@ import type { MilestoneId } from "./types";
  *  Tuesday: the counter resets at UTC midnight and the gift never lands. */
 export const GIFT_STARS = 4;
 export const GIFT_EXERCISES = 2;
-
-/** The exercise floor that keeps the gift and the labyrinth from firing on
- *  the same solve for a perfect player. */
-export const LABYRINTH_EXERCISES = 3;
 
 export const SPECIAL_TRAINING_ROOK_STARS = 12;
 
@@ -60,7 +59,7 @@ export function deriveEarnedMilestones(input: MilestoneInput): EarnedMilestone[]
 
   if (
     input.pieceStars >= LABYRINTH_UNLOCK_THRESHOLD &&
-    input.pieceCompletedExercises >= LABYRINTH_EXERCISES
+    input.pieceCompletedExercises >= LABYRINTH_MIN_EXERCISES
   ) {
     earned.push({ id: "first-labyrinth", piece });
   }

--- a/apps/web/src/lib/progression/milestones.ts
+++ b/apps/web/src/lib/progression/milestones.ts
@@ -1,0 +1,94 @@
+import type { PieceId } from "@/lib/game/types";
+import { BADGE_THRESHOLD } from "@/lib/game/exercises";
+import { LABYRINTH_UNLOCK_THRESHOLD } from "@/lib/training/path";
+import type { MilestoneId } from "./types";
+
+/** The gift is a once-ever event, so it reads once-ever counters. A daily
+ *  threshold would strand a player who earns 3 stars on Monday and 1 on
+ *  Tuesday: the counter resets at UTC midnight and the gift never lands. */
+export const GIFT_STARS = 4;
+export const GIFT_EXERCISES = 2;
+
+/** The exercise floor that keeps the gift and the labyrinth from firing on
+ *  the same solve for a perfect player. */
+export const LABYRINTH_EXERCISES = 3;
+
+export const SPECIAL_TRAINING_ROOK_STARS = 12;
+
+export const GREAT_SESSION_STARS = 8;
+
+export type MilestoneInput = {
+  /** The piece currently under play — scopes the per-piece milestones. */
+  piece: PieceId;
+  /** Best exercise stars summed across every piece. Cumulative. */
+  lifetimeStars: number;
+  /** Exercises solved at least once, across every piece. Cumulative. */
+  completedExercises: number;
+  /** Best exercise stars for `piece`. Labyrinth stars NEVER count here. */
+  pieceStars: number;
+  /** Exercises of `piece` solved at least once. */
+  pieceCompletedExercises: number;
+  /** Rook exercise stars — the Special Training gate. */
+  rookStars: number;
+  /** Net stars earned today, exercises AND labyrinths. */
+  dailyStars: number;
+  sessionQuotaExhausted: boolean;
+  /** On-chain claim state for `piece`. */
+  badgeClaimed: boolean;
+  allLabyrinthsComplete: boolean;
+  /** Whether a Great Focus Session was ever recognized before today. */
+  hadGreatSessionBefore: boolean;
+};
+
+export type EarnedMilestone = {
+  id: MilestoneId;
+  piece?: PieceId;
+};
+
+/** Pure. Returns every milestone whose condition is currently TRUE — it does
+ *  NOT know or care which ones already fired. Idempotence lives in storage. */
+export function deriveEarnedMilestones(input: MilestoneInput): EarnedMilestone[] {
+  const earned: EarnedMilestone[] = [];
+  const { piece } = input;
+
+  if (
+    input.lifetimeStars >= GIFT_STARS &&
+    input.completedExercises >= GIFT_EXERCISES
+  ) {
+    earned.push({ id: "first-reward" });
+  }
+
+  if (
+    input.pieceStars >= LABYRINTH_UNLOCK_THRESHOLD &&
+    input.pieceCompletedExercises >= LABYRINTH_EXERCISES
+  ) {
+    earned.push({ id: "first-labyrinth", piece });
+  }
+
+  if (input.rookStars >= SPECIAL_TRAINING_ROOK_STARS) {
+    earned.push({ id: "special-training" });
+  }
+
+  if (input.pieceStars >= BADGE_THRESHOLD) {
+    earned.push({ id: "piece-badge-eligible", piece });
+    if (input.badgeClaimed) {
+      earned.push({ id: "piece-badge-claimed", piece });
+    }
+  }
+
+  // The crown cannot rest on a badge that was never minted.
+  if (input.badgeClaimed && input.allLabyrinthsComplete) {
+    earned.push({ id: "mastery", piece });
+  }
+
+  const greatSession =
+    input.dailyStars >= GREAT_SESSION_STARS || input.sessionQuotaExhausted;
+  if (greatSession) {
+    earned.push({ id: "great-focus-session" });
+    if (!input.hadGreatSessionBefore) {
+      earned.push({ id: "first-great-session" });
+    }
+  }
+
+  return earned;
+}

--- a/apps/web/src/lib/progression/seed-milestones.ts
+++ b/apps/web/src/lib/progression/seed-milestones.ts
@@ -1,0 +1,150 @@
+import type { PieceId, PieceProgress } from "@/lib/game/types";
+import { readPieceStars } from "@/lib/game/exercise-progress";
+import { areAllLabyrinthsSolved } from "@/lib/game/labyrinth-progress";
+import { milestoneSeedStorageKey } from "@/lib/lite-progress-storage";
+import { getWelcomePackageState } from "@/lib/welcome-package/storage";
+import { gatherMilestoneInput } from "./gather-input";
+import { seedExistingPlayer } from "./migration";
+import { getMilestoneStore, persistMilestoneStore } from "./milestone-storage";
+import type { MilestoneStore } from "./types";
+
+const PIECES: readonly PieceId[] = [
+  "rook",
+  "bishop",
+  "knight",
+  "pawn",
+  "queen",
+  "king",
+];
+
+export type SeedMilestonesArgs = {
+  /** On-chain claim state per piece. A piece absent from the map reads as
+   *  "not claimed" — the same thing `resolve()` would see. */
+  badgeClaimedByPiece: Partial<Record<PieceId, boolean>>;
+  /** The labyrinth catalog, per piece. `mastery` needs it. */
+  labyrinthIdsByPiece: Partial<Record<PieceId, readonly string[]>>;
+  /** The gift is a Lite-only product — see `MilestoneInput.giftAvailable`. */
+  giftAvailable: boolean;
+};
+
+/** Every piece's persisted stars, straight off the disk.
+ *
+ *  Deliberately NOT taken from React state: `starsPerPiece` only arrives in a
+ *  post-mount effect, so a seed that waited for it would either read empty
+ *  progress (and seed nothing) or land after the screen had already resolved.
+ *  localStorage is synchronous and is the same source those effects read. */
+function readProgressByPiece(): Partial<Record<PieceId, PieceProgress>> {
+  const out: Partial<Record<PieceId, PieceProgress>> = {};
+  for (const piece of PIECES) {
+    out[piece] = { piece, currentId: null, stars: readPieceStars(piece) };
+  }
+  return out;
+}
+
+/** A piece the player has actually touched. `seedExistingPlayer` is scoped to
+ *  ONE piece (`MilestoneInput.piece` scopes `first-labyrinth`,
+ *  `piece-badge-*` and `mastery`), so seeding only for rook would hand a
+ *  second-piece veteran a retroactive parade the day a second piece ships. */
+function piecesWithProgress(
+  progressByPiece: Partial<Record<PieceId, PieceProgress>>,
+): PieceId[] {
+  return PIECES.filter((piece) => {
+    const stars = progressByPiece[piece]?.stars ?? {};
+    return Object.values(stars).some((value) => value > 0);
+  });
+}
+
+/** Pure core: folds one `seedExistingPlayer` pass per played piece over the
+ *  store. Exported for tests — production goes through `seedMilestonesOnce`. */
+export function computeSeededStore(
+  store: MilestoneStore,
+  progressByPiece: Partial<Record<PieceId, PieceProgress>>,
+  args: SeedMilestonesArgs,
+  welcomeClaimed: boolean,
+  now: string,
+): MilestoneStore {
+  let next = store;
+  for (const piece of piecesWithProgress(progressByPiece)) {
+    const input = gatherMilestoneInput({
+      piece,
+      progressByPiece,
+      // Today's session is NOT history. `great-focus-session` and
+      // `first-great-session` are still up for grabs, and `seedExistingPlayer`
+      // refuses to seed them anyway — these zeros just say the same thing
+      // twice, and keep a live session from leaking into a migration.
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: args.badgeClaimedByPiece[piece] === true,
+      allLabyrinthsComplete: areAllLabyrinthsSolved(
+        piece,
+        args.labyrinthIdsByPiece[piece] ?? [],
+      ),
+      hadGreatSessionBefore: false,
+      giftAvailable: args.giftAvailable,
+    });
+    next = seedExistingPlayer(next, input, welcomeClaimed, now);
+  }
+  return next;
+}
+
+export function hasSeededMilestones(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return localStorage.getItem(milestoneSeedStorageKey()) !== null;
+  } catch {
+    // No storage → no migration. Refusing to seed is the safe read: seeding
+    // is what SUPPRESSES overlays, and a store we cannot persist would make
+    // every mount re-seed from scratch.
+    return true;
+  }
+}
+
+/** Stamps the profile as migrated. Written even when nothing was seeded (a
+ *  brand-new player): the marker means "the migration ran", not "the player
+ *  had history". Without that, a new player would keep re-entering the
+ *  migration path after every solve — and eat their own celebrations. */
+export function markMilestonesSeeded(now = new Date().toISOString()): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(milestoneSeedStorageKey(), now);
+  } catch {
+    // Quota or privacy mode — nothing to do.
+  }
+}
+
+/**
+ * The migration. Stamps `celebratedAt` (and `openedAt` where the milestone is
+ * navigable) on every milestone an existing player already passed, so the
+ * upgrade never fires a retroactive parade: state preserved, overlay
+ * suppressed.
+ *
+ * Runs AT MOST ONCE per profile, guarded by `milestoneSeedStorageKey()`. That
+ * guard is load-bearing, not an optimization: an event that is earned and
+ * still awaiting its celebration is indistinguishable, on disk, from one that
+ * was never seeded. Re-running the seed later would stamp it celebrated and
+ * silently eat the overlay the player was owed.
+ *
+ * Returns the store it committed, or `null` when the profile was already
+ * migrated.
+ */
+export function seedMilestonesOnce(
+  args: SeedMilestonesArgs,
+  now: string = new Date().toISOString(),
+): MilestoneStore | null {
+  if (typeof window === "undefined") return null;
+  if (hasSeededMilestones()) return null;
+
+  const store = getMilestoneStore();
+  const next = computeSeededStore(
+    store,
+    readProgressByPiece(),
+    args,
+    getWelcomePackageState().claimed,
+    now,
+  );
+  // Persist BEFORE the marker: a write that fails must not be recorded as a
+  // migration that ran.
+  if (next !== store) persistMilestoneStore(next);
+  markMilestonesSeeded(now);
+  return next;
+}

--- a/apps/web/src/lib/progression/stars.ts
+++ b/apps/web/src/lib/progression/stars.ts
@@ -1,0 +1,74 @@
+import { todayUtc } from "@/lib/daily/progress";
+import { dailyStarsStorageKey } from "@/lib/lite-progress-storage";
+
+/** Stars earned today. The ONLY daily counter in the progression system.
+ *  Fed by exercises AND labyrinths, always as net improvement — replaying
+ *  a solved exercise must never inflate a session. */
+export type DailyStarLedger = {
+  date: string;
+  stars: number;
+};
+
+/** The improvement a result represents over the player's previous best.
+ *  A replay that does not beat the best contributes nothing. */
+export function netStars(previousBest: number, newStars: number): number {
+  return Math.max(0, newStars - previousBest);
+}
+
+export function parseDailyStars(
+  raw: string | null,
+  today: string = todayUtc(),
+): DailyStarLedger {
+  const fresh: DailyStarLedger = { date: today, stars: 0 };
+  if (!raw) return fresh;
+  try {
+    const parsed = JSON.parse(raw) as Partial<DailyStarLedger>;
+    if (parsed?.date !== today) return fresh;
+    return {
+      date: today,
+      stars: typeof parsed.stars === "number" ? Math.max(0, parsed.stars) : 0,
+    };
+  } catch {
+    return fresh;
+  }
+}
+
+export function computeAddNetStars(
+  state: DailyStarLedger,
+  gain: number,
+): DailyStarLedger {
+  if (gain <= 0) return state;
+  return { ...state, stars: state.stars + gain };
+}
+
+// ─── localStorage I/O ────────────────────────────────────────────────────
+
+export function getDailyStarLedger(): DailyStarLedger {
+  if (typeof window === "undefined") return parseDailyStars(null);
+  try {
+    return parseDailyStars(localStorage.getItem(dailyStarsStorageKey()));
+  } catch {
+    return parseDailyStars(null);
+  }
+}
+
+/** Convenience read for callers that only need the number. */
+export function getDailyStars(): number {
+  return getDailyStarLedger().stars;
+}
+
+/** Adds the net improvement a result represents. Call this once per solved
+ *  activity, exercise or labyrinth, with the previous best in hand. */
+export function addNetStars(previousBest: number, newStars: number): DailyStarLedger {
+  const current = getDailyStarLedger();
+  const next = computeAddNetStars(current, netStars(previousBest, newStars));
+  if (next === current) return current;
+  if (typeof window !== "undefined") {
+    try {
+      localStorage.setItem(dailyStarsStorageKey(), JSON.stringify(next));
+    } catch {
+      // Quota or privacy mode — the caller still gets the correct state back.
+    }
+  }
+  return next;
+}

--- a/apps/web/src/lib/progression/types.ts
+++ b/apps/web/src/lib/progression/types.ts
@@ -49,8 +49,10 @@ export type MilestoneStore = {
   dailyDate: string | null;
 };
 
-export const EMPTY_STORE: MilestoneStore = {
+/** Shared, frozen — a fresh store must never let a caller mutate the module
+ *  singleton. Callers that need a `dailyDate` stamp spread over this. */
+export const EMPTY_STORE: MilestoneStore = Object.freeze({
   version: 1,
   events: {},
   dailyDate: null,
-};
+});

--- a/apps/web/src/lib/progression/types.ts
+++ b/apps/web/src/lib/progression/types.ts
@@ -1,0 +1,56 @@
+import type { PieceId } from "@/lib/game/types";
+
+/** Every recognizable moment in the LEARN progression ladder.
+ *  `piece-badge-eligible` is the RIGHT to claim (10 stars reached).
+ *  `piece-badge-claimed` is the confirmed on-chain mint. They are two
+ *  events because a badge does not exist until a transaction confirms. */
+export type MilestoneId =
+  | "first-reward"
+  | "first-labyrinth"
+  | "special-training"
+  | "piece-badge-eligible"
+  | "piece-badge-claimed"
+  | "mastery"
+  | "great-focus-session"
+  | "first-great-session";
+
+/** Milestones that lead somewhere. Only these carry `openedAt` — a Great
+ *  Focus Session, a claimed badge and a mastery crown are recognitions,
+ *  not destinations, so an "opened" flag on them would mean nothing. */
+export const NAVIGABLE_MILESTONES: readonly MilestoneId[] = [
+  "first-reward",
+  "first-labyrinth",
+  "special-training",
+] as const;
+
+export type MilestoneEvent = {
+  id: MilestoneId;
+  /** Scopes per-piece milestones. Absent on global ones. */
+  piece?: PieceId;
+  /** ISO timestamp the condition first became true. */
+  earnedAt: string;
+  /** Set once the celebration overlay has actually been shown. */
+  celebratedAt?: string;
+  /** Set the first time the player opens the content. Clears the NEW dot.
+   *  Only ever written for a milestone in NAVIGABLE_MILESTONES. */
+  openedAt?: string;
+};
+
+/** Idempotency key. Per-piece milestones are scoped; global ones are not. */
+export function milestoneKey(id: MilestoneId, piece?: PieceId): string {
+  return piece ? `${id}:${piece}` : id;
+}
+
+export type MilestoneStore = {
+  version: 1;
+  /** Keyed by `milestoneKey()`. A present entry means the event fired. */
+  events: Record<string, MilestoneEvent>;
+  /** UTC date the daily milestones were last reset. */
+  dailyDate: string | null;
+};
+
+export const EMPTY_STORE: MilestoneStore = {
+  version: 1,
+  events: {},
+  dailyDate: null,
+};

--- a/apps/web/src/lib/progression/use-celebration-queue.ts
+++ b/apps/web/src/lib/progression/use-celebration-queue.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type { PieceId } from "@/lib/game/types";
+import { buildCelebrationQueue, type CelebrationStep } from "./celebration-queue";
+import { gatherMilestoneInput, type GatherArgs } from "./gather-input";
+import { deriveEarnedMilestones } from "./milestones";
+import {
+  getMilestoneStore,
+  markCelebrated,
+  markOpened,
+  recordEarned,
+  selectPending,
+} from "./milestone-storage";
+import type { MilestoneId } from "./types";
+
+export type UseCelebrationQueueReturn = {
+  current: CelebrationStep | null;
+  resolve: (args: GatherArgs) => void;
+  dismissCurrent: () => void;
+  releaseAbsorbed: (step: CelebrationStep) => void;
+  openContent: (id: MilestoneId, piece?: PieceId) => void;
+};
+
+export function useCelebrationQueue(): UseCelebrationQueueReturn {
+  const [queue, setQueue] = useState<CelebrationStep[]>([]);
+
+  // Latest-value ref, refreshed every render. Callbacks read from it instead
+  // of closing over `queue` directly, so a `useCallback([])` never goes
+  // stale — without needing to perform side effects inside a `setState`
+  // updater (updaters must stay pure; React may invoke them more than once).
+  const queueRef = useRef(queue);
+  queueRef.current = queue;
+
+  /** Evaluate → PERSIST → build → expose. Persistence precedes rendering:
+   *  an overlay is a consequence of having recorded the event, never the
+   *  cause of it. */
+  const resolve = useCallback((args: GatherArgs) => {
+    const input = gatherMilestoneInput(args);
+    const earned = deriveEarnedMilestones(input);
+    const store = recordEarned(earned);
+    setQueue(buildCelebrationQueue(selectPending(store)));
+  }, []);
+
+  const dismissCurrent = useCallback(() => {
+    const current = queueRef.current[0];
+    if (!current) return;
+
+    // Side effects happen here, OUTSIDE the state updater, so they run
+    // exactly once per call regardless of how many times React invokes the
+    // (pure) updater passed to setQueue below.
+    markCelebrated(current.id, current.piece);
+    // An absorbed event is recognized together with its closer — it must
+    // not be left pending and resurface as a stray overlay later.
+    for (const id of current.absorbed) {
+      markCelebrated(id, current.piece);
+    }
+
+    setQueue((prev) => prev.slice(1));
+  }, []);
+
+  /** Releases a recognition that was absorbed by a claim flow the player
+   *  cancelled. Recognition never depends on signing a transaction — it
+   *  re-queues whichever absorbed events are still pending. */
+  const releaseAbsorbed = useCallback((step: CelebrationStep) => {
+    const store = getMilestoneStore();
+    const pending = selectPending(store).filter((event) =>
+      step.absorbed.includes(event.id),
+    );
+    setQueue(buildCelebrationQueue(pending));
+  }, []);
+
+  const openContent = useCallback((id: MilestoneId, piece?: PieceId) => {
+    markOpened(id, piece);
+  }, []);
+
+  return {
+    current: queue[0] ?? null,
+    resolve,
+    dismissCurrent,
+    releaseAbsorbed,
+    openContent,
+  };
+}

--- a/apps/web/src/lib/progression/use-celebration-queue.ts
+++ b/apps/web/src/lib/progression/use-celebration-queue.ts
@@ -58,9 +58,12 @@ export function useCelebrationQueue(): UseCelebrationQueueReturn {
     // (pure) updater passed to setQueue below.
     markCelebrated(current.id, current.piece);
     // An absorbed event is recognized together with its closer — it must
-    // not be left pending and resurface as a stray overlay later.
-    for (const id of current.absorbed) {
-      markCelebrated(id, current.piece);
+    // not be left pending and resurface as a stray overlay later. Each
+    // absorbed event carries its OWN piece scope: a piece-scoped closer
+    // absorbs global events, and re-attaching the closer's piece to them
+    // would build a key that matches nothing and write nothing.
+    for (const event of current.absorbed) {
+      markCelebrated(event.id, event.piece);
     }
 
     // Advance the ref SYNCHRONOUSLY, in the same tick. `queueRef.current` is
@@ -92,7 +95,10 @@ export function useCelebrationQueue(): UseCelebrationQueueReturn {
   const releaseAbsorbed = useCallback((step: CelebrationStep) => {
     const store = getMilestoneStore();
     const pending = selectPending(store).filter((event) =>
-      step.absorbed.includes(event.id),
+      step.absorbed.some(
+        (candidate) =>
+          candidate.id === event.id && candidate.piece === event.piece,
+      ),
     );
     const next = buildCelebrationQueue(pending);
     queueRef.current = next;

--- a/apps/web/src/lib/progression/use-celebration-queue.ts
+++ b/apps/web/src/lib/progression/use-celebration-queue.ts
@@ -56,18 +56,40 @@ export function useCelebrationQueue(): UseCelebrationQueueReturn {
       markCelebrated(id, current.piece);
     }
 
+    // Advance the ref SYNCHRONOUSLY, in the same tick. `queueRef.current` is
+    // otherwise only refreshed during render, so two `dismissCurrent()`
+    // calls before React commits (a double-tap) would both read step A as
+    // `[0]`, both mark A celebrated (harmless — idempotent), but both
+    // enqueue the same `prev.slice(1)` updater. Applied sequentially those
+    // updaters compute `[A,B] → [B] → []`, dropping B from the queue
+    // WITHOUT ever marking it celebrated. This is a ref write, not state —
+    // it is safe to do outside the (still pure) updater below.
+    queueRef.current = queueRef.current.slice(1);
     setQueue((prev) => prev.slice(1));
   }, []);
 
   /** Releases a recognition that was absorbed by a claim flow the player
    *  cancelled. Recognition never depends on signing a transaction — it
-   *  re-queues whichever absorbed events are still pending. */
+   *  re-queues whichever absorbed events are still pending.
+   *
+   *  MUST be called BEFORE `dismissCurrent()` on the cancellation path. If
+   *  `dismissCurrent()` runs first, it already stamps every absorbed event
+   *  (including this one) with `celebratedAt`, so `selectPending` returns
+   *  nothing for them and this silently replaces the queue with `[]` —
+   *  recognition lost, not just delayed.
+   *
+   *  Replaces the whole queue rather than splicing into it. That is only
+   *  safe because `buildCelebrationQueue` always emits the closer LAST —
+   *  nothing follows it today. A future reorder of the queue would break
+   *  this assumption silently. */
   const releaseAbsorbed = useCallback((step: CelebrationStep) => {
     const store = getMilestoneStore();
     const pending = selectPending(store).filter((event) =>
       step.absorbed.includes(event.id),
     );
-    setQueue(buildCelebrationQueue(pending));
+    const next = buildCelebrationQueue(pending);
+    queueRef.current = next;
+    setQueue(next);
   }, []);
 
   const openContent = useCallback((id: MilestoneId, piece?: PieceId) => {

--- a/apps/web/src/lib/progression/use-celebration-queue.ts
+++ b/apps/web/src/lib/progression/use-celebration-queue.ts
@@ -16,7 +16,11 @@ import type { MilestoneId } from "./types";
 
 export type UseCelebrationQueueReturn = {
   current: CelebrationStep | null;
-  resolve: (args: GatherArgs) => void;
+  /** Returns the queue it just built. `current` is state and only updates on
+   *  the next render, so a caller that must know IN THE SAME TICK whether the
+   *  machine took ownership of a moment (e.g. the badge) reads this instead of
+   *  a stale `current`. */
+  resolve: (args: GatherArgs) => CelebrationStep[];
   dismissCurrent: () => void;
   releaseAbsorbed: (step: CelebrationStep) => void;
   openContent: (id: MilestoneId, piece?: PieceId) => void;
@@ -35,11 +39,14 @@ export function useCelebrationQueue(): UseCelebrationQueueReturn {
   /** Evaluate → PERSIST → build → expose. Persistence precedes rendering:
    *  an overlay is a consequence of having recorded the event, never the
    *  cause of it. */
-  const resolve = useCallback((args: GatherArgs) => {
+  const resolve = useCallback((args: GatherArgs): CelebrationStep[] => {
     const input = gatherMilestoneInput(args);
     const earned = deriveEarnedMilestones(input);
     const store = recordEarned(earned);
-    setQueue(buildCelebrationQueue(selectPending(store)));
+    const next = buildCelebrationQueue(selectPending(store));
+    queueRef.current = next;
+    setQueue(next);
+    return next;
   }, []);
 
   const dismissCurrent = useCallback(() => {

--- a/apps/web/src/lib/progression/use-milestone-seeding.ts
+++ b/apps/web/src/lib/progression/use-milestone-seeding.ts
@@ -8,9 +8,47 @@ export type UseMilestoneSeedingArgs = SeedMilestonesArgs & {
    *  half-known profile would mark it migrated and leave `piece-badge-claimed`
    *  / `mastery` unseeded — a retroactive overlay for a badge minted months
    *  ago. A disconnected wallet is READY: `resolve()` would see the same
-   *  `badgeClaimed: false` it does. */
+   *  `badgeClaimed: false` it does. Build it with `isMilestoneSeedReady`. */
   ready: boolean;
 };
+
+/** wagmi's `useAccount().status`. Declared structurally so this module does not
+ *  drag wagmi into a pure unit. */
+export type AccountStatus =
+  | "connected"
+  | "connecting"
+  | "reconnecting"
+  | "disconnected";
+
+/**
+ * THE seeding gate. Every surface that seeds must use this one — the hub and
+ * the exercises screen disagreeing about what "ready" means is how a profile
+ * gets stamped migrated with half its badges unknown.
+ *
+ * - `disconnected` → READY. There is no wallet, so there are no badges, and
+ *   that is exactly what a `resolve()` would see. A wallet-less player must
+ *   seed, or they never get past the migration.
+ * - `connecting` / `reconnecting` → NOT ready. The address is still undefined,
+ *   the badge read is DISABLED, and a disabled TanStack query reports
+ *   `isLoading === false` — the trap the old `!isBadgesLoading` gate fell into.
+ * - `connected` → ready only once the badge state is actually KNOWN. On an
+ *   unsupported chain `getBadgesAddress()` is null, the read never enables and
+ *   `badgeStateKnown` stays false FOREVER. That is intentional: an unknown
+ *   badge state is not "no badges". Seeding it as badge-less would leave the
+ *   veteran's real, months-old badges unseeded, and they would pop as fresh
+ *   `piece-badge-claimed` / `mastery` overlays the moment the player switched
+ *   back to the right chain. The profile stays unseeded instead — and
+ *   `resolveMilestones` refuses to run at all while unseeded, so the wrong
+ *   chain costs the player nothing but a delay.
+ */
+export function isMilestoneSeedReady(args: {
+  accountStatus: AccountStatus | undefined;
+  /** True once the on-chain badge read has actually produced an answer. */
+  badgeStateKnown: boolean;
+}): boolean {
+  if (args.accountStatus === "disconnected") return true;
+  return args.accountStatus === "connected" && args.badgeStateKnown;
+}
 
 /**
  * Runs the one-time milestone migration for an existing player.

--- a/apps/web/src/lib/progression/use-milestone-seeding.ts
+++ b/apps/web/src/lib/progression/use-milestone-seeding.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { seedMilestonesOnce, type SeedMilestonesArgs } from "./seed-milestones";
+
+export type UseMilestoneSeedingArgs = SeedMilestonesArgs & {
+  /** False while the on-chain badge state is still in flight. Seeding with a
+   *  half-known profile would mark it migrated and leave `piece-badge-claimed`
+   *  / `mastery` unseeded — a retroactive overlay for a badge minted months
+   *  ago. A disconnected wallet is READY: `resolve()` would see the same
+   *  `badgeClaimed: false` it does. */
+  ready: boolean;
+};
+
+/**
+ * Runs the one-time milestone migration for an existing player.
+ *
+ * WHERE THIS MUST MOUNT: on every surface that can reach `resolve()`. The
+ * queue is resolved on the exercises screen, and a player can deep-link
+ * straight to `/exercises` without ever passing through the hub — so seeding
+ * on the hub alone would leave that player with a parade of retroactive
+ * overlays on their first solve. It mounts on BOTH; `seedMilestonesOnce` is
+ * idempotent (a persistent marker), so the second mount is a cheap no-op and
+ * neither surface is the single writer of anything.
+ *
+ * WHEN: in a mount effect, NOT at module init. Seeding cannot beat the first
+ * render — it never needed to. All it must beat is `resolve()`, which only
+ * runs from a player action (a solve), and React flushes effects long before
+ * any click can be delivered. The seed is COMMITTED TO DISK before the queue
+ * is ever built.
+ */
+export function useMilestoneSeeding(args: UseMilestoneSeedingArgs): void {
+  // Latest-value ref: the badge map and the catalog are fresh objects on every
+  // render, so they cannot be effect dependencies without re-running the
+  // migration on every paint. `ready` is the only real trigger.
+  const argsRef = useRef(args);
+  argsRef.current = args;
+
+  useEffect(() => {
+    if (!args.ready) return;
+    const { badgeClaimedByPiece, labyrinthIdsByPiece, giftAvailable } =
+      argsRef.current;
+    seedMilestonesOnce({
+      badgeClaimedByPiece,
+      labyrinthIdsByPiece,
+      giftAvailable,
+    });
+  }, [args.ready]);
+}

--- a/apps/web/src/lib/training/__tests__/interleave.test.ts
+++ b/apps/web/src/lib/training/__tests__/interleave.test.ts
@@ -9,13 +9,15 @@ import {
 } from "@/lib/training/path";
 import { EXERCISES } from "@/lib/game/exercises";
 
-/** Spread `totalStars` across the pool (3★ per exercise, in catalog order)
- *  and return the id-keyed best-stars map. Sparse: zero entries dropped. */
+/** Spread `totalStars` across the pool (2★ per exercise, in catalog order)
+ *  and return the id-keyed best-stars map. Sparse: zero entries dropped.
+ *  Capped at 2/exercise (not 3) so a 6★ total naturally spans 3+ exercises —
+ *  matching LABYRINTH_MIN_EXERCISES instead of colliding it on exercise 2. */
 function rookStarsTotaling(totalStars: number): Record<string, number> {
   let remaining = totalStars;
   const map: Record<string, number> = {};
   for (const ex of EXERCISES.rook) {
-    const take = Math.min(3, remaining);
+    const take = Math.min(2, remaining);
     remaining -= take;
     if (take > 0) map[ex.id] = take;
   }

--- a/apps/web/src/lib/training/__tests__/interleave.test.ts
+++ b/apps/web/src/lib/training/__tests__/interleave.test.ts
@@ -5,6 +5,7 @@ import {
   getLabyrinthForAutoAdvance,
   interleaveTrainingRows,
   nextPendingLabyrinthAfterExercise,
+  LABYRINTH_MIN_EXERCISES,
   LABYRINTH_UNLOCK_THRESHOLD,
 } from "@/lib/training/path";
 import { EXERCISES } from "@/lib/game/exercises";
@@ -47,11 +48,27 @@ describe("interleaveTrainingRows — presentation-only interleave (D6)", () => {
     const exercises = EXERCISES.rook.map((e) => e.id);
     const rows = interleaveTrainingRows(exercises, rookLabs());
 
-    // First lab unlocks at LABYRINTH_UNLOCK_THRESHOLD stars; at 3★ per
-    // exercise that is reachable after ceil(threshold/3) exercises.
-    const anchor = Math.ceil(LABYRINTH_UNLOCK_THRESHOLD / 3);
+    // First lab unlocks at LABYRINTH_UNLOCK_THRESHOLD stars AND
+    // LABYRINTH_MIN_EXERCISES completed exercises — a compound gate. At 3★
+    // per exercise the stars alone are reachable after ceil(threshold/3)
+    // exercises, but the anchor is floored to the exercise requirement so
+    // the row is never laid out before the gate can possibly be open.
+    const anchor = Math.max(
+      Math.ceil(LABYRINTH_UNLOCK_THRESHOLD / 3),
+      LABYRINTH_MIN_EXERCISES,
+    );
     const firstLabAt = rows.findIndex((r) => r.kind === "labyrinth");
     expect(firstLabAt).toBe(anchor);
+  });
+
+  it("never anchors the first labyrinth earlier than the exercise floor", () => {
+    // Regression: ceil(LABYRINTH_UNLOCK_THRESHOLD / 3) alone would place
+    // this at index 2 (after the 2nd exercise), a slot where the compound
+    // gate (stars AND LABYRINTH_MIN_EXERCISES) is guaranteed still locked.
+    const exercises = EXERCISES.rook.map((e) => e.id);
+    const rows = interleaveTrainingRows(exercises, rookLabs());
+    const firstLabAt = rows.findIndex((r) => r.kind === "labyrinth");
+    expect(firstLabAt).toBeGreaterThanOrEqual(LABYRINTH_MIN_EXERCISES);
   });
 
   it("alternates: each subsequent labyrinth sits one exercise later", () => {
@@ -96,7 +113,10 @@ describe("interleaveTrainingRows — presentation-only interleave (D6)", () => {
 });
 
 describe("nextPendingLabyrinthAfterExercise — the path flows THROUGH labs (QA G1)", () => {
-  const anchor = Math.ceil(LABYRINTH_UNLOCK_THRESHOLD / 3);
+  const anchor = Math.max(
+    Math.ceil(LABYRINTH_UNLOCK_THRESHOLD / 3),
+    LABYRINTH_MIN_EXERCISES,
+  );
   const anchorExerciseId = EXERCISES.rook[anchor - 1].id;
 
   it("returns the available lab when it is the immediate next interleaved row", () => {
@@ -146,7 +166,10 @@ describe("nextPendingLabyrinthAfterExercise — the path flows THROUGH labs (QA 
 });
 
 describe("getLabyrinthForAutoAdvance — path sequencing with late-unlock (Exercise Path Sequencing)", () => {
-  const anchor = Math.ceil(LABYRINTH_UNLOCK_THRESHOLD / 3);
+  const anchor = Math.max(
+    Math.ceil(LABYRINTH_UNLOCK_THRESHOLD / 3),
+    LABYRINTH_MIN_EXERCISES,
+  );
   // Exercise right before the first lab in the interleaved path (happy path anchor)
   const anchorExerciseId = EXERCISES.rook[anchor - 1].id;
   // Exercise AFTER the anchor (player already passed the lab slot)

--- a/apps/web/src/lib/training/__tests__/path.test.ts
+++ b/apps/web/src/lib/training/__tests__/path.test.ts
@@ -83,10 +83,12 @@ describe("buildTrainingPath — fresh piece (0★)", () => {
   });
 });
 
-/** Build a stars array for a piece summing exactly `total` (3s then remainder). */
+/** Build a stars array for a piece summing exactly `total` (2s then remainder).
+ *  Capped at 2/exercise (not 3) so a 6★ total naturally spans 3+ exercises —
+ *  matching LABYRINTH_MIN_EXERCISES instead of colliding it on exercise 2. */
 function starsTotaling(piece: PieceId, total: number): number[] {
   return EXERCISES[piece].map(() => {
-    const take = Math.min(3, total);
+    const take = Math.min(2, total);
     total -= take;
     return take;
   });
@@ -149,6 +151,34 @@ describe("buildTrainingPath — labyrinth unlocks", () => {
     expect(lab.status).toBe("complete");
     expect(lab.stars).toBe(labyrinthStars(5, 3));
     expect(lab.stars).toBe(2);
+  });
+});
+
+describe("the first labyrinth needs an exercise floor, not just stars", () => {
+  it("stays locked at 6 stars across only 2 exercises", () => {
+    const path = buildTrainingPath({
+      piece: "rook",
+      progress: { piece: "rook", currentId: null, stars: { "rook-1": 3, "rook-2": 3 } },
+      labyrinthBests: {},
+      badgeClaimed: false,
+    });
+    const firstLab = path.find((node) => node.kind === "labyrinth");
+    expect(firstLab?.status).toBe("locked");
+  });
+
+  it("unlocks at 6 stars across 3 exercises", () => {
+    const path = buildTrainingPath({
+      piece: "rook",
+      progress: {
+        piece: "rook",
+        currentId: null,
+        stars: { "rook-1": 3, "rook-2": 2, "rook-3": 1 },
+      },
+      labyrinthBests: {},
+      badgeClaimed: false,
+    });
+    const firstLab = path.find((node) => node.kind === "labyrinth");
+    expect(firstLab?.status).toBe("available");
   });
 });
 

--- a/apps/web/src/lib/training/path.ts
+++ b/apps/web/src/lib/training/path.ts
@@ -65,6 +65,11 @@ export type PieceMastery = "none" | "badge" | "mastered";
  *  Flat for every piece in v1 (Queen/King asymmetry accepted). */
 export const LABYRINTH_UNLOCK_THRESHOLD = 6;
 
+/** Companion floor to LABYRINTH_UNLOCK_THRESHOLD. Stars alone let a perfect
+ *  player unlock the maze on exercise 2, colliding with the first reward.
+ *  The floor keeps the two milestones a solve apart. */
+export const LABYRINTH_MIN_EXERCISES = 3;
+
 export function buildTrainingPath(input: TrainingPathInput): TrainingNode[] {
   const { piece, progress, labyrinthBests, badgeClaimed } = input;
   const exercisesCatalog = input.catalog?.exercises ?? EXERCISES;
@@ -75,6 +80,14 @@ export function buildTrainingPath(input: TrainingPathInput): TrainingNode[] {
     (sum, value) => sum + value,
     0,
   );
+  // Same sparse map as totalStars, counting only entries with value > 0 — a
+  // present 0 means "played, scored nothing", NOT a completion.
+  const completedExercises = Object.values(progress.stars).filter(
+    (value) => value > 0,
+  ).length;
+  const meetsFirstLabGate =
+    totalStars >= LABYRINTH_UNLOCK_THRESHOLD &&
+    completedExercises >= LABYRINTH_MIN_EXERCISES;
 
   // Exercise nodes follow the authored catalog `order` (EXERCISES[piece] is
   // order-sorted at import time). Stars are read by exerciseId — immune to
@@ -106,10 +119,7 @@ export function buildTrainingPath(input: TrainingPathInput): TrainingNode[] {
         : { type: "node", nodeId: orderedLabyrinths[index - 1].id };
     const previousComplete =
       index === 0 || labyrinthNodes[index - 1].status === "complete";
-    const unlocked =
-      index === 0
-        ? totalStars >= LABYRINTH_UNLOCK_THRESHOLD
-        : previousComplete;
+    const unlocked = index === 0 ? meetsFirstLabGate : previousComplete;
     labyrinthNodes.push({
       id: labyrinth.id,
       kind: "labyrinth",

--- a/apps/web/src/lib/training/path.ts
+++ b/apps/web/src/lib/training/path.ts
@@ -211,10 +211,13 @@ export type InterleavedRow<E> =
 /** Surface redistribution D6 (presentation-only): merge the drawer's
  *  exercise rows and labyrinth nodes into ONE continuous path. The
  *  first labyrinth lands after the earliest exercises that can reach
- *  its stars unlock (ceil(min/3) at 3★ each); each subsequent lab sits
- *  one exercise later, so the list alternates Ex → Lab → Ex → Lab.
- *  Labs left over past the last exercise append at the tail. The
- *  unlock MODEL is untouched — this orders rows, it never gates them. */
+ *  its stars unlock (ceil(min/3) at 3★ each), floored to
+ *  LABYRINTH_MIN_EXERCISES so the row is never laid out before the
+ *  compound gate (stars AND exercise floor) can possibly be open; each
+ *  subsequent lab sits one exercise later, so the list alternates
+ *  Ex → Lab → Ex → Lab. Labs left over past the last exercise append
+ *  at the tail. The unlock MODEL is untouched — this orders rows, it
+ *  never gates them. */
 export function interleaveTrainingRows<E>(
   exercises: readonly E[],
   labyrinths: readonly TrainingNode[],
@@ -222,7 +225,7 @@ export function interleaveTrainingRows<E>(
   const firstUnlock = labyrinths[0]?.unlock;
   const anchor =
     firstUnlock && firstUnlock.type === "stars"
-      ? Math.ceil(firstUnlock.min / 3)
+      ? Math.max(Math.ceil(firstUnlock.min / 3), LABYRINTH_MIN_EXERCISES)
       : exercises.length;
   const rows: InterleavedRow<E>[] = [];
   let labCursor = 0;

--- a/apps/web/src/lib/welcome-package/__tests__/use-welcome-package-full-guard.test.ts
+++ b/apps/web/src/lib/welcome-package/__tests__/use-welcome-package-full-guard.test.ts
@@ -17,7 +17,6 @@ describe("useWelcomePackage — Full mode guard", () => {
     expect(result.current.isPending).toBe(false);
     expect(result.current.shouldAutoShow).toBe(false);
 
-    act(() => result.current.unlock());
     act(() => result.current.claim());
     act(() => result.current.dismiss());
     act(() => result.current.markShown());

--- a/apps/web/src/lib/welcome-package/__tests__/use-welcome-package.test.ts
+++ b/apps/web/src/lib/welcome-package/__tests__/use-welcome-package.test.ts
@@ -24,17 +24,14 @@ describe("useWelcomePackage — Lite mode", () => {
     expect(result.current.shouldAutoShow).toBe(false);
   });
 
-  it("retroactive init: unlocked+autoShowCount=2 when achievement already earned (totalCompleted>=1) but no storage", () => {
+  it("does NOT retroactively unlock from totalCompleted>=1 (Task 10 — gift belongs to the first-reward milestone, not the first Daily Focus)", () => {
     vi.mocked(getDailyProgress).mockReturnValue({ streak: 1, lastCompletedDate: "2026-06-20", totalCompleted: 1 });
     const { result } = renderHook(() => useWelcomePackage());
-    expect(result.current.isUnlocked).toBe(true);
+    expect(result.current.isUnlocked).toBe(false);
     expect(result.current.isClaimed).toBe(false);
-    expect(result.current.isPending).toBe(true);
-    expect(result.current.shouldAutoShow).toBe(false); // autoShowCount=2 → no auto-show
-    const stored = getWelcomePackageState();
-    expect(stored.unlocked).toBe(true);
-    expect(stored.autoShowCount).toBe(2);
-    expect(stored.unlockedAt).toBe("retroactive");
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.shouldAutoShow).toBe(false);
+    expect(getWelcomePackageState().unlocked).toBe(false);
   });
 
   it("unlock() sets unlocked=true and persists", () => {

--- a/apps/web/src/lib/welcome-package/__tests__/use-welcome-package.test.ts
+++ b/apps/web/src/lib/welcome-package/__tests__/use-welcome-package.test.ts
@@ -34,19 +34,13 @@ describe("useWelcomePackage — Lite mode", () => {
     expect(getWelcomePackageState().unlocked).toBe(false);
   });
 
-  it("unlock() sets unlocked=true and persists", () => {
-    const { result } = renderHook(() => useWelcomePackage());
-    act(() => result.current.unlock());
-    expect(result.current.isUnlocked).toBe(true);
-    expect(getWelcomePackageState().unlocked).toBe(true);
-  });
-
-  it("unlock() is idempotent — does not overwrite unlockedAt on second call", () => {
+  // The hook exposes NO `unlock()`. `unlockWelcomePackageGift()` (exercises
+  // screen) is the single writer of that transition — see the interface doc.
+  it("reflects an unlock written by the single writer, without exposing one", () => {
     setWelcomePackageState({ ...DEFAULT_STATE, unlocked: true, unlockedAt: "2026-06-20T00:00:00Z" });
     const { result } = renderHook(() => useWelcomePackage());
-    const atBefore = getWelcomePackageState().unlockedAt;
-    act(() => result.current.unlock());
-    expect(getWelcomePackageState().unlockedAt).toBe(atBefore);
+    expect(result.current.isUnlocked).toBe(true);
+    expect("unlock" in result.current).toBe(false);
   });
 
   it("claim() sets claimed=true and claimedAt", () => {

--- a/apps/web/src/lib/welcome-package/storage.ts
+++ b/apps/web/src/lib/welcome-package/storage.ts
@@ -1,4 +1,5 @@
 import type { WelcomePackageState } from "./types";
+import { dispatchWelcomePackageChange } from "./welcome-package-events";
 
 const STORAGE_KEY = "chesscito:welcome-package";
 
@@ -27,6 +28,10 @@ export function getWelcomePackageState(): WelcomePackageState {
   }
 }
 
+/** The single write path. It notifies AFTER the write, so every reader that
+ *  subscribes to `welcome-package-events` re-reads committed state — never a
+ *  mount-time snapshot. Notifying here (rather than in each caller) is
+ *  deliberate: a future writer that forgets to dispatch cannot exist. */
 export function setWelcomePackageState(state: WelcomePackageState): void {
   if (typeof window === "undefined") return;
   try {
@@ -34,4 +39,5 @@ export function setWelcomePackageState(state: WelcomePackageState): void {
   } catch {
     // Quota or privacy mode — skip persist
   }
+  dispatchWelcomePackageChange();
 }

--- a/apps/web/src/lib/welcome-package/use-welcome-package.ts
+++ b/apps/web/src/lib/welcome-package/use-welcome-package.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { CHESSCITO_LITE_MODE } from "@/lib/feature-flags";
 import { DEFAULT_STATE, getWelcomePackageState, setWelcomePackageState } from "./storage";
 import type { WelcomePackageState } from "./types";
+import { subscribeToWelcomePackageChanges } from "./welcome-package-events";
 
 export interface UseWelcomePackageReturn {
   isUnlocked: boolean;
@@ -38,65 +39,66 @@ function initState(): WelcomePackageState {
 export function useWelcomePackage(): UseWelcomePackageReturn {
   const [state, setState] = useState<WelcomePackageState>(initState);
 
-  // Sync from storage after hydration (handles cross-tab or re-mount).
+  // Sync from storage after hydration (handles cross-tab or re-mount) AND
+  // stay subscribed: storage — not this hook — is the owner. Another writer
+  // in the same tree (`claimWelcomePackageGift()` on the exercises screen)
+  // moves the key without going through us; without this subscription our
+  // snapshot rots and the next writer spreads a stale `claimed: false` back
+  // over it. Same bus, same reason as `lib/shop/shield-events`.
   useEffect(() => {
     if (!CHESSCITO_LITE_MODE) return;
-    setState(initState());
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    const reread = () => setState(getWelcomePackageState());
+    reread();
+    return subscribeToWelcomePackageChanges(reread);
   }, []);
+
+  /** Every writer re-reads COMMITTED storage first. Spreading React state
+   *  here would rewrite the whole object from a snapshot that another writer
+   *  may have already superseded. Returning `null` means "no change". */
+  const write = useCallback(
+    (mutate: (prev: WelcomePackageState) => WelcomePackageState | null) => {
+      if (!CHESSCITO_LITE_MODE) return;
+      const prev = getWelcomePackageState();
+      const next = mutate(prev);
+      if (!next) {
+        setState(prev);
+        return;
+      }
+      // Writes, THEN dispatches — the subscription above re-reads.
+      setWelcomePackageState(next);
+      setState(next);
+    },
+    [],
+  );
 
   const unlock = useCallback(() => {
-    if (!CHESSCITO_LITE_MODE) return;
-    setState((prev) => {
-      if (prev.unlocked) return prev; // idempotent
-      const next: WelcomePackageState = {
-        ...prev,
-        unlocked: true,
-        unlockedAt: new Date().toISOString(),
-      };
-      setWelcomePackageState(next);
-      return next;
-    });
-  }, []);
+    write((prev) =>
+      prev.unlocked
+        ? null // idempotent
+        : { ...prev, unlocked: true, unlockedAt: new Date().toISOString() },
+    );
+  }, [write]);
 
   const claim = useCallback(() => {
-    if (!CHESSCITO_LITE_MODE) return;
-    setState((prev) => {
-      const next: WelcomePackageState = {
-        ...prev,
-        claimed: true,
-        claimedAt: new Date().toISOString(),
-      };
-      setWelcomePackageState(next);
-      return next;
-    });
-  }, []);
+    write((prev) => ({
+      ...prev,
+      claimed: true,
+      claimedAt: new Date().toISOString(),
+    }));
+  }, [write]);
 
   const dismiss = useCallback(() => {
-    if (!CHESSCITO_LITE_MODE) return;
-    setState((prev) => {
-      const next: WelcomePackageState = {
-        ...prev,
-        dismissed: true,
-        dismissedAt: new Date().toISOString(),
-        dismissCount: prev.dismissCount + 1,
-      };
-      setWelcomePackageState(next);
-      return next;
-    });
-  }, []);
+    write((prev) => ({
+      ...prev,
+      dismissed: true,
+      dismissedAt: new Date().toISOString(),
+      dismissCount: prev.dismissCount + 1,
+    }));
+  }, [write]);
 
   const markShown = useCallback(() => {
-    if (!CHESSCITO_LITE_MODE) return;
-    setState((prev) => {
-      const next: WelcomePackageState = {
-        ...prev,
-        autoShowCount: prev.autoShowCount + 1,
-      };
-      setWelcomePackageState(next);
-      return next;
-    });
-  }, []);
+    write((prev) => ({ ...prev, autoShowCount: prev.autoShowCount + 1 }));
+  }, [write]);
 
   if (!CHESSCITO_LITE_MODE) return NOOP_RETURN;
 

--- a/apps/web/src/lib/welcome-package/use-welcome-package.ts
+++ b/apps/web/src/lib/welcome-package/use-welcome-package.ts
@@ -6,12 +6,16 @@ import { DEFAULT_STATE, getWelcomePackageState, setWelcomePackageState } from ".
 import type { WelcomePackageState } from "./types";
 import { subscribeToWelcomePackageChanges } from "./welcome-package-events";
 
+/** No `unlock()`. The gift is unlocked by `unlockWelcomePackageGift()` on the
+ *  exercises screen — the single writer of that transition. Re-exposing it
+ *  here would re-open the two-writer trap the change-event bus was added to
+ *  close: two hooks holding independent snapshots, each spreading its stale
+ *  view back over storage. */
 export interface UseWelcomePackageReturn {
   isUnlocked: boolean;
   isClaimed: boolean;
   isPending: boolean;
   shouldAutoShow: boolean;
-  unlock: () => void;
   claim: () => void;
   dismiss: () => void;
   markShown: () => void;
@@ -24,7 +28,6 @@ const NOOP_RETURN: UseWelcomePackageReturn = {
   isClaimed: false,
   isPending: false,
   shouldAutoShow: false,
-  unlock: noop,
   claim: noop,
   dismiss: noop,
   markShown: noop,
@@ -71,14 +74,6 @@ export function useWelcomePackage(): UseWelcomePackageReturn {
     [],
   );
 
-  const unlock = useCallback(() => {
-    write((prev) =>
-      prev.unlocked
-        ? null // idempotent
-        : { ...prev, unlocked: true, unlockedAt: new Date().toISOString() },
-    );
-  }, [write]);
-
   const claim = useCallback(() => {
     write((prev) => ({
       ...prev,
@@ -107,7 +102,6 @@ export function useWelcomePackage(): UseWelcomePackageReturn {
     isClaimed: state.claimed,
     isPending: state.unlocked && !state.claimed,
     shouldAutoShow: state.unlocked && !state.claimed && state.autoShowCount < 2,
-    unlock,
     claim,
     dismiss,
     markShown,

--- a/apps/web/src/lib/welcome-package/use-welcome-package.ts
+++ b/apps/web/src/lib/welcome-package/use-welcome-package.ts
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { CHESSCITO_LITE_MODE } from "@/lib/feature-flags";
-import { getDailyProgress } from "@/lib/daily/progress";
 import { DEFAULT_STATE, getWelcomePackageState, setWelcomePackageState } from "./storage";
 import type { WelcomePackageState } from "./types";
 
@@ -33,24 +32,7 @@ const NOOP_RETURN: UseWelcomePackageReturn = {
 function initState(): WelcomePackageState {
   if (typeof window === "undefined" || !CHESSCITO_LITE_MODE) return { ...DEFAULT_STATE };
 
-  let loaded = getWelcomePackageState();
-
-  // Retroactive init: achievement already earned but package state absent.
-  // Pre-saturate autoShowCount=2 to avoid surprise auto-show overlay.
-  if (!loaded.unlocked) {
-    const { totalCompleted } = getDailyProgress();
-    if (totalCompleted >= 1) {
-      loaded = {
-        ...DEFAULT_STATE,
-        unlocked: true,
-        unlockedAt: "retroactive",
-        autoShowCount: 2,
-      };
-      setWelcomePackageState(loaded);
-    }
-  }
-
-  return loaded;
+  return getWelcomePackageState();
 }
 
 export function useWelcomePackage(): UseWelcomePackageReturn {

--- a/apps/web/src/lib/welcome-package/welcome-package-events.ts
+++ b/apps/web/src/lib/welcome-package/welcome-package-events.ts
@@ -1,0 +1,28 @@
+/** In-tab event bus for the `chesscito:welcome-package` localStorage key.
+ *  Same shape as `lib/shop/shield-events.ts`, for the same reason: the
+ *  browser's native `storage` event only fires in *other* tabs, so a
+ *  component holding a React mirror of this key never learns that another
+ *  writer in the SAME tab moved it.
+ *
+ *  This matters here because every writer rewrites the WHOLE object. Two
+ *  writers now exist in the exercises tree — `useWelcomePackage()` (owned
+ *  by `<DailyTacticSlot>`) and `claimWelcomePackageGift()` (the celebration
+ *  queue's gift modal). A mount-time snapshot that is never invalidated
+ *  would let `markShown()` spread a stale `claimed: false` back over a gift
+ *  the player already claimed. Write, THEN notify — and re-read on notify. */
+
+const EVENT_NAME = "chesscito:welcome-package-changed";
+
+export function dispatchWelcomePackageChange(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(EVENT_NAME));
+}
+
+/** Subscribes to welcome-package changes. Returns an unsubscribe fn — call
+ *  it inside `useEffect`'s cleanup. The handler runs synchronously after
+ *  `dispatchWelcomePackageChange()`, so callers can just re-read storage. */
+export function subscribeToWelcomePackageChanges(handler: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(EVENT_NAME, handler);
+  return () => window.removeEventListener(EVENT_NAME, handler);
+}

--- a/docs/specs/2026-07-11-progression-unlocks-celebration-queue.md
+++ b/docs/specs/2026-07-11-progression-unlocks-celebration-queue.md
@@ -94,9 +94,10 @@ voids replay scoring once the session is over.
 |---|---|---|
 | **First Reward** (gift) | `lifetimeStars >= 4` AND `completedExercises >= 2` | Cumulative |
 | **First Labyrinth** | `pieceStars(piece) >= 6` AND `completedExercises(piece) >= 3` | Cumulative, per piece |
-| **Piece Badge** | `pieceStars(piece) >= 10`, claimed on-chain | Cumulative, per piece |
+| **Piece Badge eligible** | `pieceStars(piece) >= 10` | Cumulative, per piece |
+| **Piece Badge claimed** | Claim transaction confirmed on-chain | Cumulative, per piece |
 | **Special Training** | `pieceStars(rook) >= 12` | Cumulative |
-| **Mastery** | Piece Badge claimed AND all labyrinths of that piece complete | Cumulative, per piece |
+| **Mastery** | Piece Badge **claimed** AND all labyrinths of that piece complete | Cumulative, per piece |
 | **Great Focus Session** | `dailyStars >= 8` OR session quota exhausted | **Daily, repeatable** |
 | **First Great Session** | First time Great Focus Session fires | Once, ever |
 
@@ -163,14 +164,22 @@ out and the session was never recognized, it is recognized then.
 
 Evaluation order after every solved activity:
 
-```
+```text
 1. Record the activity (stars, bests, consumed slot)
 2. Evaluate every milestone condition
-3. Drain the celebration queue
-4. Persist each fired event
-5. Return the player to the experience
-6. Only then, on the next attempt to start an activity, evaluate the session limit
+3. PERSIST every fired event + its idempotency key
+4. Build and drain the celebration queue
+5. Render
+6. Return the player to the experience
+7. Only then, on the next attempt to start an activity, evaluate the session limit
 ```
+
+**Persistence precedes rendering, never follows it.** If the app is killed while
+an overlay is on screen, the event must already be on disk — otherwise it is
+either lost or ambiguously re-derived on the next launch. Showing a celebration
+is a consequence of having recorded it, not the other way round. Marking
+`celebratedAt` is a second, separate write once the overlay has actually been
+shown.
 
 The celebration and the limit are never two consecutive modals. The player
 returns to the board in between; the wall appears when they reach for the next
@@ -209,8 +218,9 @@ already-persisted progress; only acknowledgement is new state.
 export type MilestoneId =
   | "first-reward"
   | "first-labyrinth"
-  | "piece-badge"
   | "special-training"
+  | "piece-badge-eligible"
+  | "piece-badge-claimed"
   | "mastery"
   | "great-focus-session"
   | "first-great-session";
@@ -221,12 +231,34 @@ export type MilestoneEvent = {
   piece?: PieceId;
   /** ISO timestamp the condition first became true. */
   earnedAt: string;
-  /** The celebration overlay has been shown. */
-  celebrated: boolean;
-  /** The player has opened the unlocked content. Clears the NEW dot. */
-  opened: boolean;
+  /** Set when the celebration overlay has been shown. */
+  celebratedAt?: string;
+  /** Set when the player first opens the unlocked content. Clears the NEW
+   *  dot. Present ONLY on navigable milestones — `first-reward`,
+   *  `first-labyrinth`, `special-training`. A Great Focus Session, a claimed
+   *  badge and a mastery crown have no destination to open, so `openedAt` is
+   *  meaningless for them and must never be written. */
+  openedAt?: string;
 };
 ```
+
+### Eligible is not claimed
+
+At 10★ the player earns **the right to claim**. The badge does not exist
+on-chain until a transaction confirms. Collapsing both into one milestone makes
+the machine lie about wallet state, so they are two events:
+
+| Event | Meaning | Navigable |
+|---|---|---|
+| `piece-badge-eligible` | 10★ reached. Opens the claim flow. | No |
+| `piece-badge-claimed` | Transaction confirmed. The badge exists. | No |
+
+`mastery` depends on **`piece-badge-claimed`**, never on eligibility — the crown
+cannot rest on a badge that was never minted.
+
+This also makes cancellation precise: **cancelling a claim preserves
+eligibility** and releases any absorbed recognition. The player keeps the right
+to claim, keeps the Great Focus Session, and loses nothing but the transaction.
 
 **Idempotence key:** `${id}` for global milestones, `${id}:${piece}` for
 per-piece ones. A milestone is celebrated exactly once. Re-deriving a condition
@@ -266,8 +298,8 @@ mastered the rook."
 lower-tier major that also fired is **absorbed as a line inside it**, never as a
 second modal.
 
-```
-mastery  >  piece-badge  >  great-focus-session
+```text
+mastery  >  piece-badge-eligible  >  great-focus-session
 ```
 
 Showing `MASTERY!` and then `GREAT FOCUS SESSION!` drops the intensity after the
@@ -288,16 +320,21 @@ would have happened long before. The rule holds anyway.
 
 ### The closer can be a transaction, and it can be cancelled
 
-`piece-badge` is **not an overlay — it is an interactive on-chain claim flow**
-(signature + transaction). If it absorbs a Great Focus Session and the player
-cancels or defers the claim, an earned recognition would vanish with the
-cancelled transaction.
+`piece-badge-eligible` is **not an overlay — it opens an interactive on-chain
+claim flow** (signature + transaction). If it absorbs a Great Focus Session and
+the player cancels or defers the claim, an earned recognition would vanish with
+the cancelled transaction.
 
-Contract: **an absorbed event persists before the claim flow opens.** If the
-claim is cancelled, deferred, or fails, the absorbed Great Focus Session falls
-back to its own overlay. Recognition is never contingent on signing a
-transaction. This mirrors the existing victory-claim cancellation behavior
-(#206), where cancelling is a no-op rather than a loss.
+Contract: **an absorbed event is already persisted before the claim flow opens**
+(step 3 of the evaluation order). If the claim is cancelled, deferred, or fails:
+
+- `piece-badge-eligible` **survives** — the player keeps the right to claim.
+- `piece-badge-claimed` never fires — nothing was minted.
+- The absorbed Great Focus Session is **released to its own overlay**.
+
+Recognition is never contingent on signing a transaction. This mirrors the
+existing victory-claim cancellation behavior (#206), where cancelling is a no-op
+rather than a loss.
 
 ### Overlay contract
 
@@ -322,8 +359,14 @@ Special Training example:
 
 The static `HubTileStatusChip kind="ready"` on the Special Training tile
 (`hub-arena-tile.tsx:53`) is replaced by a NEW chip driven by
-`event.opened === false`. Set when the unlock persists; cleared the first time
+`openedAt === undefined`. Set when the unlock persists; cleared the first time
 the player opens the content. The same rule governs the gift indicator.
+
+`openedAt` only exists on the three **navigable** milestones — `first-reward`,
+`first-labyrinth`, `special-training`. There is nothing to "open" about a Great
+Focus Session, a claimed badge or a mastery crown; they are recognitions, not
+destinations. Writing `openedAt` on them would be inventing a state with no
+meaning.
 
 ## Special Training combinations (model only)
 
@@ -366,11 +409,12 @@ Existing players must not regress.
 
 | Case | Behavior |
 |---|---|
-| Already claimed the gift | `first-reward` seeds as `celebrated: true, opened: true`. No replay. |
-| Gift unlocked, unclaimed | `first-reward` seeds as `celebrated: true, opened: false`. NEW dot persists; no surprise overlay. |
+| Already claimed the gift | `first-reward` seeds with `celebratedAt` and `openedAt` set. No replay. |
+| Gift unlocked, unclaimed | `first-reward` seeds with `celebratedAt` set, `openedAt` unset. NEW dot persists; no surprise overlay. |
 | Already earned `first-focus-day` | Untouched. Keeps the badge. |
-| Already past 12★ rook | `special-training` seeds as `celebrated: true, opened: true`. The tile stays visible, no retroactive overlay. |
-| Already claimed a Piece Badge | Seeds `celebrated: true`. |
+| Already past 12★ rook | `special-training` seeds with `celebratedAt` and `openedAt` set. The tile stays visible, no retroactive overlay. |
+| Already past 10★, badge unclaimed | `piece-badge-eligible` seeds with `celebratedAt` set. Claim stays available, no overlay. |
+| Already claimed a Piece Badge | Both `piece-badge-eligible` and `piece-badge-claimed` seed with `celebratedAt` set. |
 
 The rule: **no retroactive celebration fires for a milestone a player already
 passed.** Seeding suppresses the overlay while preserving the state.
@@ -393,10 +437,12 @@ passed.** Seeding suppresses the overlay while preserving the state.
 | Second Great Focus Session | Celebration fires, `first-great-session` does not re-grant. |
 | Session limit reached | Never shown before a pending recognition drains. |
 | Gift + labyrinth same solve | Gift overlay first, then labyrinth. Never stacked. |
-| Badge + Great Session same solve | One closer: the badge flow, Great Session absorbed as a line. |
+| Badge eligible + Great Session same solve | One closer: the claim flow, Great Session absorbed as a line. |
 | Mastery + Great Session same solve | One closer: Mastery. Great Session absorbed, no second overlay. |
 | Special Training + Mastery same solve | Special Training overlay (incremental) first, Mastery closes. |
-| Badge claim **cancelled** with Great Session absorbed | Great Session still recognized — falls back to its own overlay. Never lost with the tx. |
+| Badge claim **cancelled** with Great Session absorbed | `piece-badge-eligible` survives, `piece-badge-claimed` never fires, Great Session released to its own overlay. |
+| 10★ reached, claim never made | `piece-badge-eligible` persists. `mastery` stays locked even with every labyrinth done. |
+| App killed while an overlay is on screen | The event is already persisted. It does not replay and is not lost. |
 | Two majors in one drain | Exactly one overlay renders. Never two back to back. |
 | Close app before claiming | Reward persists, still claimable on return. |
 | Reopen app after celebrating | Celebration does not replay. |

--- a/docs/specs/2026-07-11-progression-unlocks-celebration-queue.md
+++ b/docs/specs/2026-07-11-progression-unlocks-celebration-queue.md
@@ -241,28 +241,63 @@ it. `first-great-session` never resets.
 
 ### Celebration queue
 
-Conditions are evaluated together after a solve; overlays are drained one at a
-time, never stacked.
+This is **not** an absolute "always show everything" order. It is a priority for
+events that fire in the **same resolution**. Most solves fire nothing.
+
+Three rules govern a drain:
+
+1. **Incremental unlocks first.**
+2. **The highest-hierarchy event closes.**
+3. **Never two major celebrations back to back.**
+
+**Phase 1 — incremental unlocks.** Each gets its own overlay, in this order,
+because each carries a CTA to different content. None of them concludes
+anything; they all invite action.
 
 ```
-1. first-reward
-2. first-labyrinth
-3. piece-badge
-4. special-training
-5. mastery
-6. great-focus-session   (first-great-session rendered inside it)
+first-reward → first-labyrinth → special-training
 ```
 
-Content unlocks precede the session wrap-up. The wrap-up is the only overlay
-that says "you can stop now" — anything shown after it contradicts it. `mastery`
-sits above `great-focus-session` for the same reason: it invites the next piece.
+Special Training gates at 12★, past the 10★ badge, so when it collides with a
+closer the intensity escalates naturally: "a new mode is open" → "and you
+mastered the rook."
 
-`first-great-session` persists as an independent achievement but renders **inside**
-the Great Focus Session overlay rather than as a second modal:
+**Phase 2 — exactly one closer.** The highest tier that fired renders. Every
+lower-tier major that also fired is **absorbed as a line inside it**, never as a
+second modal.
 
-> **Great Focus Session**
-> A deep session, done.
+```
+mastery  >  piece-badge  >  great-focus-session
+```
+
+Showing `MASTERY!` and then `GREAT FOCUS SESSION!` drops the intensity after the
+climax. The closer swallows the rest:
+
+> **Rook Mastered**
+> Every exercise, every labyrinth.
+> Great Focus Session recognized.
 > **Badge unlocked: First Great Session**
+
+`first-great-session` persists as an independent achievement but always renders
+as a line inside whichever closer contains the Great Focus Session — never on
+its own.
+
+In practice, `mastery` and `first-great-session` colliding is near-impossible:
+mastery requires a claimed badge and every labyrinth, so a first great session
+would have happened long before. The rule holds anyway.
+
+### The closer can be a transaction, and it can be cancelled
+
+`piece-badge` is **not an overlay — it is an interactive on-chain claim flow**
+(signature + transaction). If it absorbs a Great Focus Session and the player
+cancels or defers the claim, an earned recognition would vanish with the
+cancelled transaction.
+
+Contract: **an absorbed event persists before the claim flow opens.** If the
+claim is cancelled, deferred, or fails, the absorbed Great Focus Session falls
+back to its own overlay. Recognition is never contingent on signing a
+transaction. This mirrors the existing victory-claim cancellation behavior
+(#206), where cancelling is a no-op rather than a loss.
 
 ### Overlay contract
 
@@ -358,7 +393,11 @@ passed.** Seeding suppresses the overlay while preserving the state.
 | Second Great Focus Session | Celebration fires, `first-great-session` does not re-grant. |
 | Session limit reached | Never shown before a pending recognition drains. |
 | Gift + labyrinth same solve | Gift overlay first, then labyrinth. Never stacked. |
-| Badge + Great Session same solve | Badge first, session wrap-up last. |
+| Badge + Great Session same solve | One closer: the badge flow, Great Session absorbed as a line. |
+| Mastery + Great Session same solve | One closer: Mastery. Great Session absorbed, no second overlay. |
+| Special Training + Mastery same solve | Special Training overlay (incremental) first, Mastery closes. |
+| Badge claim **cancelled** with Great Session absorbed | Great Session still recognized — falls back to its own overlay. Never lost with the tx. |
+| Two majors in one drain | Exactly one overlay renders. Never two back to back. |
 | Close app before claiming | Reward persists, still claimable on return. |
 | Reopen app after celebrating | Celebration does not replay. |
 | Existing player past every gate | No retroactive overlays. |

--- a/docs/specs/2026-07-11-progression-unlocks-celebration-queue.md
+++ b/docs/specs/2026-07-11-progression-unlocks-celebration-queue.md
@@ -1,0 +1,379 @@
+# Progression Unlocks and Celebration Queue
+
+- **Date:** 2026-07-11
+- **Status:** Approved for planning
+- **Surface:** LEARN (Lite + full), hub action rail, exercises screen
+- **Baseline:** `main` @ `6f4d4060`
+
+## Problem
+
+Chesscito already owns every screen this design needs: the welcome gift, the
+labyrinth path, the daily-limit card, the piece badge, the mastery crown, the
+Special Training mini-arena. What it does not own is **when** they fire.
+
+Two concrete defects drive this spec.
+
+**1. The gift and the First Focus Day badge are the same event.**
+`daily-tactic-slot.tsx:113` reads:
+
+```ts
+if (CHESSCITO_LITE_MODE && prev.totalCompleted === 0) {
+  firstFocusDayJustEarned.current = true;
+  welcomePackage.unlock();
+}
+```
+
+One `if` grants a continuity badge and a reward. A player who has done nothing
+but open the app and solve one Daily Focus tactic already carries a pending-gift
+indicator. The reward arrives before any investment exists to reward.
+
+**2. Special Training appears in silence.**
+`hub-arena-tile.tsx:38` hides the tile until `starsPerPiece.rook >= 12`
+(`legacy-hub-client.tsx:426`), so the gate is real — but the unlock has no
+moment. The tile simply materializes, carrying a permanently-lit
+`HubTileStatusChip kind="ready"` (`hub-arena-tile.tsx:51-53`, commented as *"no
+invented logic"*). The dot means "this button exists", not "something new is
+here".
+
+The through-line: **nothing important should simply appear. It is earned, then
+celebrated, then made accessible.**
+
+## Governing rules
+
+1. **Earn → celebrate → open.** Every milestone persists an event, shows an
+   overlay, offers a CTA, and only then leaves a NEW marker in navigation.
+2. **A NEW dot means "something is available", never "a feature exists".** It is
+   set when the unlock persists and cleared the first time the player opens that
+   content.
+3. **The wall never arrives before the praise.** The session limit is a
+   consumption rule, not a progression milestone. It is evaluated only after all
+   pending recognitions are processed.
+4. **Quality accelerates the ladder.** Progress is measured in stars, not in
+   exercise count — with a floor of completed activities so a single perfect
+   solve cannot skip the arc.
+5. **Replays do not inflate progress.** Stars count as **net improvement over
+   the previous best**, never as a fresh grant.
+
+## Star accounting
+
+Two counters, deliberately different windows.
+
+```
+netStars(exerciseId, newStars) = max(0, newStars - previousBest(exerciseId))
+```
+
+| Counter | Definition | Window |
+|---|---|---|
+| `lifetimeStars` | Sum of best stars across all exercises (already `progress.stars`) | Cumulative, never resets |
+| `pieceStars(piece)` | Sum of best exercise stars for that piece (already `totalStars` in `path.ts:74`) | Cumulative, never resets |
+| `dailyStars` | Sum of `netStars` earned today, exercises **and** labyrinths | Resets at UTC midnight |
+
+`dailyStars` is the only daily counter. It is the sole input to Great Focus
+Session.
+
+**Labyrinth stars count toward `dailyStars` but never toward `pieceStars`.**
+Letting a labyrinth's stars feed the threshold that unlocked that labyrinth is a
+circular dependency. `path.ts:74` already excludes them; this spec makes the
+exclusion deliberate rather than incidental.
+
+**Examples of `netStars`:**
+
+| Previous best | New result | `dailyStars` delta |
+|---|---|---|
+| 1★ | 3★ | +2 |
+| 3★ | 3★ | 0 |
+| none (new exercise) | 2★ | +2 |
+
+This makes Great Focus Session measure real progress, not repetition, and it
+composes with `shouldFreezeScoring` (`session-quota.ts:124`), which already
+voids replay scoring once the session is over.
+
+## The ladder
+
+| Milestone | Condition | Window |
+|---|---|---|
+| **First Reward** (gift) | `lifetimeStars >= 4` AND `completedExercises >= 2` | Cumulative |
+| **First Labyrinth** | `pieceStars(piece) >= 6` AND `completedExercises(piece) >= 3` | Cumulative, per piece |
+| **Piece Badge** | `pieceStars(piece) >= 10`, claimed on-chain | Cumulative, per piece |
+| **Special Training** | `pieceStars(rook) >= 12` | Cumulative |
+| **Mastery** | Piece Badge claimed AND all labyrinths of that piece complete | Cumulative, per piece |
+| **Great Focus Session** | `dailyStars >= 8` OR session quota exhausted | **Daily, repeatable** |
+| **First Great Session** | First time Great Focus Session fires | Once, ever |
+
+Outside the ladder:
+
+| Rule | Condition |
+|---|---|
+| **Session Limit** | 10 activities consumed (`SESSION_EXERCISE_LIMIT`) |
+
+### Why the gift is cumulative, not daily
+
+A daily threshold silently strands players. Someone who earns 3★ on Monday and
+1★ on Tuesday never reaches "4★ in a day" — the counter resets at UTC midnight
+and the gift is unreachable forever. The gift is a once-ever onboarding event,
+so it reads a once-ever counter.
+
+### Why the compound conditions
+
+A pure star threshold reintroduces the defect it was meant to fix: a player who
+opens with a perfect 3★ solve would take the gift on interaction one. The
+`completedExercises` floor guarantees the arc exists before the reward lands.
+
+Worked example, perfect player (3★ every solve):
+
+```
+Exercise 1 → 3★  (lifetime 3★, 1 done)  → nothing
+Exercise 2 → 3★  (lifetime 6★, 2 done)  → First Reward   (4★ ✓, 2 done ✓)
+Exercise 3 → 3★  (piece 9★,   3 done)   → First Labyrinth (6★ ✓, 3 done ✓)
+```
+
+Without the exercise floor on the labyrinth, the gift and the labyrinth would
+both fire on exercise 2 and neither would feel earned.
+
+Worked example, struggling player (1★ every solve):
+
+```
+Exercises 1-4 → First Reward   (4★ ✓, 4 done ✓)
+Exercises 5-6 → First Labyrinth (6★ ✓, 6 done ✓)
+```
+
+### The 10★ / 12★ anomaly
+
+Piece Badge unlocks at 10★; Special Training at 12★. This is **deliberate**:
+Special Training is post-badge content, a coordination test that follows the
+proof of single-piece competence. It is recorded here so the gap is not
+"corrected" by a future reader, and it must be covered by a test asserting the
+ordering.
+
+This spec does **not** raise Special Training to a "Rook + King" requirement.
+All six pieces have exercises in the catalog, so a compound requirement is
+buildable later; v1 keeps the existing `rookStars >= 12` gate and adds only the
+missing moment.
+
+## Great Focus Session and the session limit
+
+```
+greatSession = dailyStars >= 8 OR sessionQuotaExhausted
+```
+
+The `OR` is a floor, not a convenience. Without it, the weakest player — the one
+who fails, retries, and burns all 10 activity slots with only 7★ — receives the
+paywall *instead of* the celebration. That inverts the intent. If the quota runs
+out and the session was never recognized, it is recognized then.
+
+Evaluation order after every solved activity:
+
+```
+1. Record the activity (stars, bests, consumed slot)
+2. Evaluate every milestone condition
+3. Drain the celebration queue
+4. Persist each fired event
+5. Return the player to the experience
+6. Only then, on the next attempt to start an activity, evaluate the session limit
+```
+
+The celebration and the limit are never two consecutive modals. The player
+returns to the board in between; the wall appears when they reach for the next
+activity.
+
+## Two layers of "day"
+
+The naming collision is resolved by keeping the two behaviors separate.
+
+| System | Measures | Condition | Grants |
+|---|---|---|---|
+| **Daily Focus** | Continuity — did they show up? | 1 Daily Focus solved | Stamps the Focus Passport, advances the streak, grants `first-focus-day` |
+| **Great Focus Session** | Depth — was the session substantial? | `dailyStars >= 8` OR quota exhausted | Session celebration, grants `first-great-session` |
+
+Great Focus Session is **not** required to keep the streak. Requiring 8★ daily
+to hold a streak — with streak recovery permanently off the table — converts a
+motivating mechanic into an abandonment driver.
+
+### `first-focus-day` is kept, not renamed
+
+Once the gift is unbundled from it, `first-focus-day` stops being wrong. It was
+never an inaccurate badge; it was a badly packaged one. It keeps its id, its
+condition (`totalCompleted >= 1`, `achievements/lite.ts:11`), and its art
+(`/art/achievements/1day-focus`).
+
+`first-great-session` is a **new, fourth** Lite achievement. Renaming
+`first-focus-day` instead would force a re-derivation from a counter existing
+players do not have, silently revoking a badge they already earned.
+
+## The unlock machine
+
+One state shape for every milestone. Conditions are pure derivations from
+already-persisted progress; only acknowledgement is new state.
+
+```ts
+export type MilestoneId =
+  | "first-reward"
+  | "first-labyrinth"
+  | "piece-badge"
+  | "special-training"
+  | "mastery"
+  | "great-focus-session"
+  | "first-great-session";
+
+export type MilestoneEvent = {
+  id: MilestoneId;
+  /** Scopes per-piece milestones. Absent for global ones. */
+  piece?: PieceId;
+  /** ISO timestamp the condition first became true. */
+  earnedAt: string;
+  /** The celebration overlay has been shown. */
+  celebrated: boolean;
+  /** The player has opened the unlocked content. Clears the NEW dot. */
+  opened: boolean;
+};
+```
+
+**Idempotence key:** `${id}` for global milestones, `${id}:${piece}` for
+per-piece ones. A milestone is celebrated exactly once. Re-deriving a condition
+that is already `celebrated` is a no-op.
+
+**Persistence:** localStorage, alongside the existing progress stores. Survives
+app close — a reward earned but not claimed is still waiting on return, and a
+celebration already consumed never replays.
+
+**Daily milestones:** `great-focus-session` is keyed by UTC date and resets with
+it. `first-great-session` never resets.
+
+### Celebration queue
+
+Conditions are evaluated together after a solve; overlays are drained one at a
+time, never stacked.
+
+```
+1. first-reward
+2. first-labyrinth
+3. piece-badge
+4. special-training
+5. mastery
+6. great-focus-session   (first-great-session rendered inside it)
+```
+
+Content unlocks precede the session wrap-up. The wrap-up is the only overlay
+that says "you can stop now" — anything shown after it contradicts it. `mastery`
+sits above `great-focus-session` for the same reason: it invites the next piece.
+
+`first-great-session` persists as an independent achievement but renders **inside**
+the Great Focus Session overlay rather than as a second modal:
+
+> **Great Focus Session**
+> A deep session, done.
+> **Badge unlocked: First Great Session**
+
+### Overlay contract
+
+Every unlock overlay uses the existing correct-exercise celebration shell, with
+the earned artifact replacing the wolf as the central icon.
+
+| Field | Value |
+|---|---|
+| Icon | The artifact earned (gift, labyrinth, training shield, badge, crown) |
+| Title | What was unlocked, ≤ 5 words |
+| Body | One line, what it is for |
+| Primary CTA | Enter the content |
+| Secondary CTA | "Later" — dismisses, sets the NEW dot |
+
+Special Training example:
+
+> **Special Training Unlocked**
+> Coordinate the Rook and the King.
+> `Start Training` / `Later`
+
+### NEW indicator
+
+The static `HubTileStatusChip kind="ready"` on the Special Training tile
+(`hub-arena-tile.tsx:53`) is replaced by a NEW chip driven by
+`event.opened === false`. Set when the unlock persists; cleared the first time
+the player opens the content. The same rule governs the gift indicator.
+
+## Special Training combinations (model only)
+
+The schema is defined now; only `rook-king` ships.
+
+| Combination | Requirement | Status |
+|---|---|---|
+| Rook & King Coordination | `rookStars >= 12` | **v1 — ships** |
+| Queen & King Coordination | TBD | Model only |
+| Bishop & King Coordination | TBD | Model only |
+| Rook Battery | TBD | Model only |
+| Knight Defense | TBD | Model only |
+
+Each entry carries: explicit requirement, locked state, unlock event, overlay
+copy, NEW indicator, entry content, completion condition. No further combination
+is authored in this cluster.
+
+## What changes in code
+
+| File | Change |
+|---|---|
+| `daily-tactic-slot.tsx:113` | Unbundle. `first-focus-day` stays; `welcomePackage.unlock()` moves to the milestone machine. |
+| `hub-daily-tile.tsx:155` | Same unbundling. |
+| `lib/welcome-package/use-welcome-package.ts:38` | Retroactive init (`totalCompleted >= 1`) is replaced by the `first-reward` condition. |
+| `lib/training/path.ts:66` | `LABYRINTH_UNLOCK_THRESHOLD` gains the `completedExercises >= 3` companion condition. |
+| `hub-arena-tile.tsx:53` | Static `ready` chip → NEW chip driven by `opened`. |
+| `lib/achievements/lite.ts` | Add `first-great-session`. Three achievements become four. |
+| New: `lib/progression/milestones.ts` | Pure condition derivation. No IO, no React. |
+| New: `lib/progression/milestone-storage.ts` | Persistence + idempotence. |
+| New: `lib/progression/use-celebration-queue.ts` | Ordered drain. |
+| New: `components/progression/unlock-overlay.tsx` | Shared overlay shell. |
+
+Untouched: the on-chain Piece Badge (soulbound, already minted on mainnet) and
+the Mastery node in `path.ts`. Their semantics are correct; future growth builds
+on top of them, never by reinterpreting a badge already in players' wallets.
+
+## Migration
+
+Existing players must not regress.
+
+| Case | Behavior |
+|---|---|
+| Already claimed the gift | `first-reward` seeds as `celebrated: true, opened: true`. No replay. |
+| Gift unlocked, unclaimed | `first-reward` seeds as `celebrated: true, opened: false`. NEW dot persists; no surprise overlay. |
+| Already earned `first-focus-day` | Untouched. Keeps the badge. |
+| Already past 12★ rook | `special-training` seeds as `celebrated: true, opened: true`. The tile stays visible, no retroactive overlay. |
+| Already claimed a Piece Badge | Seeds `celebrated: true`. |
+
+The rule: **no retroactive celebration fires for a milestone a player already
+passed.** Seeding suppresses the overlay while preserving the state.
+
+## Test matrix
+
+| Scenario | Expected |
+|---|---|
+| 1 perfect exercise (3★) | No gift. Floor of 2 exercises not met. |
+| 2 exercises, 4★ total | Gift fires. |
+| 1★ × 4 exercises | Gift fires on the fourth. |
+| 3★ on Monday, 1★ on Tuesday | Gift fires Tuesday (cumulative, not daily). |
+| 6★ piece, 2 exercises | No labyrinth. Floor of 3 not met. |
+| 6★ piece, 3 exercises | Labyrinth unlocks. |
+| Replay a 3★ exercise at 3★ | `dailyStars` += 0. |
+| Replay a 1★ exercise at 3★ | `dailyStars` += 2. |
+| 8★ earned today | Great Focus Session fires. |
+| Quota exhausted at 7★ | Great Focus Session fires anyway (floor). |
+| First Great Focus Session | `first-great-session` granted, rendered inside the same overlay. |
+| Second Great Focus Session | Celebration fires, `first-great-session` does not re-grant. |
+| Session limit reached | Never shown before a pending recognition drains. |
+| Gift + labyrinth same solve | Gift overlay first, then labyrinth. Never stacked. |
+| Badge + Great Session same solve | Badge first, session wrap-up last. |
+| Close app before claiming | Reward persists, still claimable on return. |
+| Reopen app after celebrating | Celebration does not replay. |
+| Existing player past every gate | No retroactive overlays. |
+| 12★ rook | Special Training overlay, then NEW chip until opened. |
+| Open Special Training | NEW chip clears. |
+
+## Open questions
+
+1. **Special Training copy** says "Coordinate the Rook and the King" while the
+   gate is rook-only. Accepted for v1; revisit if the requirement becomes
+   compound.
+2. **Analytics.** Each milestone should emit an event. Naming not specified here.
+3. **`dailyStars` display.** Whether to surface "6/8 Focus" in the HUD is a
+   separate design call. The counter exists either way.
+
+---
+
+Wolfcito 🐾 @akawolfcito

--- a/docs/specs/2026-07-11-progression-unlocks-implementation-plan.md
+++ b/docs/specs/2026-07-11-progression-unlocks-implementation-plan.md
@@ -1,0 +1,2454 @@
+# Progression Unlocks and Celebration Queue — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every earned reward in LEARN fire at the moment it is earned, through one milestone machine with persisted, idempotent events and an ordered celebration queue.
+
+**Architecture:** A pure derivation core (`lib/progression/*.ts`) computes milestone conditions from progress that is *already persisted* — no new source of truth for stars. Only *acknowledgement* is new state. Persistence precedes rendering. A React hook drains an ordered queue of at most one major celebration, and the existing overlays are re-pointed at it.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript, Vitest + RTL, localStorage.
+
+**Spec:** `docs/specs/2026-07-11-progression-unlocks-celebration-queue.md`
+
+## Global Constraints
+
+- Copy is authored in `lib/content/editorial.ts` and mirrored by hand in `lib/content/messages/es.ts`. **Never edit `messages/en.ts` by hand** — it is derived.
+- Reward copy: ≤ 5 words, no web3 jargon. No em-dashes or en-dashes in user-facing prose.
+- Never prefix a Bash call with `cd`. Use `pnpm -C <abs-path>` and `git -C <abs-path>`.
+- Typecheck with a bare `pnpm exec tsc --noEmit`.
+- Stars are `0..3` per exercise, sparse map keyed by `exerciseId` (`PieceProgress.stars`).
+- `dailyStars` counts **net improvement over previous best**, exercises AND labyrinths.
+- Labyrinth stars feed `dailyStars` but **never** `pieceStars` (circular dependency).
+- `mastery` depends on `piece-badge-claimed`, never on eligibility.
+- `openedAt` is written **only** on navigable milestones: `first-reward`, `first-labyrinth`, `special-training`.
+- Persist the event, THEN render the overlay. Never the reverse.
+- No retroactive celebration fires for a milestone a player already passed.
+- Do not touch the on-chain badge semantics (soulbound, already minted on mainnet).
+- Run the full suite before each commit. Baseline: 4875 passing / 404 files.
+
+---
+
+### Task 1: Milestone types (SDD — the contract first)
+
+**Files:**
+- Create: `apps/web/src/lib/progression/types.ts`
+
+**Interfaces:**
+- Consumes: `PieceId` from `@/lib/game/types`.
+- Produces: `MilestoneId`, `MilestoneEvent`, `MilestoneStore`, `milestoneKey()`, `NAVIGABLE_MILESTONES`.
+
+- [ ] **Step 1: Write the type module**
+
+```ts
+import type { PieceId } from "@/lib/game/types";
+
+/** Every recognizable moment in the LEARN progression ladder.
+ *  `piece-badge-eligible` is the RIGHT to claim (10 stars reached).
+ *  `piece-badge-claimed` is the confirmed on-chain mint. They are two
+ *  events because a badge does not exist until a transaction confirms. */
+export type MilestoneId =
+  | "first-reward"
+  | "first-labyrinth"
+  | "special-training"
+  | "piece-badge-eligible"
+  | "piece-badge-claimed"
+  | "mastery"
+  | "great-focus-session"
+  | "first-great-session";
+
+/** Milestones that lead somewhere. Only these carry `openedAt` — a Great
+ *  Focus Session, a claimed badge and a mastery crown are recognitions,
+ *  not destinations, so an "opened" flag on them would mean nothing. */
+export const NAVIGABLE_MILESTONES: readonly MilestoneId[] = [
+  "first-reward",
+  "first-labyrinth",
+  "special-training",
+] as const;
+
+export type MilestoneEvent = {
+  id: MilestoneId;
+  /** Scopes per-piece milestones. Absent on global ones. */
+  piece?: PieceId;
+  /** ISO timestamp the condition first became true. */
+  earnedAt: string;
+  /** Set once the celebration overlay has actually been shown. */
+  celebratedAt?: string;
+  /** Set the first time the player opens the content. Clears the NEW dot.
+   *  Only ever written for a milestone in NAVIGABLE_MILESTONES. */
+  openedAt?: string;
+};
+
+/** Idempotency key. Per-piece milestones are scoped; global ones are not. */
+export function milestoneKey(id: MilestoneId, piece?: PieceId): string {
+  return piece ? `${id}:${piece}` : id;
+}
+
+export type MilestoneStore = {
+  version: 1;
+  /** Keyed by `milestoneKey()`. A present entry means the event fired. */
+  events: Record<string, MilestoneEvent>;
+  /** UTC date the daily milestones were last reset. */
+  dailyDate: string | null;
+};
+
+export const EMPTY_STORE: MilestoneStore = {
+  version: 1,
+  events: {},
+  dailyDate: null,
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/types.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): milestone event contract
+
+Eligible and claimed are separate events because a badge does not exist
+until a transaction confirms. openedAt exists only on milestones that
+lead somewhere.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 2: Net-star accounting
+
+**Files:**
+- Create: `apps/web/src/lib/progression/stars.ts`
+- Modify: `apps/web/src/lib/lite-progress-storage.ts` (add `dailyStarsStorageKey`)
+- Test: `apps/web/src/lib/progression/__tests__/stars.test.ts`
+
+**Interfaces:**
+- Produces: `netStars(previousBest, newStars)`, `DailyStarLedger`, `parseDailyStars()`, `computeAddNetStars()`, and the IO wrappers `getDailyStarLedger()`, `getDailyStars()`, `addNetStars(previousBest, newStars)` — Task 13 calls `getDailyStars()` and `addNetStars()` from the save flow.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  computeAddNetStars,
+  netStars,
+  parseDailyStars,
+  type DailyStarLedger,
+} from "@/lib/progression/stars";
+
+describe("netStars", () => {
+  it("counts only the improvement over the previous best", () => {
+    expect(netStars(1, 3)).toBe(2);
+  });
+
+  it("is zero when a replay does not beat the previous best", () => {
+    expect(netStars(3, 3)).toBe(0);
+  });
+
+  it("is zero when a replay is worse than the previous best", () => {
+    expect(netStars(3, 1)).toBe(0);
+  });
+
+  it("counts the full result for a never-played exercise", () => {
+    expect(netStars(0, 2)).toBe(2);
+  });
+});
+
+describe("parseDailyStars", () => {
+  it("returns a zeroed ledger for a stored date that is not today", () => {
+    const raw = JSON.stringify({ date: "2026-07-10", stars: 8 });
+    expect(parseDailyStars(raw, "2026-07-11")).toEqual({
+      date: "2026-07-11",
+      stars: 0,
+    });
+  });
+
+  it("returns a zeroed ledger for corrupt input", () => {
+    expect(parseDailyStars("{{{", "2026-07-11")).toEqual({
+      date: "2026-07-11",
+      stars: 0,
+    });
+  });
+
+  it("keeps today's ledger", () => {
+    const raw = JSON.stringify({ date: "2026-07-11", stars: 5 });
+    expect(parseDailyStars(raw, "2026-07-11")).toEqual({
+      date: "2026-07-11",
+      stars: 5,
+    });
+  });
+});
+
+describe("computeAddNetStars", () => {
+  it("adds the net gain and leaves the reference untouched on a no-op", () => {
+    const state: DailyStarLedger = { date: "2026-07-11", stars: 5 };
+    expect(computeAddNetStars(state, 0)).toBe(state);
+    expect(computeAddNetStars(state, 2)).toEqual({
+      date: "2026-07-11",
+      stars: 7,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/stars.test.ts`
+Expected: FAIL — cannot resolve `@/lib/progression/stars`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+import { todayUtc } from "@/lib/daily/progress";
+
+/** Stars earned today. The ONLY daily counter in the progression system.
+ *  Fed by exercises AND labyrinths, always as net improvement — replaying
+ *  a solved exercise must never inflate a session. */
+export type DailyStarLedger = {
+  date: string;
+  stars: number;
+};
+
+/** The improvement a result represents over the player's previous best.
+ *  A replay that does not beat the best contributes nothing. */
+export function netStars(previousBest: number, newStars: number): number {
+  return Math.max(0, newStars - previousBest);
+}
+
+export function parseDailyStars(
+  raw: string | null,
+  today: string = todayUtc(),
+): DailyStarLedger {
+  const fresh: DailyStarLedger = { date: today, stars: 0 };
+  if (!raw) return fresh;
+  try {
+    const parsed = JSON.parse(raw) as Partial<DailyStarLedger>;
+    if (parsed?.date !== today) return fresh;
+    return {
+      date: today,
+      stars: typeof parsed.stars === "number" ? Math.max(0, parsed.stars) : 0,
+    };
+  } catch {
+    return fresh;
+  }
+}
+
+export function computeAddNetStars(
+  state: DailyStarLedger,
+  gain: number,
+): DailyStarLedger {
+  if (gain <= 0) return state;
+  return { ...state, stars: state.stars + gain };
+}
+
+// ─── localStorage I/O ────────────────────────────────────────────────────
+
+export function getDailyStarLedger(): DailyStarLedger {
+  if (typeof window === "undefined") return parseDailyStars(null);
+  try {
+    return parseDailyStars(localStorage.getItem(dailyStarsStorageKey()));
+  } catch {
+    return parseDailyStars(null);
+  }
+}
+
+/** Convenience read for callers that only need the number. */
+export function getDailyStars(): number {
+  return getDailyStarLedger().stars;
+}
+
+/** Adds the net improvement a result represents. Call this once per solved
+ *  activity, exercise or labyrinth, with the previous best in hand. */
+export function addNetStars(previousBest: number, newStars: number): DailyStarLedger {
+  const current = getDailyStarLedger();
+  const next = computeAddNetStars(current, netStars(previousBest, newStars));
+  if (next === current) return current;
+  if (typeof window !== "undefined") {
+    try {
+      localStorage.setItem(dailyStarsStorageKey(), JSON.stringify(next));
+    } catch {
+      // Quota or privacy mode — the caller still gets the correct state back.
+    }
+  }
+  return next;
+}
+```
+
+Import `dailyStarsStorageKey` from `@/lib/lite-progress-storage` and add it there beside `dailySessionStorageKey`:
+
+```ts
+export function dailyStarsStorageKey(): string {
+  return `${progressPrefix()}daily-stars`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/stars.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/stars.ts apps/web/src/lib/progression/__tests__/stars.test.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): net-star accounting
+
+Replaying a solved exercise contributes zero, so a session measures real
+progress rather than repetition.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 3: Milestone condition derivation (pure)
+
+**Files:**
+- Create: `apps/web/src/lib/progression/milestones.ts`
+- Test: `apps/web/src/lib/progression/__tests__/milestones.test.ts`
+
+**Interfaces:**
+- Consumes: `MilestoneId`, `milestoneKey` (Task 1).
+- Produces: `MilestoneInput`, `deriveEarnedMilestones(input): { id: MilestoneId; piece?: PieceId }[]`, and the threshold constants `GIFT_STARS`, `GIFT_EXERCISES`, `LABYRINTH_EXERCISES`, `GREAT_SESSION_STARS`.
+
+**Note on thresholds:** `LABYRINTH_UNLOCK_THRESHOLD` (6) lives in `lib/training/path.ts:66` and `BADGE_THRESHOLD` (10) in `lib/game/exercises.ts:28`. Import them; do not redeclare.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  deriveEarnedMilestones,
+  type MilestoneInput,
+} from "@/lib/progression/milestones";
+
+function input(overrides: Partial<MilestoneInput> = {}): MilestoneInput {
+  return {
+    piece: "rook",
+    lifetimeStars: 0,
+    completedExercises: 0,
+    pieceStars: 0,
+    pieceCompletedExercises: 0,
+    rookStars: 0,
+    dailyStars: 0,
+    sessionQuotaExhausted: false,
+    badgeClaimed: false,
+    allLabyrinthsComplete: false,
+    hadGreatSessionBefore: false,
+    ...overrides,
+  };
+}
+
+function ids(result: ReturnType<typeof deriveEarnedMilestones>): string[] {
+  return result.map((event) => event.id);
+}
+
+describe("first-reward", () => {
+  it("does not fire on a single perfect solve — the exercise floor is not met", () => {
+    const earned = deriveEarnedMilestones(
+      input({ lifetimeStars: 3, completedExercises: 1 }),
+    );
+    expect(ids(earned)).not.toContain("first-reward");
+  });
+
+  it("fires at 4 stars across 2 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ lifetimeStars: 4, completedExercises: 2 }),
+    );
+    expect(ids(earned)).toContain("first-reward");
+  });
+
+  it("fires for a struggling player at 1 star across 4 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ lifetimeStars: 4, completedExercises: 4 }),
+    );
+    expect(ids(earned)).toContain("first-reward");
+  });
+});
+
+describe("first-labyrinth", () => {
+  it("does not fire at 6 piece stars across only 2 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 6, pieceCompletedExercises: 2 }),
+    );
+    expect(ids(earned)).not.toContain("first-labyrinth");
+  });
+
+  it("fires at 6 piece stars across 3 exercises", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 6, pieceCompletedExercises: 3 }),
+    );
+    expect(ids(earned)).toContain("first-labyrinth");
+  });
+});
+
+describe("piece badge", () => {
+  it("is eligible at 10 piece stars but not claimed", () => {
+    const earned = deriveEarnedMilestones(input({ pieceStars: 10 }));
+    expect(ids(earned)).toContain("piece-badge-eligible");
+    expect(ids(earned)).not.toContain("piece-badge-claimed");
+  });
+
+  it("is claimed once the transaction confirms", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 10, badgeClaimed: true }),
+    );
+    expect(ids(earned)).toContain("piece-badge-claimed");
+  });
+});
+
+describe("mastery", () => {
+  it("stays locked when every labyrinth is done but the badge was never claimed", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 10, allLabyrinthsComplete: true, badgeClaimed: false }),
+    );
+    expect(ids(earned)).not.toContain("mastery");
+  });
+
+  it("fires when the badge is claimed and every labyrinth is done", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 10, allLabyrinthsComplete: true, badgeClaimed: true }),
+    );
+    expect(ids(earned)).toContain("mastery");
+  });
+});
+
+describe("special-training", () => {
+  it("fires at 12 rook stars", () => {
+    expect(ids(deriveEarnedMilestones(input({ rookStars: 12 })))).toContain(
+      "special-training",
+    );
+  });
+
+  it("does not fire at 11 rook stars", () => {
+    expect(ids(deriveEarnedMilestones(input({ rookStars: 11 })))).not.toContain(
+      "special-training",
+    );
+  });
+});
+
+describe("great-focus-session", () => {
+  it("fires at 8 daily stars", () => {
+    expect(ids(deriveEarnedMilestones(input({ dailyStars: 8 })))).toContain(
+      "great-focus-session",
+    );
+  });
+
+  it("fires on an exhausted quota even at 7 daily stars — the wall never beats the praise", () => {
+    const earned = deriveEarnedMilestones(
+      input({ dailyStars: 7, sessionQuotaExhausted: true }),
+    );
+    expect(ids(earned)).toContain("great-focus-session");
+  });
+
+  it("grants first-great-session only the first time", () => {
+    const first = deriveEarnedMilestones(input({ dailyStars: 8 }));
+    expect(ids(first)).toContain("first-great-session");
+
+    const later = deriveEarnedMilestones(
+      input({ dailyStars: 8, hadGreatSessionBefore: true }),
+    );
+    expect(ids(later)).toContain("great-focus-session");
+    expect(ids(later)).not.toContain("first-great-session");
+  });
+});
+
+describe("per-piece scoping", () => {
+  it("scopes piece milestones to the piece under play", () => {
+    const earned = deriveEarnedMilestones(
+      input({ piece: "bishop", pieceStars: 10 }),
+    );
+    const badge = earned.find((event) => event.id === "piece-badge-eligible");
+    expect(badge?.piece).toBe("bishop");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/milestones.test.ts`
+Expected: FAIL — cannot resolve `@/lib/progression/milestones`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+import type { PieceId } from "@/lib/game/types";
+import { BADGE_THRESHOLD } from "@/lib/game/exercises";
+import { LABYRINTH_UNLOCK_THRESHOLD } from "@/lib/training/path";
+import type { MilestoneId } from "./types";
+
+/** The gift is a once-ever event, so it reads once-ever counters. A daily
+ *  threshold would strand a player who earns 3 stars on Monday and 1 on
+ *  Tuesday: the counter resets at UTC midnight and the gift never lands. */
+export const GIFT_STARS = 4;
+export const GIFT_EXERCISES = 2;
+
+/** The exercise floor that keeps the gift and the labyrinth from firing on
+ *  the same solve for a perfect player. */
+export const LABYRINTH_EXERCISES = 3;
+
+export const SPECIAL_TRAINING_ROOK_STARS = 12;
+
+export const GREAT_SESSION_STARS = 8;
+
+export type MilestoneInput = {
+  /** The piece currently under play — scopes the per-piece milestones. */
+  piece: PieceId;
+  /** Best exercise stars summed across every piece. Cumulative. */
+  lifetimeStars: number;
+  /** Exercises solved at least once, across every piece. Cumulative. */
+  completedExercises: number;
+  /** Best exercise stars for `piece`. Labyrinth stars NEVER count here. */
+  pieceStars: number;
+  /** Exercises of `piece` solved at least once. */
+  pieceCompletedExercises: number;
+  /** Rook exercise stars — the Special Training gate. */
+  rookStars: number;
+  /** Net stars earned today, exercises AND labyrinths. */
+  dailyStars: number;
+  sessionQuotaExhausted: boolean;
+  /** On-chain claim state for `piece`. */
+  badgeClaimed: boolean;
+  allLabyrinthsComplete: boolean;
+  /** Whether a Great Focus Session was ever recognized before today. */
+  hadGreatSessionBefore: boolean;
+};
+
+export type EarnedMilestone = {
+  id: MilestoneId;
+  piece?: PieceId;
+};
+
+/** Pure. Returns every milestone whose condition is currently TRUE — it does
+ *  NOT know or care which ones already fired. Idempotence lives in storage. */
+export function deriveEarnedMilestones(input: MilestoneInput): EarnedMilestone[] {
+  const earned: EarnedMilestone[] = [];
+  const { piece } = input;
+
+  if (
+    input.lifetimeStars >= GIFT_STARS &&
+    input.completedExercises >= GIFT_EXERCISES
+  ) {
+    earned.push({ id: "first-reward" });
+  }
+
+  if (
+    input.pieceStars >= LABYRINTH_UNLOCK_THRESHOLD &&
+    input.pieceCompletedExercises >= LABYRINTH_EXERCISES
+  ) {
+    earned.push({ id: "first-labyrinth", piece });
+  }
+
+  if (input.rookStars >= SPECIAL_TRAINING_ROOK_STARS) {
+    earned.push({ id: "special-training" });
+  }
+
+  if (input.pieceStars >= BADGE_THRESHOLD) {
+    earned.push({ id: "piece-badge-eligible", piece });
+    if (input.badgeClaimed) {
+      earned.push({ id: "piece-badge-claimed", piece });
+    }
+  }
+
+  // The crown cannot rest on a badge that was never minted.
+  if (input.badgeClaimed && input.allLabyrinthsComplete) {
+    earned.push({ id: "mastery", piece });
+  }
+
+  const greatSession =
+    input.dailyStars >= GREAT_SESSION_STARS || input.sessionQuotaExhausted;
+  if (greatSession) {
+    earned.push({ id: "great-focus-session" });
+    if (!input.hadGreatSessionBefore) {
+      earned.push({ id: "first-great-session" });
+    }
+  }
+
+  return earned;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/milestones.test.ts`
+Expected: PASS, 13 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/milestones.ts apps/web/src/lib/progression/__tests__/milestones.test.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): derive milestone conditions
+
+Compound conditions with an exercise floor, so a single perfect solve
+cannot skip the arc and the gift never strands a player who spreads stars
+across days.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 4: Celebration queue ordering (pure)
+
+**Files:**
+- Create: `apps/web/src/lib/progression/celebration-queue.ts`
+- Test: `apps/web/src/lib/progression/__tests__/celebration-queue.test.ts`
+
+**Interfaces:**
+- Consumes: `EarnedMilestone` (Task 3), `MilestoneId` (Task 1).
+- Produces: `buildCelebrationQueue(pending): CelebrationStep[]`, `CelebrationStep`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildCelebrationQueue } from "@/lib/progression/celebration-queue";
+
+describe("buildCelebrationQueue", () => {
+  it("returns nothing when nothing fired", () => {
+    expect(buildCelebrationQueue([])).toEqual([]);
+  });
+
+  it("shows incremental unlocks in ladder order, each its own overlay", () => {
+    const queue = buildCelebrationQueue([
+      { id: "special-training" },
+      { id: "first-reward" },
+      { id: "first-labyrinth", piece: "rook" },
+    ]);
+    expect(queue.map((step) => step.id)).toEqual([
+      "first-reward",
+      "first-labyrinth",
+      "special-training",
+    ]);
+  });
+
+  it("closes with the great focus session when it is the only major", () => {
+    const queue = buildCelebrationQueue([
+      { id: "first-reward" },
+      { id: "great-focus-session" },
+    ]);
+    expect(queue.map((step) => step.id)).toEqual([
+      "first-reward",
+      "great-focus-session",
+    ]);
+  });
+
+  it("renders exactly one closer and absorbs the lower major into it", () => {
+    const queue = buildCelebrationQueue([
+      { id: "great-focus-session" },
+      { id: "mastery", piece: "rook" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("mastery");
+    expect(queue[0].absorbed).toEqual(["great-focus-session"]);
+  });
+
+  it("lets the claim flow close and absorb the session", () => {
+    const queue = buildCelebrationQueue([
+      { id: "great-focus-session" },
+      { id: "piece-badge-eligible", piece: "rook" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("piece-badge-eligible");
+    expect(queue[0].absorbed).toEqual(["great-focus-session"]);
+  });
+
+  it("always renders first-great-session inside the closer, never alone", () => {
+    const queue = buildCelebrationQueue([
+      { id: "great-focus-session" },
+      { id: "first-great-session" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("great-focus-session");
+    expect(queue[0].absorbed).toContain("first-great-session");
+  });
+
+  it("shows the incremental unlock before the closer when both fire", () => {
+    const queue = buildCelebrationQueue([
+      { id: "mastery", piece: "rook" },
+      { id: "special-training" },
+    ]);
+    expect(queue.map((step) => step.id)).toEqual(["special-training", "mastery"]);
+  });
+
+  it("never renders two majors back to back", () => {
+    const queue = buildCelebrationQueue([
+      { id: "mastery", piece: "rook" },
+      { id: "piece-badge-eligible", piece: "rook" },
+      { id: "great-focus-session" },
+    ]);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe("mastery");
+    expect(queue[0].absorbed).toEqual([
+      "piece-badge-eligible",
+      "great-focus-session",
+    ]);
+  });
+
+  it("drops piece-badge-claimed from the queue — the claim flow owns that moment", () => {
+    const queue = buildCelebrationQueue([
+      { id: "piece-badge-claimed", piece: "rook" },
+    ]);
+    expect(queue).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/celebration-queue.test.ts`
+Expected: FAIL — cannot resolve `@/lib/progression/celebration-queue`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+import type { PieceId } from "@/lib/game/types";
+import type { EarnedMilestone } from "./milestones";
+import type { MilestoneId } from "./types";
+
+/** Incremental unlocks. Each gets its own overlay because each carries a CTA
+ *  to different content. None of them concludes anything — they invite action. */
+const INCREMENTAL_ORDER: MilestoneId[] = [
+  "first-reward",
+  "first-labyrinth",
+  "special-training",
+];
+
+/** Majors, highest hierarchy first. Exactly ONE renders per drain; every
+ *  other major that fired is absorbed as a line inside it. Showing MASTERY!
+ *  and then GREAT FOCUS SESSION! drops the intensity after the climax. */
+const CLOSER_ORDER: MilestoneId[] = [
+  "mastery",
+  "piece-badge-eligible",
+  "great-focus-session",
+];
+
+export type CelebrationStep = {
+  id: MilestoneId;
+  piece?: PieceId;
+  /** Lower majors rendered as lines inside this overlay, never as modals. */
+  absorbed: MilestoneId[];
+};
+
+export function buildCelebrationQueue(
+  pending: readonly EarnedMilestone[],
+): CelebrationStep[] {
+  const find = (id: MilestoneId) => pending.find((event) => event.id === id);
+
+  const steps: CelebrationStep[] = [];
+
+  for (const id of INCREMENTAL_ORDER) {
+    const event = find(id);
+    if (event) steps.push({ id, piece: event.piece, absorbed: [] });
+  }
+
+  const firedClosers = CLOSER_ORDER.filter((id) => find(id));
+  if (firedClosers.length === 0) return steps;
+
+  const [closerId, ...absorbedClosers] = firedClosers;
+  const closer = find(closerId);
+  const absorbed: MilestoneId[] = [...absorbedClosers];
+
+  // first-great-session is an achievement, never an overlay of its own.
+  if (find("first-great-session")) absorbed.push("first-great-session");
+
+  steps.push({ id: closerId, piece: closer?.piece, absorbed });
+  return steps;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/celebration-queue.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/celebration-queue.ts apps/web/src/lib/progression/__tests__/celebration-queue.test.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): one closer per drain
+
+Incremental unlocks invite action and come first; the highest-hierarchy
+event closes and absorbs every lower major as a line. Never two major
+celebrations back to back.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 5: Milestone persistence and idempotence
+
+**Files:**
+- Create: `apps/web/src/lib/progression/milestone-storage.ts`
+- Modify: `apps/web/src/lib/lite-progress-storage.ts` (add one key helper)
+- Test: `apps/web/src/lib/progression/__tests__/milestone-storage.test.ts`
+
+**Interfaces:**
+- Consumes: `MilestoneStore`, `MilestoneEvent`, `milestoneKey`, `EMPTY_STORE`, `NAVIGABLE_MILESTONES` (Task 1); `EarnedMilestone` (Task 3).
+- Produces: `parseMilestoneStore()`, `computeRecordEarned()`, `computeMarkCelebrated()`, `computeMarkOpened()`, `selectPending()`, `getMilestoneStore()`, `recordEarned()`, `markCelebrated()`, `markOpened()`.
+
+- [ ] **Step 1: Add the storage key helper**
+
+In `apps/web/src/lib/lite-progress-storage.ts`, after `dailySessionStorageKey`:
+
+```ts
+export function milestoneStorageKey(): string {
+  return `${progressPrefix()}milestones`;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  computeMarkCelebrated,
+  computeMarkOpened,
+  computeRecordEarned,
+  parseMilestoneStore,
+  selectPending,
+} from "@/lib/progression/milestone-storage";
+import { EMPTY_STORE, type MilestoneStore } from "@/lib/progression/types";
+
+const NOW = "2026-07-11T10:00:00.000Z";
+const TODAY = "2026-07-11";
+
+describe("parseMilestoneStore", () => {
+  it("returns an empty store for corrupt input", () => {
+    expect(parseMilestoneStore("{{{", TODAY)).toEqual(EMPTY_STORE);
+  });
+
+  it("clears daily milestones when the stored date is not today", () => {
+    const stored: MilestoneStore = {
+      version: 1,
+      dailyDate: "2026-07-10",
+      events: {
+        "great-focus-session": {
+          id: "great-focus-session",
+          earnedAt: "2026-07-10T09:00:00.000Z",
+          celebratedAt: "2026-07-10T09:00:00.000Z",
+        },
+        "first-reward": { id: "first-reward", earnedAt: "2026-07-10T08:00:00.000Z" },
+      },
+    };
+    const parsed = parseMilestoneStore(JSON.stringify(stored), TODAY);
+    expect(parsed.events["great-focus-session"]).toBeUndefined();
+    expect(parsed.events["first-reward"]).toBeDefined();
+    expect(parsed.dailyDate).toBe(TODAY);
+  });
+
+  it("keeps first-great-session across days — it never resets", () => {
+    const stored: MilestoneStore = {
+      version: 1,
+      dailyDate: "2026-07-10",
+      events: {
+        "first-great-session": {
+          id: "first-great-session",
+          earnedAt: "2026-07-10T09:00:00.000Z",
+        },
+      },
+    };
+    const parsed = parseMilestoneStore(JSON.stringify(stored), TODAY);
+    expect(parsed.events["first-great-session"]).toBeDefined();
+  });
+});
+
+describe("computeRecordEarned", () => {
+  it("records a new event with its earnedAt", () => {
+    const next = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    expect(next.events["first-reward"]).toEqual({
+      id: "first-reward",
+      earnedAt: NOW,
+    });
+  });
+
+  it("scopes per-piece events by their idempotency key", () => {
+    const next = computeRecordEarned(
+      EMPTY_STORE,
+      [{ id: "piece-badge-eligible", piece: "bishop" }],
+      NOW,
+    );
+    expect(next.events["piece-badge-eligible:bishop"]?.piece).toBe("bishop");
+  });
+
+  it("is idempotent — re-deriving a recorded event returns the same reference", () => {
+    const first = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    const second = computeRecordEarned(first, [{ id: "first-reward" }], NOW);
+    expect(second).toBe(first);
+  });
+
+  it("never overwrites earnedAt on a re-derive", () => {
+    const first = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    const later = computeRecordEarned(
+      first,
+      [{ id: "first-reward" }],
+      "2026-07-12T10:00:00.000Z",
+    );
+    expect(later.events["first-reward"].earnedAt).toBe(NOW);
+  });
+});
+
+describe("selectPending", () => {
+  it("returns events that have never been celebrated", () => {
+    const store = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    expect(selectPending(store)).toEqual([{ id: "first-reward", piece: undefined }]);
+  });
+
+  it("excludes an already celebrated event", () => {
+    const earned = computeRecordEarned(EMPTY_STORE, [{ id: "first-reward" }], NOW);
+    const celebrated = computeMarkCelebrated(earned, "first-reward", undefined, NOW);
+    expect(selectPending(celebrated)).toEqual([]);
+  });
+});
+
+describe("computeMarkOpened", () => {
+  it("clears the NEW dot on a navigable milestone", () => {
+    const earned = computeRecordEarned(EMPTY_STORE, [{ id: "special-training" }], NOW);
+    const opened = computeMarkOpened(earned, "special-training", undefined, NOW);
+    expect(opened.events["special-training"].openedAt).toBe(NOW);
+  });
+
+  it("refuses to write openedAt on a recognition — it has no destination", () => {
+    const earned = computeRecordEarned(
+      EMPTY_STORE,
+      [{ id: "great-focus-session" }],
+      NOW,
+    );
+    const opened = computeMarkOpened(earned, "great-focus-session", undefined, NOW);
+    expect(opened.events["great-focus-session"].openedAt).toBeUndefined();
+    expect(opened).toBe(earned);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/milestone-storage.test.ts`
+Expected: FAIL — cannot resolve `@/lib/progression/milestone-storage`.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+```ts
+import type { PieceId } from "@/lib/game/types";
+import { todayUtc } from "@/lib/daily/progress";
+import { milestoneStorageKey } from "@/lib/lite-progress-storage";
+import type { EarnedMilestone } from "./milestones";
+import {
+  EMPTY_STORE,
+  milestoneKey,
+  NAVIGABLE_MILESTONES,
+  type MilestoneEvent,
+  type MilestoneId,
+  type MilestoneStore,
+} from "./types";
+
+/** Resets with the UTC day. Everything else is cumulative and permanent. */
+const DAILY_MILESTONES: readonly MilestoneId[] = ["great-focus-session"];
+
+export function parseMilestoneStore(
+  raw: string | null,
+  today: string = todayUtc(),
+): MilestoneStore {
+  if (!raw) return { ...EMPTY_STORE, dailyDate: today };
+  let parsed: Partial<MilestoneStore>;
+  try {
+    parsed = JSON.parse(raw) as Partial<MilestoneStore>;
+  } catch {
+    return { ...EMPTY_STORE, dailyDate: today };
+  }
+  if (parsed.version !== 1 || typeof parsed.events !== "object" || !parsed.events) {
+    return { ...EMPTY_STORE, dailyDate: today };
+  }
+
+  const events = { ...parsed.events };
+  if (parsed.dailyDate !== today) {
+    for (const id of DAILY_MILESTONES) {
+      delete events[id];
+    }
+  }
+  return { version: 1, events, dailyDate: today };
+}
+
+/** Records every earned milestone that is not already on disk. Returns the
+ *  SAME reference when nothing is new, so callers can skip the write. */
+export function computeRecordEarned(
+  store: MilestoneStore,
+  earned: readonly EarnedMilestone[],
+  now: string,
+): MilestoneStore {
+  const fresh = earned.filter(
+    (event) => !store.events[milestoneKey(event.id, event.piece)],
+  );
+  if (fresh.length === 0) return store;
+
+  const events = { ...store.events };
+  for (const event of fresh) {
+    const record: MilestoneEvent = { id: event.id, earnedAt: now };
+    if (event.piece) record.piece = event.piece;
+    events[milestoneKey(event.id, event.piece)] = record;
+  }
+  return { ...store, events };
+}
+
+export function computeMarkCelebrated(
+  store: MilestoneStore,
+  id: MilestoneId,
+  piece: PieceId | undefined,
+  now: string,
+): MilestoneStore {
+  const key = milestoneKey(id, piece);
+  const event = store.events[key];
+  if (!event || event.celebratedAt) return store;
+  return {
+    ...store,
+    events: { ...store.events, [key]: { ...event, celebratedAt: now } },
+  };
+}
+
+/** Only a navigable milestone has somewhere to go. Writing `openedAt` on a
+ *  recognition would invent a state with no meaning, so it is refused. */
+export function computeMarkOpened(
+  store: MilestoneStore,
+  id: MilestoneId,
+  piece: PieceId | undefined,
+  now: string,
+): MilestoneStore {
+  if (!NAVIGABLE_MILESTONES.includes(id)) return store;
+  const key = milestoneKey(id, piece);
+  const event = store.events[key];
+  if (!event || event.openedAt) return store;
+  return {
+    ...store,
+    events: { ...store.events, [key]: { ...event, openedAt: now } },
+  };
+}
+
+/** Earned but never celebrated. This is what the queue drains. */
+export function selectPending(store: MilestoneStore): EarnedMilestone[] {
+  return Object.values(store.events)
+    .filter((event) => !event.celebratedAt)
+    .map((event) => ({ id: event.id, piece: event.piece }));
+}
+
+// ─── localStorage I/O ────────────────────────────────────────────────────
+
+export function getMilestoneStore(): MilestoneStore {
+  if (typeof window === "undefined") return parseMilestoneStore(null);
+  try {
+    return parseMilestoneStore(localStorage.getItem(milestoneStorageKey()));
+  } catch {
+    return parseMilestoneStore(null);
+  }
+}
+
+function persist(store: MilestoneStore): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(milestoneStorageKey(), JSON.stringify(store));
+  } catch {
+    // Quota or privacy mode — the caller still gets the correct state back.
+  }
+}
+
+/** Persists BEFORE anything is rendered. If the app dies mid-overlay the
+ *  event is already on disk, so it neither replays nor gets lost. */
+export function recordEarned(
+  earned: readonly EarnedMilestone[],
+  now: string = new Date().toISOString(),
+): MilestoneStore {
+  const current = getMilestoneStore();
+  const next = computeRecordEarned(current, earned, now);
+  if (next !== current) persist(next);
+  return next;
+}
+
+export function markCelebrated(
+  id: MilestoneId,
+  piece?: PieceId,
+  now: string = new Date().toISOString(),
+): MilestoneStore {
+  const current = getMilestoneStore();
+  const next = computeMarkCelebrated(current, id, piece, now);
+  if (next !== current) persist(next);
+  return next;
+}
+
+export function markOpened(
+  id: MilestoneId,
+  piece?: PieceId,
+  now: string = new Date().toISOString(),
+): MilestoneStore {
+  const current = getMilestoneStore();
+  const next = computeMarkOpened(current, id, piece, now);
+  if (next !== current) persist(next);
+  return next;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/milestone-storage.test.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/milestone-storage.ts apps/web/src/lib/progression/__tests__/milestone-storage.test.ts apps/web/src/lib/lite-progress-storage.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): persist milestones idempotently
+
+An event is written before it is ever rendered, so an app killed mid-overlay
+loses nothing and repeats nothing. openedAt is refused on recognitions.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 6: Migration — seed what the player already passed
+
+**Files:**
+- Create: `apps/web/src/lib/progression/migration.ts`
+- Test: `apps/web/src/lib/progression/__tests__/migration.test.ts`
+
+**Interfaces:**
+- Consumes: `MilestoneStore`, `EMPTY_STORE` (Task 1); `MilestoneInput`, `deriveEarnedMilestones` (Task 3).
+- Produces: `seedExistingPlayer(store, input, welcomeClaimed, welcomeUnlocked, now): MilestoneStore`.
+
+**Why this task exists:** the rule is that **no retroactive celebration fires**. Seeding stamps `celebratedAt` on every milestone an existing player already passed, so the overlay is suppressed while the state is preserved.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { seedExistingPlayer } from "@/lib/progression/migration";
+import { EMPTY_STORE } from "@/lib/progression/types";
+import type { MilestoneInput } from "@/lib/progression/milestones";
+
+const NOW = "2026-07-11T10:00:00.000Z";
+
+function input(overrides: Partial<MilestoneInput> = {}): MilestoneInput {
+  return {
+    piece: "rook",
+    lifetimeStars: 0,
+    completedExercises: 0,
+    pieceStars: 0,
+    pieceCompletedExercises: 0,
+    rookStars: 0,
+    dailyStars: 0,
+    sessionQuotaExhausted: false,
+    badgeClaimed: false,
+    allLabyrinthsComplete: false,
+    hadGreatSessionBefore: false,
+    ...overrides,
+  };
+}
+
+describe("seedExistingPlayer", () => {
+  it("leaves a brand new player untouched", () => {
+    const seeded = seedExistingPlayer(EMPTY_STORE, input(), false, NOW);
+    expect(seeded.events).toEqual({});
+  });
+
+  it("suppresses the overlay for a player already past 12 rook stars", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ rookStars: 12, lifetimeStars: 12, completedExercises: 5 }),
+      true,
+      NOW,
+    );
+    expect(seeded.events["special-training"].celebratedAt).toBe(NOW);
+  });
+
+  it("marks a claimed gift as opened so no NEW dot reappears", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ lifetimeStars: 6, completedExercises: 3 }),
+      true,
+      NOW,
+    );
+    expect(seeded.events["first-reward"].celebratedAt).toBe(NOW);
+    expect(seeded.events["first-reward"].openedAt).toBe(NOW);
+  });
+
+  it("keeps the NEW dot for a gift earned but never claimed", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ lifetimeStars: 6, completedExercises: 3 }),
+      false,
+      NOW,
+    );
+    expect(seeded.events["first-reward"].celebratedAt).toBe(NOW);
+    expect(seeded.events["first-reward"].openedAt).toBeUndefined();
+  });
+
+  it("never seeds a daily milestone — today's session is still up for grabs", () => {
+    const seeded = seedExistingPlayer(
+      EMPTY_STORE,
+      input({ dailyStars: 8 }),
+      false,
+      NOW,
+    );
+    expect(seeded.events["great-focus-session"]).toBeUndefined();
+    expect(seeded.events["first-great-session"]).toBeUndefined();
+  });
+
+  it("is a no-op on a store that was already seeded", () => {
+    const first = seedExistingPlayer(EMPTY_STORE, input({ rookStars: 12 }), true, NOW);
+    const second = seedExistingPlayer(
+      first,
+      input({ rookStars: 12 }),
+      true,
+      "2026-07-12T10:00:00.000Z",
+    );
+    expect(second).toBe(first);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/migration.test.ts`
+Expected: FAIL — cannot resolve `@/lib/progression/migration`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+import { deriveEarnedMilestones, type MilestoneInput } from "./milestones";
+import {
+  milestoneKey,
+  NAVIGABLE_MILESTONES,
+  type MilestoneEvent,
+  type MilestoneId,
+  type MilestoneStore,
+} from "./types";
+
+/** Daily milestones are never seeded: today's session is still live and the
+ *  player deserves the chance to earn it. */
+const NEVER_SEEDED: readonly MilestoneId[] = [
+  "great-focus-session",
+  "first-great-session",
+];
+
+/** Stamps every milestone an existing player already passed as celebrated,
+ *  so upgrading the app never fires a retroactive parade. State preserved,
+ *  overlay suppressed. Idempotent: returns the same reference once seeded. */
+export function seedExistingPlayer(
+  store: MilestoneStore,
+  input: MilestoneInput,
+  welcomeClaimed: boolean,
+  now: string,
+): MilestoneStore {
+  const earned = deriveEarnedMilestones(input).filter(
+    (event) => !NEVER_SEEDED.includes(event.id),
+  );
+  const fresh = earned.filter(
+    (event) => !store.events[milestoneKey(event.id, event.piece)],
+  );
+  if (fresh.length === 0) return store;
+
+  const events = { ...store.events };
+  for (const event of fresh) {
+    const record: MilestoneEvent = {
+      id: event.id,
+      earnedAt: now,
+      celebratedAt: now,
+    };
+    if (event.piece) record.piece = event.piece;
+
+    if (NAVIGABLE_MILESTONES.includes(event.id)) {
+      // The gift is the ONE navigable milestone with a pre-existing claim
+      // state, so it is the only one that can still owe the player a NEW dot.
+      // An unclaimed gift keeps its dot; a claimed gift and every other
+      // milestone the player has already lived through count as opened.
+      const opened = event.id === "first-reward" ? welcomeClaimed : true;
+      if (opened) record.openedAt = now;
+    }
+
+    events[milestoneKey(event.id, event.piece)] = record;
+  }
+  return { ...store, events };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/migration.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/migration.ts apps/web/src/lib/progression/__tests__/migration.test.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): seed milestones an existing player already passed
+
+Upgrading the app must not fire a retroactive parade. Seeding preserves the
+state and suppresses the overlay. Today's session is never seeded — it is
+still up for grabs.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 7: Gather the milestone input from live progress
+
+**Files:**
+- Create: `apps/web/src/lib/progression/gather-input.ts`
+- Test: `apps/web/src/lib/progression/__tests__/gather-input.test.ts`
+
+**Interfaces:**
+- Consumes: `MilestoneInput` (Task 3); `PieceProgress` from `@/lib/game/types`; `DailySessionState` + `isSessionOver` from `@/lib/daily/session-quota`.
+- Produces: `gatherMilestoneInput(args): MilestoneInput`.
+
+**Why a separate module:** the derivation core must stay free of IO. This is the adapter that reads the already-persisted stores and shapes them into `MilestoneInput`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { gatherMilestoneInput } from "@/lib/progression/gather-input";
+import type { PieceProgress } from "@/lib/game/types";
+
+const rook: PieceProgress = {
+  piece: "rook",
+  currentId: null,
+  stars: { "rook-1": 3, "rook-2": 2, "rook-3": 0 },
+};
+
+const bishop: PieceProgress = {
+  piece: "bishop",
+  currentId: null,
+  stars: { "bishop-1": 1 },
+};
+
+describe("gatherMilestoneInput", () => {
+  it("sums lifetime stars across every piece", () => {
+    const input = gatherMilestoneInput({
+      piece: "rook",
+      progressByPiece: { rook, bishop },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false,
+    });
+    expect(input.lifetimeStars).toBe(6);
+  });
+
+  it("counts only exercises solved at least once — a 0-star entry is not completed", () => {
+    const input = gatherMilestoneInput({
+      piece: "rook",
+      progressByPiece: { rook, bishop },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false,
+    });
+    expect(input.completedExercises).toBe(3);
+    expect(input.pieceCompletedExercises).toBe(2);
+  });
+
+  it("scopes piece stars to the piece under play and exposes rook stars separately", () => {
+    const input = gatherMilestoneInput({
+      piece: "bishop",
+      progressByPiece: { rook, bishop },
+      dailyStars: 0,
+      sessionQuotaExhausted: false,
+      badgeClaimed: false,
+      allLabyrinthsComplete: false,
+      hadGreatSessionBefore: false,
+    });
+    expect(input.pieceStars).toBe(1);
+    expect(input.rookStars).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/gather-input.test.ts`
+Expected: FAIL — cannot resolve `@/lib/progression/gather-input`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+import type { PieceId, PieceProgress } from "@/lib/game/types";
+import type { MilestoneInput } from "./milestones";
+
+export type GatherArgs = {
+  piece: PieceId;
+  /** Every piece's persisted progress. Missing pieces read as zero. */
+  progressByPiece: Partial<Record<PieceId, PieceProgress>>;
+  dailyStars: number;
+  sessionQuotaExhausted: boolean;
+  badgeClaimed: boolean;
+  allLabyrinthsComplete: boolean;
+  hadGreatSessionBefore: boolean;
+};
+
+function sumStars(progress: PieceProgress | undefined): number {
+  if (!progress) return 0;
+  return Object.values(progress.stars).reduce((sum, value) => sum + value, 0);
+}
+
+/** An exercise counts as completed once it has been solved at least once.
+ *  A sparse 0 means "played and scored nothing", which is not a completion. */
+function countCompleted(progress: PieceProgress | undefined): number {
+  if (!progress) return 0;
+  return Object.values(progress.stars).filter((value) => value > 0).length;
+}
+
+/** Adapter: reads already-persisted progress and shapes it for the pure core.
+ *  Introduces NO new source of truth for stars. */
+export function gatherMilestoneInput(args: GatherArgs): MilestoneInput {
+  const pieces = Object.values(args.progressByPiece) as PieceProgress[];
+  const current = args.progressByPiece[args.piece];
+
+  return {
+    piece: args.piece,
+    lifetimeStars: pieces.reduce((sum, progress) => sum + sumStars(progress), 0),
+    completedExercises: pieces.reduce(
+      (sum, progress) => sum + countCompleted(progress),
+      0,
+    ),
+    pieceStars: sumStars(current),
+    pieceCompletedExercises: countCompleted(current),
+    rookStars: sumStars(args.progressByPiece.rook),
+    dailyStars: args.dailyStars,
+    sessionQuotaExhausted: args.sessionQuotaExhausted,
+    badgeClaimed: args.badgeClaimed,
+    allLabyrinthsComplete: args.allLabyrinthsComplete,
+    hadGreatSessionBefore: args.hadGreatSessionBefore,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/gather-input.test.ts`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/gather-input.ts apps/web/src/lib/progression/__tests__/gather-input.test.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): adapt persisted progress into milestone input
+
+The derivation core stays free of IO. Stars keep exactly one source of truth.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 8: The celebration queue hook
+
+**Files:**
+- Create: `apps/web/src/lib/progression/use-celebration-queue.ts`
+- Test: `apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx`
+
+**Interfaces:**
+- Consumes: everything from Tasks 3-7.
+- Produces: `useCelebrationQueue(): { current: CelebrationStep | null; resolve(args): void; dismissCurrent(): void; openContent(id, piece?): void; }`
+
+**Contract:** `resolve()` derives, **persists**, then exposes the queue. `dismissCurrent()` stamps `celebratedAt` and advances. The session limit is never consulted here — the caller evaluates it only after `current` is null.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useCelebrationQueue } from "@/lib/progression/use-celebration-queue";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
+import type { GatherArgs } from "@/lib/progression/gather-input";
+
+const solveArgs: GatherArgs = {
+  piece: "rook",
+  progressByPiece: {
+    rook: { piece: "rook", currentId: null, stars: { "rook-1": 2, "rook-2": 2 } },
+  },
+  dailyStars: 4,
+  sessionQuotaExhausted: false,
+  badgeClaimed: false,
+  allLabyrinthsComplete: false,
+  hadGreatSessionBefore: false,
+};
+
+describe("useCelebrationQueue", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists the event BEFORE it exposes the overlay", () => {
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+
+    // On disk already — an app killed right now loses nothing.
+    expect(getMilestoneStore().events["first-reward"]).toBeDefined();
+    expect(result.current.current?.id).toBe("first-reward");
+  });
+
+  it("stamps celebratedAt on dismiss and does not replay the overlay", () => {
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+    act(() => {
+      result.current.dismissCurrent();
+    });
+
+    expect(result.current.current).toBeNull();
+    expect(getMilestoneStore().events["first-reward"].celebratedAt).toBeDefined();
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+    expect(result.current.current).toBeNull();
+  });
+
+  it("clears the NEW dot when the content is opened", () => {
+    const { result } = renderHook(() => useCelebrationQueue());
+
+    act(() => {
+      result.current.resolve(solveArgs);
+    });
+    act(() => {
+      result.current.openContent("first-reward");
+    });
+
+    expect(getMilestoneStore().events["first-reward"].openedAt).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/use-celebration-queue.test.tsx`
+Expected: FAIL — cannot resolve `@/lib/progression/use-celebration-queue`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+"use client";
+
+import { useCallback, useState } from "react";
+import type { PieceId } from "@/lib/game/types";
+import { buildCelebrationQueue, type CelebrationStep } from "./celebration-queue";
+import { gatherMilestoneInput, type GatherArgs } from "./gather-input";
+import { deriveEarnedMilestones } from "./milestones";
+import {
+  getMilestoneStore,
+  markCelebrated,
+  markOpened,
+  recordEarned,
+  selectPending,
+} from "./milestone-storage";
+import type { MilestoneId } from "./types";
+
+export function useCelebrationQueue() {
+  const [queue, setQueue] = useState<CelebrationStep[]>([]);
+
+  /** Evaluate → PERSIST → build → expose. Persistence precedes rendering:
+   *  an overlay is a consequence of having recorded the event, never the
+   *  cause of it. */
+  const resolve = useCallback((args: GatherArgs) => {
+    const input = gatherMilestoneInput(args);
+    const earned = deriveEarnedMilestones(input);
+    const store = recordEarned(earned);
+    setQueue(buildCelebrationQueue(selectPending(store)));
+  }, []);
+
+  const dismissCurrent = useCallback(() => {
+    setQueue((prev) => {
+      const [current, ...rest] = prev;
+      if (!current) return prev;
+      markCelebrated(current.id, current.piece);
+      // An absorbed event is recognized with its closer — it must not be
+      // left pending and resurface as a stray overlay later.
+      for (const id of current.absorbed) {
+        markCelebrated(id, current.piece);
+      }
+      return rest;
+    });
+  }, []);
+
+  /** Releases a recognition that was absorbed by a claim flow the player
+   *  cancelled. Recognition never depends on signing a transaction. */
+  const releaseAbsorbed = useCallback((step: CelebrationStep) => {
+    const store = getMilestoneStore();
+    const pending = selectPending(store).filter((event) =>
+      step.absorbed.includes(event.id),
+    );
+    setQueue(buildCelebrationQueue(pending));
+  }, []);
+
+  const openContent = useCallback((id: MilestoneId, piece?: PieceId) => {
+    markOpened(id, piece);
+  }, []);
+
+  return {
+    current: queue[0] ?? null,
+    resolve,
+    dismissCurrent,
+    releaseAbsorbed,
+    openContent,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/use-celebration-queue.test.tsx`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/progression/use-celebration-queue.ts apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): drain the celebration queue
+
+Evaluate, persist, then render. A cancelled claim releases whatever
+recognition it absorbed, so praise never rides on a signature.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 9: The shared unlock overlay
+
+**Files:**
+- Create: `apps/web/src/components/progression/unlock-overlay.tsx`
+- Modify: `apps/web/src/lib/content/editorial.ts` (add `PROGRESSION_COPY`)
+- Modify: `apps/web/src/lib/content/messages/es.ts` (mirror the keys by hand)
+- Test: `apps/web/src/components/progression/__tests__/unlock-overlay.test.tsx`
+
+**Interfaces:**
+- Consumes: `CelebrationStep` (Task 4).
+- Produces: `<UnlockOverlay step onPrimary onDismiss />`.
+
+**Copy rules:** titles ≤ 5 words, no web3 jargon, no em-dashes. Add to `editorial.ts` and mirror in `messages/es.ts` in the same commit. **Never hand-edit `messages/en.ts`.**
+
+- [ ] **Step 1: Add the copy to `editorial.ts`**
+
+```ts
+export const PROGRESSION_COPY = {
+  "first-reward": {
+    title: "First Reward Earned",
+    body: "Practice pays. Open your gift.",
+    primary: "Open Gift",
+    dismiss: "Later",
+  },
+  "first-labyrinth": {
+    title: "First Maze Unlocked",
+    body: "Guide the rook through it.",
+    primary: "Enter Maze",
+    dismiss: "Later",
+  },
+  "special-training": {
+    title: "Special Training Unlocked",
+    body: "Coordinate the rook and the king.",
+    primary: "Start Training",
+    dismiss: "Later",
+  },
+  "piece-badge-eligible": {
+    title: "Badge Ready to Claim",
+    body: "Ten stars. The badge is yours.",
+    primary: "Claim Badge",
+    dismiss: "Later",
+  },
+  mastery: {
+    title: "Piece Mastered",
+    body: "Every exercise, every maze.",
+    primary: "Continue",
+    dismiss: "Close",
+  },
+  "great-focus-session": {
+    title: "Great Focus Session",
+    body: "A deep session, done.",
+    primary: "Continue",
+    dismiss: "Close",
+  },
+  absorbed: {
+    "great-focus-session": "Great Focus Session recognized.",
+    "first-great-session": "Badge unlocked: First Great Session",
+    "piece-badge-eligible": "Your badge is ready to claim.",
+  },
+} as const;
+```
+
+Mirror the same keys in `apps/web/src/lib/content/messages/es.ts` under `PROGRESSION_COPY`.
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { UnlockOverlay } from "@/components/progression/unlock-overlay";
+
+describe("UnlockOverlay", () => {
+  it("names what was unlocked and offers a way in", () => {
+    render(
+      <UnlockOverlay
+        step={{ id: "special-training", absorbed: [] }}
+        onPrimary={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Special Training Unlocked")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start Training" })).toBeInTheDocument();
+  });
+
+  it("renders an absorbed recognition as a line, never as a second modal", () => {
+    render(
+      <UnlockOverlay
+        step={{
+          id: "mastery",
+          piece: "rook",
+          absorbed: ["great-focus-session", "first-great-session"],
+        }}
+        onPrimary={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Piece Mastered")).toBeInTheDocument();
+    expect(screen.getByText("Great Focus Session recognized.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Badge unlocked: First Great Session"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/progression/__tests__/unlock-overlay.test.tsx`
+Expected: FAIL — cannot resolve `@/components/progression/unlock-overlay`.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+The overlay reuses the existing correct-exercise celebration shell. The earned artifact replaces the wolf as the central icon.
+
+```tsx
+"use client";
+
+import Image from "next/image";
+import { PROGRESSION_COPY } from "@/lib/content/editorial";
+import type { CelebrationStep } from "@/lib/progression/celebration-queue";
+import type { MilestoneId } from "@/lib/progression/types";
+
+const ICONS: Partial<Record<MilestoneId, string>> = {
+  "first-reward": "/art/welcome-package/focus-stamp-day1",
+  "first-labyrinth": "/art/new-icons-chesscito/labyrinth-icon-v1",
+  "special-training": "/art/new-icons-chesscito/training-icon-v1",
+  "piece-badge-eligible": "/art/achievements/1day-focus",
+  mastery: "/art/new-icons-chesscito/training-icon-v1",
+  "great-focus-session": "/art/achievements/1day-focus",
+};
+
+type Props = {
+  step: CelebrationStep;
+  onPrimary: () => void;
+  onDismiss: () => void;
+};
+
+export function UnlockOverlay({ step, onPrimary, onDismiss }: Props) {
+  const copy = PROGRESSION_COPY[step.id as keyof typeof PROGRESSION_COPY];
+  if (!copy || !("title" in copy)) return null;
+  const icon = ICONS[step.id];
+
+  return (
+    <div role="dialog" aria-modal="true" className="progression-overlay">
+      {icon ? (
+        <picture className="progression-overlay-icon">
+          <source srcSet={`${icon}.avif`} type="image/avif" />
+          <source srcSet={`${icon}.webp`} type="image/webp" />
+          <Image src={`${icon}.png`} alt="" width={128} height={128} />
+        </picture>
+      ) : null}
+
+      <h2 className="progression-overlay-title">{copy.title}</h2>
+      <p className="progression-overlay-body">{copy.body}</p>
+
+      {step.absorbed.map((id) => {
+        const line =
+          PROGRESSION_COPY.absorbed[
+            id as keyof typeof PROGRESSION_COPY.absorbed
+          ];
+        return line ? (
+          <p key={id} className="progression-overlay-absorbed">
+            {line}
+          </p>
+        ) : null;
+      })}
+
+      <button type="button" className="cta-primary" onClick={onPrimary}>
+        {copy.primary}
+      </button>
+      <button type="button" className="cta-ghost" onClick={onDismiss}>
+        {copy.dismiss}
+      </button>
+    </div>
+  );
+}
+```
+
+Add the `.progression-overlay*` classes to `apps/web/src/styles/exercises.css` (the overlay is only consumed by the exercises surface). Reuse the existing CTA token families — do not mint a new one.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/progression/__tests__/unlock-overlay.test.tsx`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/components/progression apps/web/src/lib/content/editorial.ts apps/web/src/lib/content/messages/es.ts apps/web/src/styles/exercises.css
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): shared unlock overlay
+
+The earned artifact replaces the wolf as the central icon, and an absorbed
+recognition renders as a line inside the closer rather than a second modal.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 10: Unbundle the gift from the First Focus Day badge
+
+**Files:**
+- Modify: `apps/web/src/components/daily/daily-tactic-slot.tsx:111-116`
+- Modify: `apps/web/src/components/hub/hub-daily-tile.tsx:150-160`
+- Modify: `apps/web/src/lib/welcome-package/use-welcome-package.ts:33-54`
+- Test: `apps/web/src/components/daily/__tests__/daily-tactic-slot-unbundle.test.tsx`
+
+**This is the defect the whole spec exists for.** One `if` currently grants a continuity badge and a reward:
+
+```ts
+if (CHESSCITO_LITE_MODE && prev.totalCompleted === 0) {
+  firstFocusDayJustEarned.current = true;
+  welcomePackage.unlock();   // ← must go
+}
+```
+
+`first-focus-day` stays exactly as it is. Only `welcomePackage.unlock()` moves out — the gift now belongs to `first-reward` in the milestone machine.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { getWelcomePackageState } from "@/lib/welcome-package/storage";
+import { getDailyProgress } from "@/lib/daily/progress";
+
+describe("the gift is no longer bundled with the first Daily Focus", () => {
+  it("does not unlock the gift when the first daily tactic is solved", async () => {
+    localStorage.clear();
+    // Solve the first Daily Focus. Render the slot and complete it — see the
+    // existing daily-tactic-slot tests for the harness this file reuses.
+    await solveFirstDailyFocus();
+
+    expect(getDailyProgress().totalCompleted).toBe(1);
+    expect(getWelcomePackageState().unlocked).toBe(false);
+  });
+});
+```
+
+Reuse the render harness already present in the existing `daily-tactic-slot` test file rather than inventing a new one; `solveFirstDailyFocus()` is a local helper that renders the slot and drives it to `handleSolve`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/daily/__tests__/daily-tactic-slot-unbundle.test.tsx`
+Expected: FAIL — `unlocked` is `true`.
+
+- [ ] **Step 3: Remove the bundling**
+
+In `daily-tactic-slot.tsx`, the block becomes:
+
+```ts
+if (CHESSCITO_LITE_MODE && prev.totalCompleted === 0) {
+  firstFocusDayJustEarned.current = true;
+}
+```
+
+Apply the identical removal in `hub-daily-tile.tsx:155`. Drop the now-unused `useWelcomePackage` import from both files if nothing else consumes it.
+
+In `use-welcome-package.ts`, delete the retroactive init that reads `totalCompleted >= 1` (lines 42-51). The gift's condition now lives in `deriveEarnedMilestones`, and the seeding in Task 6 owns the migration.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/daily`
+Expected: PASS. The existing `first-focus-day` assertions must still pass untouched.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run`
+Expected: PASS. Report the count in the commit message.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/components/daily apps/web/src/components/hub/hub-daily-tile.tsx apps/web/src/lib/welcome-package/use-welcome-package.ts
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "fix(progression): unbundle the gift from the first focus day
+
+One if granted a continuity badge and a reward together, so the gift landed
+before any investment existed to reward. first-focus-day is untouched and
+still fires on the first Daily Focus; the gift now belongs to first-reward.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 11: The labyrinth exercise floor
+
+**Files:**
+- Modify: `apps/web/src/lib/training/path.ts:66-121`
+- Test: `apps/web/src/lib/training/__tests__/path.test.ts` (extend the existing file)
+
+**Interfaces:**
+- Produces: `LABYRINTH_MIN_EXERCISES = 3`; `TrainingPathInput` gains `completedExercises?: number`.
+
+**Why:** without the floor, a perfect player hits 6 stars on exercise 2 and takes the gift and the labyrinth on the same solve. Neither feels earned.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildTrainingPath } from "@/lib/training/path";
+
+describe("the first labyrinth needs an exercise floor, not just stars", () => {
+  it("stays locked at 6 stars across only 2 exercises", () => {
+    const path = buildTrainingPath({
+      piece: "rook",
+      progress: { piece: "rook", currentId: null, stars: { "rook-1": 3, "rook-2": 3 } },
+      labyrinthBests: {},
+      badgeClaimed: false,
+    });
+    const firstLab = path.find((node) => node.kind === "labyrinth");
+    expect(firstLab?.status).toBe("locked");
+  });
+
+  it("unlocks at 6 stars across 3 exercises", () => {
+    const path = buildTrainingPath({
+      piece: "rook",
+      progress: {
+        piece: "rook",
+        currentId: null,
+        stars: { "rook-1": 3, "rook-2": 2, "rook-3": 1 },
+      },
+      labyrinthBests: {},
+      badgeClaimed: false,
+    });
+    const firstLab = path.find((node) => node.kind === "labyrinth");
+    expect(firstLab?.status).toBe("available");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/training/__tests__/path.test.ts`
+Expected: FAIL — the first labyrinth is `available` at 2 exercises.
+
+- [ ] **Step 3: Add the floor**
+
+In `path.ts`, beside `LABYRINTH_UNLOCK_THRESHOLD`:
+
+```ts
+/** Companion floor to LABYRINTH_UNLOCK_THRESHOLD. Stars alone let a perfect
+ *  player unlock the maze on exercise 2, colliding with the first reward.
+ *  The floor keeps the two milestones a solve apart. */
+export const LABYRINTH_MIN_EXERCISES = 3;
+```
+
+Inside `buildTrainingPath`, derive the count from the same sparse map that already feeds `totalStars` and require both:
+
+```ts
+const completedExercises = Object.values(progress.stars).filter(
+  (value) => value > 0,
+).length;
+
+const meetsFirstLabGate =
+  totalStars >= LABYRINTH_UNLOCK_THRESHOLD &&
+  completedExercises >= LABYRINTH_MIN_EXERCISES;
+```
+
+Then replace the `index === 0` unlock check:
+
+```ts
+const unlocked = index === 0 ? meetsFirstLabGate : previousComplete;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/training`
+Expected: PASS. Existing path tests that assumed a star-only gate may need their fixtures widened to 3 exercises — update them, they are asserting the old rule.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/training
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): floor the first labyrinth at 3 exercises
+
+Stars alone let a perfect player take the gift and the maze on the same solve.
+The floor keeps the two milestones a solve apart.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 12: An honest NEW dot on Special Training
+
+**Files:**
+- Modify: `apps/web/src/components/hub/hub-arena-tile.tsx:51-54`
+- Test: `apps/web/src/components/hub/__tests__/hub-arena-tile.test.tsx`
+
+**The defect:** the tile carries a permanently-lit `HubTileStatusChip kind="ready"`. The dot means "this button exists", not "something new is here".
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { HubArenaTile } from "@/components/hub/hub-arena-tile";
+import { markOpened, recordEarned } from "@/lib/progression/milestone-storage";
+import { MINI_ARENA_SETUPS } from "@/lib/game/mini-arena";
+
+const setup = MINI_ARENA_SETUPS[0];
+
+describe("HubArenaTile NEW dot", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows NEW while the unlocked content has never been opened", () => {
+    recordEarned([{ id: "special-training" }]);
+    render(<HubArenaTile setup={setup} unlocked />);
+    expect(screen.getByTestId("hub-tile-new")).toBeInTheDocument();
+  });
+
+  it("drops the dot once the player has opened it", () => {
+    recordEarned([{ id: "special-training" }]);
+    markOpened("special-training");
+    render(<HubArenaTile setup={setup} unlocked />);
+    expect(screen.queryByTestId("hub-tile-new")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/hub/__tests__/hub-arena-tile.test.tsx`
+Expected: FAIL — no `hub-tile-new` testid exists.
+
+- [ ] **Step 3: Drive the chip from `openedAt`**
+
+In `hub-arena-tile.tsx`, replace the static chip:
+
+```tsx
+import { getMilestoneStore, markOpened } from "@/lib/progression/milestone-storage";
+
+// ...inside the component, after `if (!unlocked) return null;`
+const [isNew, setIsNew] = useState(
+  () => getMilestoneStore().events["special-training"]?.openedAt === undefined,
+);
+```
+
+and in `onClick`:
+
+```tsx
+onClick={() => {
+  markOpened("special-training");
+  setIsNew(false);
+  setEverOpened(true);
+  setOpen(true);
+}}
+badge={isNew ? <HubTileStatusChip kind="new" data-testid="hub-tile-new" /> : null}
+```
+
+Add the `new` kind to `HubTileStatusChip` if it does not exist, reusing the existing chip token family. Do not mint a sixth CTA family.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/hub`
+Expected: PASS.
+
+- [ ] **Step 5: Refresh the visual baselines**
+
+The hub rail changed. Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web test:e2e:visual`
+If the Special Training tile diff is expected, update the baselines **in this same commit**. A stale baseline never crosses a PR boundary.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/components/hub apps/web/tests
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): an honest NEW dot on special training
+
+The chip was permanently lit, so it meant 'this button exists' rather than
+'something new is here'. It now clears the first time the player opens it.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 13: Wire the queue into the exercises screen
+
+**Files:**
+- Modify: `apps/web/src/components/exercises/exercises-screen.tsx`
+- Modify: `apps/web/src/components/exercises/exercises-save-flow-logic.ts`
+- Test: `apps/web/src/components/exercises/__tests__/celebration-order.test.tsx`
+
+**Contract (spec, evaluation order):**
+
+```text
+1. Record the activity (stars, bests, consumed slot)
+2. Evaluate every milestone condition
+3. PERSIST every fired event
+4. Build and drain the celebration queue
+5. Render
+6. Return the player to the experience
+7. Only THEN, on the next attempt to start an activity, evaluate the session limit
+```
+
+The session limit must never be consulted while `current` is non-null.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, expect, it } from "vitest";
+
+describe("celebration order on the exercises screen", () => {
+  it("never shows the session limit while a recognition is pending", async () => {
+    // Drive a solve that exhausts the quota at 7 daily stars: the Great Focus
+    // Session must be recognized, and the limit card must not be on screen.
+    await solveExerciseExhaustingQuota({ dailyStarsBefore: 7 });
+
+    expect(screen.getByText("Great Focus Session")).toBeInTheDocument();
+    expect(screen.queryByText("Great focus today.")).not.toBeInTheDocument();
+  });
+
+  it("shows the gift overlay before the maze overlay, never stacked", async () => {
+    await solveExerciseUnlockingGiftAndMaze();
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(screen.getByText("First Reward Earned")).toBeInTheDocument();
+  });
+});
+```
+
+Reuse the render harness in the existing `exercises-screen` test files.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/exercises/__tests__/celebration-order.test.tsx`
+Expected: FAIL — the limit card renders and no unlock overlay exists.
+
+- [ ] **Step 3: Wire it**
+
+In the save flow, after the activity is recorded and the daily star ledger is updated with `netStars`, call `resolve()` with the gathered args, then render `<UnlockOverlay>` while `current` is non-null. Gate the existing daily-limit guard on `current === null`.
+
+```tsx
+const celebration = useCelebrationQueue();
+
+// after recording the solve and adding netStars to the daily ledger:
+celebration.resolve({
+  piece,
+  progressByPiece,
+  dailyStars: getDailyStars(),
+  sessionQuotaExhausted: isSessionOver(getDailySession()),
+  badgeClaimed,
+  allLabyrinthsComplete,
+  hadGreatSessionBefore: hasEverEarned("first-great-session"),
+});
+
+// render:
+{celebration.current ? (
+  <UnlockOverlay
+    step={celebration.current}
+    onPrimary={() => {
+      celebration.openContent(celebration.current!.id, celebration.current!.piece);
+      celebration.dismissCurrent();
+      navigateToContent(celebration.current!.id);
+    }}
+    onDismiss={celebration.dismissCurrent}
+  />
+) : null}
+
+// the limit guard only when nothing is pending:
+{celebration.current === null && isSessionOver(session) ? <DailyLimitGuard /> : null}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/components/exercises`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite and the visual baselines**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run`
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web test:e2e:visual`
+Expected: PASS. Refresh any baseline the new overlay changed, in this commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/components/exercises apps/web/tests
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): the wall never arrives before the praise
+
+The session limit is now evaluated only after every pending recognition has
+drained, so the player who burns the quota while struggling gets the
+celebration rather than the paywall.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 14: The First Great Session achievement
+
+**Files:**
+- Modify: `apps/web/src/lib/achievements/lite.ts`
+- Modify: `apps/web/src/components/trophies/achievements-grid.tsx:21,28`
+- Modify: `apps/web/src/lib/content/editorial.ts` + `messages/es.ts`
+- Test: `apps/web/src/lib/achievements/__tests__/lite.test.ts`
+
+**Interfaces:**
+- Consumes: `getMilestoneStore` (Task 5).
+- Produces: a fourth Lite achievement, `first-great-session`.
+
+`first-focus-day` keeps its id, its condition and its art. Renaming it would force a re-derivation from a counter existing players do not have, silently revoking a badge they already earned.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { deriveLiteAchievements } from "@/lib/achievements/lite";
+
+const progress = { streak: 1, lastCompletedDate: "2026-07-11", totalCompleted: 1 };
+
+describe("first-great-session", () => {
+  it("is unearned before any deep session", () => {
+    const achievements = deriveLiteAchievements(progress, false);
+    const great = achievements.find((a) => a.id === "first-great-session");
+    expect(great?.earned).toBe(false);
+  });
+
+  it("is earned once a great focus session has happened", () => {
+    const achievements = deriveLiteAchievements(progress, true);
+    const great = achievements.find((a) => a.id === "first-great-session");
+    expect(great?.earned).toBe(true);
+  });
+
+  it("leaves first-focus-day exactly as it was", () => {
+    const achievements = deriveLiteAchievements(progress, false);
+    const day = achievements.find((a) => a.id === "first-focus-day");
+    expect(day?.earned).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/achievements/__tests__/lite.test.ts`
+Expected: FAIL — `deriveLiteAchievements` takes one argument.
+
+- [ ] **Step 3: Add the fourth achievement**
+
+```ts
+export function deriveLiteAchievements(
+  progress: DailyProgress,
+  hadGreatSession: boolean,
+): Achievement[] {
+  const { streak, totalCompleted } = progress;
+  const firstDone = totalCompleted >= 1;
+  const rhythmDone = streak >= 3;
+  const weekDone = streak >= 7;
+  return [
+    {
+      id: "first-focus-day",
+      earned: firstDone,
+      progress: firstDone ? undefined : { current: Math.min(totalCompleted, 1), goal: 1 },
+    },
+    {
+      id: "first-great-session",
+      earned: hadGreatSession,
+      progress: hadGreatSession ? undefined : { current: 0, goal: 1 },
+    },
+    {
+      id: "three-day-rhythm",
+      earned: rhythmDone,
+      progress: rhythmDone ? undefined : { current: Math.min(streak, 3), goal: 3 },
+    },
+    {
+      id: "seven-day-focus",
+      earned: weekDone,
+      progress: weekDone ? undefined : { current: Math.min(streak, 7), goal: 7 },
+    },
+  ];
+}
+```
+
+Callers pass `getMilestoneStore().events["first-great-session"] !== undefined`.
+
+Add the grid entries in `achievements-grid.tsx`:
+
+```ts
+"first-great-session": "star",
+// and
+"first-great-session": "/art/achievements/1day-focus",
+```
+
+Reuse an existing achievement asset — do not upscale a low-res sprite, and do not commission new art in this cluster. Add the title and description to `editorial.ts` and mirror them in `messages/es.ts`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/achievements src/components/trophies`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run`
+Expected: PASS. Report the count.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/lib/achievements apps/web/src/components/trophies apps/web/src/lib/content
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): add first-great-session as a fourth achievement
+
+Continuity and depth are two behaviors, so they get two badges.
+first-focus-day keeps its id, condition and art — renaming it would revoke a
+badge players already earned.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+### Task 15: Run the migration once, on hub mount
+
+**Files:**
+- Modify: `apps/web/src/components/hub/legacy-hub-client.tsx`
+- Test: `apps/web/src/lib/progression/__tests__/migration-integration.test.tsx`
+
+**Why here:** `legacy-hub-client` is the one component guaranteed to mount for every returning player. Seeding must run before any surface can derive a milestone, or an existing player gets a parade of retroactive overlays on first launch.
+
+**Careful:** `useShieldSync` mounts here too and only here (`legacy-hub-client.tsx:186`). That single-mount fragility is the exact class of bug that produced the shield credited-cache defect. Seeding is idempotent, so a single mount is safe — but it must not be the *only* writer of anything.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { getMilestoneStore } from "@/lib/progression/milestone-storage";
+
+describe("migration on hub mount", () => {
+  it("seeds a returning player without firing any overlay", async () => {
+    localStorage.clear();
+    seedLegacyProgress({ rookStars: 14, exercisesSolved: 6, giftClaimed: true });
+
+    renderHub();
+
+    const store = getMilestoneStore();
+    expect(store.events["first-reward"].celebratedAt).toBeDefined();
+    expect(store.events["special-training"].celebratedAt).toBeDefined();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression/__tests__/migration-integration.test.tsx`
+Expected: FAIL — the store is empty.
+
+- [ ] **Step 3: Run the seed on mount**
+
+```tsx
+useEffect(() => {
+  const store = getMilestoneStore();
+  const input = gatherMilestoneInput({
+    piece: "rook",
+    progressByPiece,
+    dailyStars: 0,
+    sessionQuotaExhausted: false,
+    badgeClaimed,
+    allLabyrinthsComplete,
+    hadGreatSessionBefore: false,
+  });
+  const welcome = getWelcomePackageState();
+  const seeded = seedExistingPlayer(
+    store,
+    input,
+    welcome.claimed,
+    new Date().toISOString(),
+  );
+  if (seeded !== store) persistMilestoneStore(seeded);
+}, []);
+```
+
+Export `persistMilestoneStore` from `milestone-storage.ts` for this one caller.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run src/lib/progression`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite and the visual baselines**
+
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web exec vitest run`
+Run: `pnpm -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito/apps/web test:e2e:visual`
+Expected: PASS, 51/51 visual.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito add apps/web/src/components/hub/legacy-hub-client.tsx apps/web/src/lib/progression
+git -C /Users/wolfcito/development/BLCKCHN/GOOD_WOLF_LABS/akawolfcito/celo/chesscito commit -m "feat(progression): seed returning players on hub mount
+
+A player who already passed a milestone must not be greeted by a parade of
+retroactive overlays. Seeding is idempotent and stamps them as celebrated.
+
+Wolfcito 🐾 @akawolfcito"
+```
+
+---
+
+## Manual verification
+
+Before opening the PR, drive the real screens — a green suite can verify a dead
+shape, and two green suites in isolation do not prove their composition.
+
+1. `pnpm -C apps/web dev`. Check `env | grep NEXT_PUBLIC` first: an exported flag beats `.env.local`.
+2. Reset via `/dev/reset`. Solve exercise 1 with 3 stars. **No gift.**
+3. Solve exercise 2. **Gift overlay.** Dismiss it. The NEW dot is on the gift.
+4. Solve exercise 3. **Maze overlay**, not stacked with the gift.
+5. Open the gift. The NEW dot clears and does not come back on reload.
+6. Reach 8 daily stars. **Great Focus Session**, with `First Great Session` as a line inside it, not a second modal.
+7. Kill the app mid-overlay. Reopen. The celebration does not replay and the reward is still there.
+8. Reach 10 rook stars, open the claim, **cancel it**. Eligibility survives and any absorbed session is still recognized.
+9. Burn the quota while failing. The **celebration** appears, never the paywall first.
+10. Load a pre-existing profile (12+ rook stars). **No retroactive overlays.**
+
+## Definition of done
+
+- Full suite green. Report the count against the 4875 baseline.
+- `pnpm exec tsc --noEmit` clean.
+- Visual baselines refreshed in the same PR that changed the UI.
+- Every row of the spec's test matrix has a passing test.
+- No new copy in `messages/en.ts` written by hand.
+
+---
+
+Wolfcito 🐾 @akawolfcito


### PR DESCRIPTION
Every reward screen in LEARN already existed. None of them fired at the right moment.

Two defects drove this. One `if` in `daily-tactic-slot.tsx` granted the First Focus Day badge **and** the welcome gift together, so a player who had done nothing but solve a single Daily Focus tactic already carried a pending-gift indicator: the reward landed before any investment existed to reward it. And Special Training, though correctly gated at 12 rook stars, simply materialized behind a permanently-lit "ready" dot that meant "this button exists" rather than "something new is here".

This branch replaces that with one milestone machine.

## The ladder

| Milestone | Condition | Window |
|---|---|---|
| First Reward (gift) | 4★ + at least 2 exercises | cumulative |
| First Labyrinth | 6★ of the piece + at least 3 exercises | cumulative, per piece |
| Piece Badge eligible | 10★ of the piece | cumulative, per piece |
| Special Training | 12★ of rook | cumulative |
| Mastery | badge **claimed** + every labyrinth | cumulative, per piece |
| Great Focus Session | 8 net stars today **or** the quota running out | **daily** |
| First Great Session | the first Great Focus Session | once |

The session limit is deliberately **not** on this ladder. It is a consumption rule, evaluated only after every pending recognition has drained, because the player who struggles, retries, and burns the day's quota must receive the celebration rather than the paywall.

## How it works

Conditions are derived purely from progress that is already persisted; no new source of truth for stars. Only acknowledgement is new state. **Persistence precedes rendering** — an event is written to disk before its overlay appears, so an app killed mid-celebration neither replays nor loses it.

Stars count as **net improvement over the previous best**, so replaying a solved exercise contributes zero and a session measures real progress rather than repetition.

Celebrations drain in two phases. Incremental unlocks come first, each with its own overlay and its own CTA. Then exactly **one** closer renders, highest in the hierarchy `mastery > piece-badge-eligible > great-focus-session`, absorbing every lower major as a line inside itself. Showing `MASTERY!` and then `GREAT FOCUS SESSION!` would drop the intensity right after the climax.

Recognition never depends on signing. A cancelled on-chain badge claim preserves eligibility and releases whatever recognition it had absorbed.

`first-focus-day` keeps its id, its condition and its art. It was never an inaccurate badge, only a badly packaged one. `first-great-session` is a new, fourth achievement: continuity and depth are two behaviors, so they get two badges. Renaming the old one would have silently revoked a badge existing players already earned.

## What the reviews caught that the green suite did not

The suite was green at every step. It still hid all of these:

- The **Great Focus Session celebrated twice** on the ordinary badge moment. `CelebrationStep.absorbed` dropped the piece scope, so dismissing re-attached the closer's piece to a global event, built a key that did not exist, and wrote nothing. The praise then re-fired alone on the next solve.
- The **gift's CTA opened the wrong product** — the server shield pack, not the welcome gift the overlay had just promised.
- A **stale storage snapshot silently un-claimed a claimed gift**, the same bug class as the shield credited-cache (#213). Closed with a change-event bus.
- **Two stacked modals** on every player's badge moment, because a legacy popup and the new overlay each looked correct alone.
- A **false, permanently-stamped Mastery crown** on a piece whose badge was never minted, if the player switched pieces before claiming.

## Migration

No retroactive celebration fires for a milestone a player already passed. Seeding stamps `celebratedAt` on everything a returning player already earned, so the state is preserved while the overlay is suppressed. It runs in the same component that calls `resolve()`, so no path — including a deep link straight to `/exercises` — can bypass it.

## Verification

5003 tests passing across 420 files (baseline before this branch: 4875). Typecheck clean. VR 51/51 with no baseline changes — though note that no VR fixture reaches the new overlays, so that is "nothing existing broke", not "the new UI is covered".

Spec: `docs/specs/2026-07-11-progression-unlocks-celebration-queue.md`
Plan: `docs/specs/2026-07-11-progression-unlocks-implementation-plan.md`

## Accepted trade-offs

- `first-focus-day` and `first-great-session` share the `1day-focus` icon. New art was out of scope; the founder accepted the duplication for now.
- A player connected to an unsupported chain receives no milestone celebrations until they switch back. Nothing is lost — history is seeded and new milestones re-derive on the next solve. The alternative was seeding their profile as badge-less and later firing their real achievements as if new.

Wolfcito 🐾 @akawolfcito
