### PR TITLE
refactor(hub): rename LegacyHubClient to LearnHubClient + MiniPay device pass doc

### DIFF
--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -1060,7 +1060,7 @@ export function ExercisesScreen({
   }, [labyrinthCatalog]);
 
   useMilestoneSeeding({
-    // ONE gate, shared with the hub (`legacy-hub-client.tsx`) — see
+    // ONE gate, shared with the hub (`learn-hub-client.tsx`) — see
     // `isMilestoneSeedReady` for why a disabled read is not "no badges" and
     // why an unsupported chain never becomes ready. `resolveMilestones`
     // carries the other half of that contract: it refuses to run while the

--- a/apps/web/src/components/hub/hub-scaffold-client.tsx
+++ b/apps/web/src/components/hub/hub-scaffold-client.tsx
@@ -2,19 +2,19 @@
 
 import { CHESSCITO_MODE } from "@/lib/feature-flags";
 import {
-  LegacyHubClient,
+  LearnHubClient,
   type HubScaffoldClientProps,
-} from "@/components/hub/legacy-hub-client";
+} from "@/components/hub/learn-hub-client";
 import { PlayHubClient } from "@/components/hub/play-hub-client";
 
-export type { HubInitialSheet } from "@/components/hub/legacy-hub-client";
+export type { HubInitialSheet } from "@/components/hub/learn-hub-client";
 
-/** Hook-free deployment dispatcher. Play never mounts the legacy client, so
+/** Hook-free deployment dispatcher. Play never mounts the LEARN client, so
  * `useHubData` and all Training progress hooks remain outside its React tree. */
 export function HubScaffoldClient(props: HubScaffoldClientProps) {
   return CHESSCITO_MODE === "play" ? (
     <PlayHubClient {...props} />
   ) : (
-    <LegacyHubClient {...props} />
+    <LearnHubClient {...props} />
   );
 }

--- a/apps/web/src/components/hub/learn-hub-client.tsx
+++ b/apps/web/src/components/hub/learn-hub-client.tsx
@@ -99,7 +99,11 @@ function deriveProShape(
   return { active: true, daysRemaining: days };
 }
 
-/** Client-side container that hydrates `<HubScaffold>` with real data:
+/** The LEARN hub, mounted at `/` whenever `CHESSCITO_MODE !== "play"`.
+ *  (Was `LegacyHubClient`: the name predated the LEARN/PLAY split and read
+ *  as a dead surface. PLAY's hub is `PlayHubClient`.)
+ *
+ *  Client-side container that hydrates `<HubScaffold>` with real data:
  *  - Trophies: count of claimed badges (Badges contract, batched read).
  *  - PRO chip: `useProStatus(address)` shape + days-remaining math.
  *  - Reward tiles: `deriveRewardTiles({ badgesClaimed, starsPerPiece })`.
@@ -109,7 +113,7 @@ function deriveProShape(
  *
  *  Pure presentational composition — no on-chain mutations belong here.
  *  Those stay on `<ExercisesScreen>` until the scaffold becomes the default. */
-export function LegacyHubClient({
+export function LearnHubClient({
   initialSheet,
 }: HubScaffoldClientProps) {
   const tHud = useTranslations("HUD_COPY");

--- a/apps/web/src/lib/progression/__tests__/migration-integration.test.tsx
+++ b/apps/web/src/lib/progression/__tests__/migration-integration.test.tsx
@@ -73,7 +73,7 @@ class NoopIntersectionObserver {
 vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
 
 const { ExercisesScreen } = await import("@/components/exercises/exercises-screen");
-const { LegacyHubClient } = await import("@/components/hub/legacy-hub-client");
+const { LearnHubClient } = await import("@/components/hub/learn-hub-client");
 
 /** Five trivial one-move rook slides — every solve is a clean 3★. */
 const ROOK_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
@@ -106,7 +106,7 @@ function renderExercises() {
 }
 
 function renderHub() {
-  return renderWithAppProviders(<LegacyHubClient />);
+  return renderWithAppProviders(<LearnHubClient />);
 }
 
 /** Every celebration overlay is a `VictoryPopupShell` with `aria-modal="true"`.

--- a/apps/web/src/lib/progression/__tests__/use-milestone-seeding.test.ts
+++ b/apps/web/src/lib/progression/__tests__/use-milestone-seeding.test.ts
@@ -8,7 +8,7 @@ import { isMilestoneSeedReady } from "../use-milestone-seeding";
  *
  * The gate shipped bare in the previous fix: the expression lived inline in two
  * components, so nothing could go red if one of them drifted. It is a pure
- * function now, used by BOTH `exercises-screen.tsx` and `legacy-hub-client.tsx`.
+ * function now, used by BOTH `exercises-screen.tsx` and `learn-hub-client.tsx`.
  */
 describe("isMilestoneSeedReady", () => {
   it("waits while wagmi is connecting — the badge read is DISABLED, not empty", () => {

--- a/docs/testing/2026-07-12-minipay-progression-device-pass.md
+++ b/docs/testing/2026-07-12-minipay-progression-device-pass.md
@@ -1,0 +1,102 @@
+# Device pass — máquina de hitos en MiniPay (perfil del founder)
+
+**Fecha**: 2026-07-12 · **Estado**: pendiente de correr
+**Build bajo prueba**: `main` ≥ `#214` (`9cfc24db`) · `learn-preview.chesscito.com` · Celo Mainnet
+**Cuenta**: la del founder — **12★ de torre, badge de torre ya minteado**
+
+> Por qué esta cuenta y no una limpia: esa forma exacta (progreso alto + badge on-chain)
+> es la que expuso la carrera de seeding (`useAccount().status` contra una lectura de
+> contrato deshabilitada). Una wallet limpia **no** reproduce el riesgo principal.
+
+---
+
+## Superficies — todo el pase es LEARN
+
+El build de LEARN tiene **dos pantallas** en juego, y es fácil buscar en la equivocada:
+
+- **HUB de LEARN = `/`** (la raíz, no `/hub`: esa es un alias legacy que redirige a `/`).
+  Ahí vive la tile de **Special Training** y su chip NEW. Lo monta
+  `hub-scaffold-client.tsx:15` cuando el modo no es `play` (`LearnHubClient`; se llamaba
+  `LegacyHubClient` y ese nombre hacía pensar en un hub muerto que no existe).
+- **`/exercises`** — la escalera de estrellas, el laberinto, el badge y las celebraciones.
+  El *Daily Tactic* que ves acá **no** es Special Training.
+
+PLAY/Arena queda **fuera** de este pase.
+
+## Antes de empezar
+
+- Saldo chico de un stable (sin CELO no hay gas — la app pasa `feeCurrency`).
+- Anotar: modelo, versión de MiniPay, commit del deploy.
+- **No borrar el storage.** El valor del pase está en el perfil viejo.
+- Tener a mano una **pieza virgen** (caballo o alfil, sin estrellas): es el único
+  camino para ver la escalera dispararse en vivo.
+
+---
+
+## Bloque A — Lo negativo (arranque en frío), el corazón del pase
+
+Tu perfil ya pasó `first-reward`, `first-labyrinth:rook`, `special-training`,
+`piece-badge-eligible:rook` y `piece-badge-claimed:rook`. El seeding debe marcarlos como
+históricos y **no celebrar nada**. Cualquier ✅ acá es una regresión.
+
+| # | Paso | Esperado |
+| --- | --- | --- |
+| A1 | Abrir la app en MiniPay, en frío, y esperar a que la wallet conecte | **Cero overlays.** Ni regalo, ni laberinto, ni Special Training, ni badge |
+| A2 | En **`/`** (HUB de LEARN), mirar la tile de **Special Training** en el action rail | La tile **está visible** (tenés 12★ de torre) y **sin punto NEW**. Las dos mitades importan: bajo 12★ la tile no existe (`hub-arena-tile.tsx:78`), y el seeding te la marca como ya abierta (`migration.ts:48`). **Sin NEW es un pass, no un fallo** |
+| A2b | ¿La tile NO aparece? | **Eso sí es hallazgo** — tenés el umbral cumplido. Anotarlo con screenshot |
+| A3 | Matar la app y reabrirla 2–3 veces seguidas | Ninguna celebración aparece en ningún reintento |
+| A4 | Abrir la app **con la wallet aún desconectando** y quedarse en el HUB | No se estampa la corona de Mastery ni un `piece-badge-claimed` falso. Ese es el race |
+| A5 | Grid de trofeos | El badge de torre figura como poseído; ningún trofeo nuevo aparece "recién ganado" |
+
+---
+
+## Bloque B — La escalera en vivo (pieza virgen: caballo o alfil)
+
+| # | Paso | Esperado |
+| --- | --- | --- |
+| B1 | Resolver ejercicios de la pieza virgen hasta **6★ + 3 ejercicios** | Overlay de **desbloqueo del laberinto**, con punto NEW en el drawer |
+| B2 | Abrir el laberinto desde ese overlay | El NEW se apaga al abrir (no antes) |
+| B3 | Seguir hasta **10★ de esa pieza** | Overlay de **badge disponible** — y **UN SOLO** diálogo en pantalla, no dos apilados |
+| B4 | Reclamar el badge y esperar el receipt | Háptica, celebración, badge en Owned. Nada celebra sobre el hash |
+| B5 | **Cancelar** un claim (rechazar en la wallet) | Vuelve a idle, sin celebración, **y el reconocimiento sobrevive**: el overlay de "badge disponible" sigue reclamable |
+
+> El regalo (`first-reward`) **no se puede ver en tu cuenta**: es global y ya lo pasaste.
+> Sólo aparece en wallet/storage limpios, y sólo en build **Lite** (`giftAvailable`).
+
+---
+
+## Bloque C — Lo diario (sí se puede probar en tu cuenta; resetea a UTC midnight)
+
+| # | Paso | Esperado |
+| --- | --- | --- |
+| C1 | Ganar **8★ netas hoy** (mejoras reales; repetir un ejercicio ya perfecto no suma) | Overlay **Great Focus Session** |
+| C2 | Alternativa: agotar la cuota de sesión (10) sin llegar a 8★ | Igual celebra — y **la celebración va antes del límite de sesión**, nunca al revés |
+| C3 | Agotar la cuota estando ya celebrado | El paywall/límite recién aparece después de drenar la cola |
+| C4 | Si te toca `first-great-session` | Aparece **una vez**, y comparte icono con `first-focus-day` (aceptado, no es bug) |
+
+---
+
+## Bloque D — Cola y persistencia
+
+| # | Paso | Esperado |
+| --- | --- | --- |
+| D1 | Provocar dos hitos juntos (ej. llegar a 10★ y a 8★ diarias en el mismo solve) | **Un modal por vez**, en orden. Nunca dos `aria-modal` a la vez |
+| D2 | Cerrar la app **con un overlay abierto** y reabrir | El hito ya quedó persistido: no se re-celebra, y tampoco se pierde el acceso |
+| D3 | Cerrar la app durante `confirming` de un claim y reabrir | El badge se auto-cura leyendo la cadena. Sin celebración fantasma |
+| D4 | Cambiar a una **cadena no soportada** y volver | Sin celebraciones mientras estás en la cadena mala; al volver, nada se perdió |
+
+---
+
+## Cómo reportar
+
+Por fila: ✅ / 🔴 + screenshot si es 🔴. Un 🔴 en el **Bloque A** es bloqueante y frena el
+pase: significa que la máquina le está mintiendo a un jugador con historia. Un 🔴 en B/C/D
+se anota y se evalúa contra el criterio de siempre: **¿impide completar el flujo o corrompe
+progreso, pagos o estado?** Si no, se difiere.
+
+## Riesgos ya conocidos (no los reportes como nuevos)
+
+- `first-focus-day` y `first-great-session` comparten icono. Aceptado.
+- En `timeout` el CTA sigue ofreciendo *Try Again* aunque la tx ya se firmó. No tocar sin medir.
+- `first-great-session` y `piece-badge-claimed` pueden quedar "pending" para siempre en el
+  store. Benigno hoy: el grid lee presencia, no `celebratedAt`.


### PR DESCRIPTION
## Why

Auditing where the Special Training NEW chip lives cost a review cycle because the LEARN hub is called `LegacyHubClient`. There is no legacy hub: `hub-scaffold-client.tsx` dispatches to exactly two clients, PLAY and LEARN. The name described a surface that does not exist.

The `/hub` **route** is genuinely legacy (it redirects to `/`) and keeps its name.

## What

1. `LegacyHubClient` → `LearnHubClient` (`legacy-hub-client.tsx` → `learn-hub-client.tsx`), plus the four call sites and comments that cited the old name.
2. `docs/testing/2026-07-12-minipay-progression-device-pass.md` — the device pass for the milestone machine (#214), which has never been exercised on device.

## The point of the device pass

The founder's profile (12★ rook, minted badge) has already passed half the ladder, so seeding suppresses those celebrations. Most of the pass is therefore a **negative test**: a veteran must see no retroactive parade on cold open. That is the exact shape that exposed the seeding race (`useAccount().status` vs a disabled contract read) — a clean wallet cannot reproduce it.

It also records where the surfaces are: Special Training and its NEW chip are on the LEARN hub at `/`, not `/exercises`. A veteran seeing **no** NEW dot is a pass, not a failure (`migration.ts:48` seeds `openedAt`).

## Verification

- Suite: **5003 passing / 420 files** (baseline unchanged).
- `tsc --noEmit` clean.
- No behavior change: pure rename + docs.

Wolfcito 🐾 @akawolfcito