### PR TITLE
fix(progression): open Special Training in place, not on a hub with no tile

### DIFF
--- a/apps/web/src/components/exercises/__tests__/special-training-cta.test.tsx
+++ b/apps/web/src/components/exercises/__tests__/special-training-cta.test.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+
+import { renderWithAppProviders } from "@/test-utils/render-with-app-providers";
+import { ContentCatalogProvider } from "@/lib/content/catalog-context";
+import { EXERCISES, LABYRINTHS } from "@/lib/game/exercises";
+import { GENERATED_EXERCISE_DESCRIPTIONS } from "@/lib/game/generated/puzzles.generated";
+import {
+  milestoneStorageKey,
+  pieceProgressStorageKey,
+} from "@/lib/lite-progress-storage";
+import { markMilestonesSeeded } from "@/lib/progression/seed-milestones";
+import type { Exercise } from "@/lib/game/types";
+
+/**
+ * The Special Training celebration must open the door it just promised.
+ *
+ * It used to `router.push("/hub")`, aiming at `HubArenaTile` — a tile that only
+ * mounts inside the FULL `HubScaffold`. FULL is internal-only: the builds that
+ * ship are LEARN (lite) and PLAY, and LEARN's hub renders `HubLiteScaffold`,
+ * which has no such tile. So the overlay handed the player a CTA and dropped
+ * them on a hub with no door. Found on device (2026-07-12), with the suite green
+ * — the hub tile and the overlay were each correct alone.
+ *
+ * The door that actually ships is `MiniArenaBridgeSlot`, in the exercises
+ * action row. This pins the CTA to it.
+ *
+ * Harness mirrors `celebration-order.test.tsx`.
+ */
+
+vi.mock("@/lib/feature-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/feature-flags")>();
+  return {
+    ...actual,
+    CHESSCITO_MODE: "learn" as const,
+    CHESSCITO_LITE_MODE: true,
+    isLearnMode: () => true,
+    isPlayMode: () => false,
+    isFullMode: () => false,
+  };
+});
+
+const pushMock = vi.fn();
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    back: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+  usePathname: () => "/exercises",
+  redirect: (path: string) => path,
+  getPathname: ({ href }: { href: string }) => href,
+}));
+
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+  root = null;
+  rootMargin = "";
+  thresholds: number[] = [];
+}
+vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+
+const { ExercisesScreen } = await import("../exercises-screen");
+
+/** Five trivial one-move rook slides — every solve is a clean 3★. */
+const ROOK_POOL: Exercise[] = [1, 2, 3, 4, 5].map((n) => ({
+  id: `t-rook-${n}`,
+  startPos: { file: 0, rank: n - 1 },
+  targetPos: { file: 7, rank: n - 1 },
+  optimalMoves: 1,
+}));
+
+function renderScreen() {
+  return renderWithAppProviders(
+    <ContentCatalogProvider
+      value={{
+        exercises: { ...EXERCISES, rook: ROOK_POOL },
+        labyrinths: { ...LABYRINTHS, rook: [] },
+        descriptions: GENERATED_EXERCISE_DESCRIPTIONS,
+      }}
+    >
+      <ExercisesScreen />
+    </ContentCatalogProvider>,
+  );
+}
+
+function solve(exercise: Exercise) {
+  const from = `Square ${String.fromCharCode(97 + exercise.startPos.file)}${exercise.startPos.rank + 1}`;
+  const to = `Square ${String.fromCharCode(97 + exercise.targetPos.file)}${exercise.targetPos.rank + 1}`;
+  fireEvent.click(screen.getByRole("gridcell", { name: from }));
+  fireEvent.click(screen.getByRole("gridcell", { name: to }));
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Already earned AND already celebrated, so they neither re-fire nor crowd the
+ *  queue — leaving Special Training as the only recognition under test. */
+function seedCelebrated(...keys: string[]) {
+  const now = new Date().toISOString();
+  const events: Record<string, unknown> = {};
+  for (const key of keys) {
+    const [id, piece] = key.split(":");
+    events[key] = piece
+      ? { id, piece, earnedAt: now, celebratedAt: now }
+      : { id, earnedAt: now, celebratedAt: now };
+  }
+  localStorage.setItem(
+    milestoneStorageKey(),
+    JSON.stringify({ version: 1, events, dailyDate: today() }),
+  );
+}
+
+describe("Special Training celebration — the CTA opens the door it promised", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    pushMock.mockClear();
+    // Nine rook stars banked across three solves; the fourth lands on 12 —
+    // SPECIAL_TRAINING_ROOK_STARS — and fires the milestone.
+    localStorage.setItem(
+      pieceProgressStorageKey("rook"),
+      JSON.stringify({
+        piece: "rook",
+        currentId: "t-rook-4",
+        stars: { "t-rook-1": 3, "t-rook-2": 3, "t-rook-3": 3 },
+      }),
+    );
+    // Everything the player already passed on the way to 12★, so the queue
+    // holds exactly one step.
+    seedCelebrated(
+      "first-reward",
+      "first-labyrinth:rook",
+      "piece-badge-eligible:rook",
+    );
+    markMilestonesSeeded();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens the mini-arena sheet in place instead of navigating to a hub with no tile", async () => {
+    renderScreen();
+
+    solve(ROOK_POOL[3]);
+
+    const cta = await screen.findByRole("button", { name: "Start Training" });
+    fireEvent.click(cta);
+
+    // The promised content, right here.
+    await waitFor(() => {
+      expect(screen.getByTestId("mini-arena-sheet")).toBeInTheDocument();
+    });
+
+    // And NOT a trip to the hub. `/hub` redirects to `/`, where the LEARN hub
+    // renders no Special Training tile at all — the dead end this test pins.
+    expect(pushMock).not.toHaveBeenCalledWith("/hub");
+  });
+});

--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -338,6 +338,10 @@ export function ExercisesScreen({
   const { writeContractAsync: writeBadgeAsync } = useWriteContract();
   const { writeContractAsync: writeShopAsync, isPending: isShopWriting } = useWriteContract();
   const [selectedPiece, setSelectedPiece] = useState<PieceKey>(initialPiece);
+  // Lets the Special Training celebration open the bridge sheet directly. The
+  // pedestal still manages itself on a normal tap; this only adds an outside
+  // opener. See `handleMilestoneNavigate`.
+  const [miniArenaOpen, setMiniArenaOpen] = useState(false);
   const [phase, setPhase] = useState<"ready" | "success" | "failure">("ready");
   const [boardKey, setBoardKey] = useState(0);
   const [moves, setMoves] = useState(0);
@@ -1894,8 +1898,19 @@ export function ExercisesScreen({
     }
 
     if (step.id === "special-training") {
-      // The Special Training tile lives on the hub right-rail.
-      router.push("/hub");
+      // Open the bridge sheet HERE. The old `router.push("/hub")` aimed at
+      // `HubArenaTile`, which only mounts inside the FULL `HubScaffold` — and
+      // FULL is internal-only. The shipped builds are LEARN (lite) and PLAY,
+      // and LEARN's hub renders `HubLiteScaffold`, which has no such tile. So
+      // the CTA promised Special Training and dropped the player on a hub with
+      // no door. The door that actually ships is `MiniArenaBridgeSlot`, in
+      // this screen's action row.
+      //
+      // The slot is gated on `selectedPiece === "rook"`, and this milestone can
+      // fire while the player is on another piece (it reads `rookStars`), so
+      // select the rook first: the slot mounts on the next render, already open.
+      setSelectedPiece("rook");
+      setMiniArenaOpen(true);
       return;
     }
 
@@ -2683,6 +2698,8 @@ export function ExercisesScreen({
             <MiniArenaBridgeSlot
               setup={MINI_ARENA_SETUPS[0]}
               unlocked={selectedPiece === "rook" && totalStars >= 12}
+              open={miniArenaOpen}
+              onOpenChange={setMiniArenaOpen}
             />
           }
           contextualAction={

--- a/apps/web/src/components/mini-arena/mini-arena-bridge-slot.tsx
+++ b/apps/web/src/components/mini-arena/mini-arena-bridge-slot.tsx
@@ -22,6 +22,12 @@ type Props = {
    *  earn. Surfaces like the Hub right rail use this so the
    *  vertical stack stays visually stable across unlock thresholds. */
   renderLocked?: boolean;
+  /** Controlled open state. Pass BOTH `open` and `onOpenChange` to drive the
+   *  sheet from outside — the Special Training celebration does this, so its
+   *  primary CTA opens the content it just promised instead of navigating.
+   *  Omit both to keep the pedestal self-managed (the default). */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
 
 /**
@@ -29,9 +35,21 @@ type Props = {
  * bridge setup. Lives in the action row next to the contextual action
  * pin so the bridge entry point doesn't push the board down.
  */
-export function MiniArenaBridgeSlot({ setup, unlocked, renderLocked = false }: Props) {
+export function MiniArenaBridgeSlot({
+  setup,
+  unlocked,
+  renderLocked = false,
+  open: controlledOpen,
+  onOpenChange,
+}: Props) {
   const t = useTranslations("HUB_ACTION_RAIL_COPY");
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  };
   // Signal hierarchy (Sally pass 2026-06-11): the dot marks NEW
   // content — unlocked but never beaten. Once beaten the marker clears
   // entirely (no done-check): the bridge is a permanent replayable

--- a/docs/testing/2026-07-12-minipay-progression-device-pass.md
+++ b/docs/testing/2026-07-12-minipay-progression-device-pass.md
@@ -15,13 +15,19 @@
 El build de LEARN tiene **dos pantallas** en juego, y es fácil buscar en la equivocada:
 
 - **HUB de LEARN = `/`** (la raíz, no `/hub`: esa es un alias legacy que redirige a `/`).
-  Ahí vive la tile de **Special Training** y su chip NEW. Lo monta
-  `hub-scaffold-client.tsx:15` cuando el modo no es `play` (`LearnHubClient`; se llamaba
-  `LegacyHubClient` y ese nombre hacía pensar en un hub muerto que no existe).
-- **`/exercises`** — la escalera de estrellas, el laberinto, el badge y las celebraciones.
-  El *Daily Tactic* que ves acá **no** es Special Training.
+  Lo monta `hub-scaffold-client.tsx:15` cuando el modo no es `play` (`LearnHubClient`).
+  En LEARN renderiza `HubLiteScaffold`: Mind Challenge, Focus Passport, Start Focus.
+- **`/exercises`** — la escalera de estrellas, el laberinto, el badge, **Special Training**
+  y todas las celebraciones.
 
 PLAY/Arena queda **fuera** de este pase.
+
+> **Special Training vive en `/exercises`, no en el hub.** Su puerta es el pedestal
+> **TRAINING** del action row (`MiniArenaBridgeSlot`, `exercises-screen.tsx:2683`), abierto
+> con 12★ de torre. La tile del hub (`HubArenaTile`) **solo monta en el scaffold FULL, que
+> es interno** — en LEARN no existe. Buscarla ahí es buscar algo que ese build no tiene.
+> Su punto rojo es un marcador propio ("desbloqueado, nunca ganado"), **distinto** del NEW
+> de la máquina de hitos.
 
 ## Antes de empezar
 
@@ -42,8 +48,8 @@ históricos y **no celebrar nada**. Cualquier ✅ acá es una regresión.
 | # | Paso | Esperado |
 | --- | --- | --- |
 | A1 | Abrir la app en MiniPay, en frío, y esperar a que la wallet conecte | **Cero overlays.** Ni regalo, ni laberinto, ni Special Training, ni badge |
-| A2 | En **`/`** (HUB de LEARN), mirar la tile de **Special Training** en el action rail | La tile **está visible** (tenés 12★ de torre) y **sin punto NEW**. Las dos mitades importan: bajo 12★ la tile no existe (`hub-arena-tile.tsx:78`), y el seeding te la marca como ya abierta (`migration.ts:48`). **Sin NEW es un pass, no un fallo** |
-| A2b | ¿La tile NO aparece? | **Eso sí es hallazgo** — tenés el umbral cumplido. Anotarlo con screenshot |
+| A2 | En **`/exercises`** con la **torre** seleccionada, mirar el pedestal **TRAINING** del action row | Está **presente y abierto** (tenés 12★ de torre). Su punto rojo es el marcador "nunca lo ganaste", no el NEW de la máquina de hitos. **No buscar tile de Special Training en el hub: en LEARN no existe** (vive en el scaffold FULL, que es interno) |
+| A2b | Tocar el pedestal TRAINING | Abre la MiniArenaSheet (K+R vs K) |
 | A3 | Matar la app y reabrirla 2–3 veces seguidas | Ninguna celebración aparece en ningún reintento |
 | A4 | Abrir la app **con la wallet aún desconectando** y quedarse en el HUB | No se estampa la corona de Mastery ni un `piece-badge-claimed` falso. Ese es el race |
 | A5 | Grid de trofeos | El badge de torre figura como poseído; ningún trofeo nuevo aparece "recién ganado" |


### PR DESCRIPTION
## The bug

Found on device during the milestone-machine pass. The Special Training celebration fired, the player tapped **Start Training**, and landed on a hub with no Special Training anywhere.

`exercises-screen.tsx` did `router.push("/hub")`, aiming at `HubArenaTile`. That tile mounts in exactly one place — inside the **FULL** `HubScaffold`. FULL is internal-only: the builds that ship are **LEARN** (lite) and **PLAY**, and LEARN's hub renders `HubLiteScaffold`, which has no such tile. (`/hub` is itself a legacy alias that redirects to `/`.)

So the overlay promised content and delivered a dead end. The suite was green: the hub tile and the overlay were each correct **alone**. Same class as the gift CTA that opened the wrong product in #214.

## The fix

The door that actually ships is `MiniArenaBridgeSlot` — the TRAINING pedestal in the exercises action row. The CTA now opens **that**, in place:

- Selects the rook first. The milestone reads `rookStars`, so it can fire while the player is on another piece, and the slot is gated on `selectedPiece === "rook"`.
- Opens the sheet via a new optional controlled `open`/`onOpenChange` pair on `MiniArenaBridgeSlot`. Omit both and the pedestal stays self-managed, as every existing caller does.

No mode branching: the bridge slot is in `/exercises`, which is shared, so this is correct in LEARN and PLAY alike.

## Verification

- New regression test `special-training-cta.test.tsx`, **verified red against the old CTA** and green with the fix.
- Suite: **5004 passing / 421 files**. `tsc --noEmit` clean.

Wolfcito 🐾 @akawolfcito