### PR TITLE
docs(handoff): route the next session at the device pass

### DIFF
--- a/docs/handoffs/2026-07-12-progression-unlocks-celebration-queue-handoff.md
+++ b/docs/handoffs/2026-07-12-progression-unlocks-celebration-queue-handoff.md
@@ -109,12 +109,13 @@ upgrade that can never re-fire after a solve and eat a pending celebration.
 2. **VR coverage gap.** VR is 51/51, but **no fixture reaches the new overlays, the NEW
    chip, or the fourth trophies tile** — the suite runs anonymous with empty storage.
    Green means "nothing existing broke", not "the new UI is covered". Add fixtures.
-3. **`CLAUDE.md` is stale.** It documents a CSS split
-   (`apps/web/src/styles/{arena,hub,coach,exercises}.css`, "P4 CSS split 2026-06-12")
-   that was **reverted** — those files do not exist. It misroutes every new CSS class.
-   Fix during cluster closure.
+3. ~~**`CLAUDE.md` is stale.**~~ **DONE** — PR #216 (`60695ab3`). It routed every new CSS
+   class to `apps/web/src/styles/{arena,hub,coach,exercises}.css`, a split that was
+   reverted; that directory does not exist and `globals.css` is the only stylesheet.
+   Also corrected: all six pieces are playable (`PLAYABLE_PIECES`), not just the rook,
+   and the test baseline (1727 → 5003 / 420).
 4. Cluster closure protocol: close issues/milestone, README "What's live" sync,
-   MEMORY.md sync, branch hygiene.
+   branch hygiene. (MEMORY.md synced; branches deleted.)
 
 ## Open questions
 

--- a/docs/handoffs/_next-session-prompt.md
+++ b/docs/handoffs/_next-session-prompt.md
@@ -1,19 +1,22 @@
-# Next session prompt — post 2026-07-11 season-pass celebration
+# Next session prompt — post 2026-07-12 milestone machine
 
 Di **"continuemos"** y el agente debe leer este archivo y seguirlo.
 
 ---
 
-**Estado al arrancar:** `main` = `9672302d`. Suite **4865 passing / 401 test files**.
-`tsc` limpio, VR **51/51**. Smoke de MiniPay **cerrado en device (17/17)**, checkpoint firmado.
+**Estado al arrancar:** `main` = `60695ab3`. Suite **5003 passing / 420 test files**.
+`tsc` limpio, VR **51/51**. Smoke de MiniPay cerrado en device (17/17) — pero **el cluster
+de progression NO ha sido ejercitado en device todavía** (ver punto 1).
 
 **Leer primero:**
-- `docs/handoffs/2026-07-11-season-pass-celebration-handoff.md` — la última sesión.
+- `docs/handoffs/2026-07-12-progression-unlocks-celebration-queue-handoff.md` — la última sesión.
 - `docs/backlog/2026-07-10-backlog-index.md` — el backlog vigente, auditado contra el código.
 
-**Ya cerrado (2026-07-11):** el Season Pass ahora tiene pantalla de celebración
-post-compra (PRs #210/#211/#212). Probe vivo en `/dev/season-pass-celebration`
-(`?variant=pending` para el estado de shields no acreditados).
+**Ya cerrado (2026-07-12):** la **máquina de hitos** (PR #214). Las recompensas de LEARN
+ahora disparan cuando se ganan: regalo a 4★ + 2 ejercicios, laberinto a 6★ + 3 ejercicios,
+Great Focus Session a 8★ netas o cuota agotada, un solo modal por vez, y el session limit
+**nunca antes del reconocimiento**. Spec en
+`docs/specs/2026-07-11-progression-unlocks-celebration-queue.md`.
 
 **Modo:** pulido sobre lo que ya existe. Un solo bloque activo a la vez.
 
@@ -21,30 +24,34 @@ post-compra (PRs #210/#211/#212). Probe vivo en `/dev/season-pass-celebration`
 
 ## Ruta vigente
 
-1. **▶️ Investigar "Claim 3 Shields"** — el único pendiente con comportamiento *inexplicado*.
-   Nadie sabe a qué sistema pertenece, si duplica los 3 shields de onboarding, ni por qué al
-   tocarlo lanza el 21-Day Mind Challenge. **Investigación, no código. No cambiar lógica
-   hasta entenderlo.**
+1. **▶️ Device pass de MiniPay sobre el cluster de progression.** Es lo único del cluster que
+   **no** está verificado. Hacerlo con **un perfil real de 12★ y badge de torre minteado** —
+   el del founder — porque esa es exactamente la forma que expuso la carrera de seeding
+   (`useAccount().status` vs una lectura de contrato deshabilitada). Caminos a recorrer:
+   ganar el regalo (4★/2 ejercicios), desbloquear el laberinto, llegar a la Great Focus
+   Session, reclamar el badge, y **cancelar** un claim para confirmar que el reconocimiento
+   sobrevive. Ningún jugador real ha visto esta máquina todavía.
 
-2. **Decoder de custom errors** — `docs/backlog/2026-07-10-custom-errors-decoder.md`.
-   GO, **no bloquea estabilidad**. Mejora la copy, no la corrección. El extractor está
-   escrito; falta el generador de error-ABIs desde `artifacts/` y el mapa nombre → copy.
+2. **Hueco de VR.** VR está 51/51 **pero ningún fixture llega a los overlays nuevos, al chip
+   NEW del hub, ni al cuarto tile de trofeos** — la suite corre anónima con storage vacío.
+   Verde significa "no rompí lo viejo", **no** "lo nuevo está cubierto". Agregar fixtures.
 
-3. **PLAY #8 — quitar la confirmación redundante de LUZ.** Borra una pantalla intermedia.
+3. **Investigar "Claim 3 Shields"** — sigue abierto. El único pendiente con comportamiento
+   *inexplicado*. **Investigación, no código.**
 
-Después de eso: **Belt System vs server-verified progress**, que es decisión de producto.
+4. **Decoder de custom errors** — `docs/backlog/2026-07-10-custom-errors-decoder.md`. GO,
+   no bloquea estabilidad.
 
 ---
 
 ## Antes de correr cualquier cosa
 
-- **`env | grep NEXT_PUBLIC` debe salir vacío.** Confirmado sucio el 2026-07-10: el shell
-  exporta `NEXT_PUBLIC_CHAIN_ID=11142220` y **le gana a `.env.local`**, apuntando el dev
-  server a Sepolia sin avisar. Para correr limpio sin tocar el shell:
+- **`env | grep NEXT_PUBLIC` debe salir vacío.** **Confirmado sucio otra vez el 2026-07-12**:
+  el shell exporta `NEXT_PUBLIC_CHAIN_ID=11142220` y **le gana a `.env.local`**, apuntando a
+  Sepolia sin avisar. Para correr limpio sin tocar el shell:
   `env -u NEXT_PUBLIC_CHAIN_ID -u NEXT_PUBLIC_BADGES_ADDRESS -u NEXT_PUBLIC_SCOREBOARD_ADDRESS pnpm -C apps/web <cmd>`
 - **`lsof -ti:3000` debe salir vacío** antes de VR o E2E.
-- El **play hub** solo se monta con `NEXT_PUBLIC_CHESSCITO_MODE=play` (flag de build). El
-  switch de modo en la UI **no** lo alcanza.
+- El **play hub** solo se monta con `NEXT_PUBLIC_CHESSCITO_MODE=play` (flag de build).
 
 ## Higiene de comandos (evita prompts de permiso)
 
@@ -55,37 +62,41 @@ Después de eso: **Belt System vs server-verified progress**, que es decisión d
 
 ## Reglas que estas sesiones ganaron a golpes
 
-- **Un tipo redeclarado con el mismo nombre desarma al compilador.** `arena-end-state.tsx`
-  tenía su propio `ClaimPhase`; borrar un miembro en el hook dio `tsc` verde con la variante
-  muerta todavía alcanzable. Importá el tipo de quien lo posee; `grep` el nombre del miembro.
-- **Un flujo opcional no puede tener estado terminal de cancelación.** Si se puede hacer
-  después, cancelar es un no-op.
-- **Una matriz de smoke se escribe por caminos que piden firma, no por pantallas.** El
-  dead-end de victory vivía en el único camino de firma sin fila.
-- **Verificá pixeles antes de llamar trivial a un cambio de arte.**
+- **Contar `role="dialog"` en un test deja pasar modales apilados.** `LabyrinthCompleteOverlay`
+  usa `role="alert"`. Contar **`[aria-modal="true"]`**. Esto escondió dos diálogos apilados en
+  el momento del badge de TODOS los jugadores, con la suite verde.
+- **Dos suites aisladas verdes no prueban su composición.** Confirmado a lo grande en #214: con
+  4900+ tests en verde se escondían celebración doble, un CTA al producto equivocado, un regalo
+  des-reclamándose solo, y una corona de maestría sobre una pieza jamás minteada. Cada
+  componente era correcto **solo**.
+- **Un componente que cachea storage al montar se pudre.** Pasó con los shields (#213) y otra
+  vez con el welcome-package (#214). Si algo nuevo escribe un storage compartido, **todo lector
+  necesita un event bus** — escribir y NO notificar es un no-op disfrazado de fix.
+- **Persistir ANTES de renderizar.** Mostrar una celebración es consecuencia de haberla
+  registrado, nunca al revés.
+- **Un test que pasa por el motivo equivocado no es un guard.** Un mock de `useAccount` sin
+  `status` hacía que un gate nuevo nunca se evaluara; el test pasaba por otra razón.
+- **Una constante duplicada en dos sistemas que deben coincidir es un bug en espera.**
+- **Un flujo opcional no puede tener estado terminal de cancelación.** Cancelar es un no-op.
 - **El entorno miente antes que el código.** Rojo masivo → sospechar del entorno.
-- **Dos suites aisladas verdes no prueban su composición.**
-- **Una suite verde puede estar cubriendo nada.** La rama de éxito del Season Pass tenía
-  **cero tests**: cambiarle la forma entera no rompió un solo caso. Antes de confiar en el
-  verde, `grep` el `data-testid` de lo que vas a tocar.
-- **Un `/dev` probe existe para validar la pantalla real, no para ser una segunda.** Monta los
-  mismos componentes; fakeá solo las *entradas*. Su valor está en los estados que no podés
-  provocar a mano — ahí apareció el stat row roto. Gate en `VERCEL_ENV`, **no** `NODE_ENV`
-  (los builds de preview son `NODE_ENV=production`).
-- **La VR no protege la tipografía.** Los fixtures viven bajo `/dev`, que es su propio root
-  layout y nunca carga Rowdies/Fredoka: los 51 baselines están en fuente de sistema.
-  **Decisión del founder (2026-07-11): dejarlo así, NO regenerar baselines por esto.**
+- **La VR no protege la tipografía.** Los fixtures viven bajo `/dev` y nunca cargan
+  Rowdies/Fredoka. **Decisión del founder (2026-07-11): dejarlo así.**
 
 ## Qué NO tocar todavía
 
-- **No abrir el Belt System** hasta que cierren MiniPay/slides. Único item con reloj:
-  `BADGE_THRESHOLD` → proporción, mientras haya exactamente un badge minteado.
+- **No abrir el Belt System** hasta que cierren MiniPay/slides.
 - **Nunca construir recovery para el Daily-Streak.** El shield protege el COMBO.
 - **No implementar server-verified progress con umbral proporcional evaluado en vivo** — des-
   califica retroactivamente. Bit monótono `qualified(player, piece)`.
-- **No subir ningún techo a un literal.** Una constante derivada de contenido debe ser
-  función del contenido.
 - **No tocar el *Try Again* de `timeout`** sin medir: la tx ya se firmó y transmitió.
+- **No renombrar `first-focus-day`.** Mide constancia y es correcto; `first-great-session` mide
+  profundidad y es un logro aparte. Renombrar revocaría un badge ya ganado.
+
+## Trade-offs aceptados (no re-litigar sin el founder)
+
+- `first-focus-day` y `first-great-session` **comparten el icono** `1day-focus`. Aceptado hasta
+  encargar arte.
+- En **cadena no soportada** no hay celebraciones hasta volver a la correcta. Nada se pierde.
 
 ## Si el usuario dice…
 


### PR DESCRIPTION
The milestone machine (#214) is merged and green, but **no real player has seen it**. The next-session route now opens on a MiniPay device pass with a 12-star minted-badge profile — the exact shape that exposed the seeding race — rather than on new work.

Also records two things worth inheriting:

- VR is 51/51 while **no fixture reaches the new overlays, the NEW chip, or the fourth trophies tile**. That green means "nothing old broke", not "the new UI is covered".
- The shell exports a `NEXT_PUBLIC_*` chain override that silently wins over the local config and points dev at the wrong network. Second time it has bitten us; the workaround is in the file.

Closes the CLAUDE.md item (#216).

Wolfcito 🐾 @akawolfcito
