### PR TITLE
fix(progression): stop the ghost 'Badge Ready to Claim' overlay

### DIFF
--- a/apps/web/src/components/exercises/exercises-screen.tsx
+++ b/apps/web/src/components/exercises/exercises-screen.tsx
@@ -1834,6 +1834,22 @@ export function ExercisesScreen({
       // the re-resolve below reading from ONE scope.
       const claimedPiece = (step.piece as PieceKey | undefined) ?? selectedPiece;
 
+      // Nothing left to claim: the chain already holds this badge. The
+      // recognition is real but SPENT, so consume it. `handleClaimBadge`
+      // returns a silent `false` here, which the cancellation path below reads
+      // as "the player backed out" — leaving the event pending forever. And
+      // because the queue drains every pending event regardless of the piece on
+      // screen, that one stuck event re-opened this overlay on every solve of
+      // every other piece. Found on device (2026-07-12).
+      if (badgesClaimed[claimedPiece]) {
+        celebration.dismissCurrent();
+        return;
+      }
+
+      // Every OTHER failure — cancelled, reverted, no wallet, wrong chain —
+      // keeps the eligibility pending on purpose: that badge is still owed, so
+      // the recognition must survive to be offered again. Only an owned badge
+      // is spent, and only it is consumed above.
       void handleClaimBadge(claimedPiece)
         .then((claimed) => {
           if (claimed) {

--- a/apps/web/src/lib/progression/__tests__/migration.test.ts
+++ b/apps/web/src/lib/progression/__tests__/migration.test.ts
@@ -106,9 +106,14 @@ describe("seedExistingPlayer", () => {
     expect(seeded.events["first-reward"]).toBeDefined();
     expect(seeded.events["first-labyrinth:rook"]).toBeDefined();
     expect(seeded.events["special-training"]).toBeDefined();
-    expect(seeded.events["piece-badge-eligible:rook"]).toBeDefined();
     expect(seeded.events["piece-badge-claimed:rook"]).toBeDefined();
     expect(seeded.events["mastery:rook"]).toBeDefined();
+    // The eligibility does NOT survive the claim: a minted badge is claimed,
+    // not claimable. Seeding it would put a spent recognition on disk, and the
+    // queue drains pending events globally — that is exactly the event that
+    // haunted every other piece with a "Badge Ready to Claim" it could never
+    // dismiss.
+    expect(seeded.events["piece-badge-eligible:rook"]).toBeUndefined();
   });
 
   it("never seeds daily milestones even when sessionQuotaExhausted is true", () => {

--- a/apps/web/src/lib/progression/__tests__/milestones.test.ts
+++ b/apps/web/src/lib/progression/__tests__/milestones.test.ts
@@ -77,6 +77,20 @@ describe("piece badge", () => {
     );
     expect(ids(earned)).toContain("piece-badge-claimed");
   });
+
+  /** The RIGHT to claim does not survive the claim. Found on device: an
+   *  already-minted piece kept deriving `piece-badge-eligible`, and because
+   *  the celebration queue drains EVERY pending event regardless of the piece
+   *  on screen, that stuck event re-opened "Badge Ready to Claim" on every
+   *  solve of every other piece — over a board showing 9 stars. Its CTA then
+   *  hit `handleClaimBadge`, which no-ops on an owned badge, so the event was
+   *  never celebrated and the loop fed itself. */
+  it("is NOT eligible any more once the badge is on chain", () => {
+    const earned = deriveEarnedMilestones(
+      input({ pieceStars: 10, badgeClaimed: true }),
+    );
+    expect(ids(earned)).not.toContain("piece-badge-eligible");
+  });
 });
 
 describe("mastery", () => {

--- a/apps/web/src/lib/progression/__tests__/repair-claimed-badges.test.ts
+++ b/apps/web/src/lib/progression/__tests__/repair-claimed-badges.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { computeRepairClaimedBadges } from "../repair-claimed-badges";
+import type { MilestoneStore } from "../types";
+
+/**
+ * The device repair for the stuck badge overlay.
+ *
+ * Not deriving `piece-badge-eligible` for an owned badge stops NEW profiles
+ * from getting stuck — it does nothing for the profiles that already are. Their
+ * store holds a pending `piece-badge-eligible:<piece>` for a badge that is
+ * already on chain, and `selectPending` is global: it re-opens "Badge Ready to
+ * Claim" on every solve of every piece, forever. The event has to be laid to
+ * rest on disk.
+ *
+ * The rule is narrow on purpose: consume ONLY the recognition whose badge the
+ * chain says is already minted. An earned-but-unclaimed badge is a celebration
+ * the player is still owed, and stamping it would swallow it silently.
+ */
+
+const NOW = "2026-07-12T12:00:00.000Z";
+
+function store(events: MilestoneStore["events"]): MilestoneStore {
+  return { version: 1, events, dailyDate: "2026-07-12" };
+}
+
+describe("computeRepairClaimedBadges", () => {
+  it("celebrates a pending eligibility whose badge is already on chain", () => {
+    const next = computeRepairClaimedBadges(
+      store({
+        "piece-badge-eligible:rook": {
+          id: "piece-badge-eligible",
+          piece: "rook",
+          earnedAt: "2026-07-01T00:00:00.000Z",
+        },
+      }),
+      { rook: true },
+      NOW,
+    );
+
+    expect(next.events["piece-badge-eligible:rook"].celebratedAt).toBe(NOW);
+  });
+
+  it("leaves an unclaimed badge pending — that celebration is still owed", () => {
+    const input = store({
+      "piece-badge-eligible:pawn": {
+        id: "piece-badge-eligible",
+        piece: "pawn",
+        earnedAt: "2026-07-01T00:00:00.000Z",
+      },
+    });
+
+    const next = computeRepairClaimedBadges(input, { pawn: false }, NOW);
+
+    expect(next.events["piece-badge-eligible:pawn"].celebratedAt).toBeUndefined();
+    // Same reference: nothing to write, so nothing is persisted.
+    expect(next).toBe(input);
+  });
+
+  it("never touches other milestones", () => {
+    const next = computeRepairClaimedBadges(
+      store({
+        "first-labyrinth:rook": {
+          id: "first-labyrinth",
+          piece: "rook",
+          earnedAt: "2026-07-01T00:00:00.000Z",
+        },
+      }),
+      { rook: true },
+      NOW,
+    );
+
+    expect(next.events["first-labyrinth:rook"].celebratedAt).toBeUndefined();
+  });
+
+  it("is idempotent — an already-celebrated event is left alone", () => {
+    const input = store({
+      "piece-badge-eligible:rook": {
+        id: "piece-badge-eligible",
+        piece: "rook",
+        earnedAt: "2026-07-01T00:00:00.000Z",
+        celebratedAt: "2026-07-02T00:00:00.000Z",
+      },
+    });
+
+    expect(computeRepairClaimedBadges(input, { rook: true }, NOW)).toBe(input);
+  });
+});

--- a/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
+++ b/apps/web/src/lib/progression/__tests__/use-celebration-queue.test.tsx
@@ -110,6 +110,10 @@ describe("useCelebrationQueue", () => {
     // (< 2) and `pieceCompletedExercises` stays at 1 (< 3), so neither
     // first-reward nor first-labyrinth fire — the queue holds only the
     // closer, keeping this test's assertions unambiguous.
+    //
+    // The crown absorbs the Great Focus Session. It can no longer absorb
+    // `piece-badge-eligible`: mastery REQUIRES a claimed badge, and a claimed
+    // badge is no longer claimable — the two are exclusive states of one badge.
     const masteryArgs: GatherArgs = {
       piece: "rook",
       progressByPiece: {
@@ -119,7 +123,7 @@ describe("useCelebrationQueue", () => {
           stars: { "rook-1": 10 },
         },
       },
-      dailyStars: 0,
+      dailyStars: 8,
       sessionQuotaExhausted: false,
       badgeClaimed: true,
       allLabyrinthsComplete: true,
@@ -134,8 +138,7 @@ describe("useCelebrationQueue", () => {
 
     expect(result.current.current?.id).toBe("mastery");
     expect(result.current.current?.absorbed).toContainEqual({
-      id: "piece-badge-eligible",
-      piece: "rook",
+      id: "great-focus-session",
     });
 
     act(() => {
@@ -144,7 +147,7 @@ describe("useCelebrationQueue", () => {
 
     expect(getMilestoneStore().events["mastery:rook"].celebratedAt).toBeDefined();
     expect(
-      getMilestoneStore().events["piece-badge-eligible:rook"].celebratedAt,
+      getMilestoneStore().events["great-focus-session"].celebratedAt,
     ).toBeDefined();
   });
 

--- a/apps/web/src/lib/progression/milestones.ts
+++ b/apps/web/src/lib/progression/milestones.ts
@@ -78,9 +78,17 @@ export function deriveEarnedMilestones(input: MilestoneInput): EarnedMilestone[]
   }
 
   if (input.pieceStars >= BADGE_THRESHOLD) {
-    earned.push({ id: "piece-badge-eligible", piece });
+    // The RIGHT to claim does not survive the claim. Deriving it for an owned
+    // badge kept `piece-badge-eligible` permanently earned, and the queue
+    // drains EVERY pending event regardless of the piece on screen — so one
+    // stuck eligibility re-opened "Badge Ready to Claim" on every solve of
+    // every other piece, and its CTA no-ops on an owned badge, so it could
+    // never be celebrated away. The two events are exclusive states of one
+    // badge, not a sequence.
     if (input.badgeClaimed) {
       earned.push({ id: "piece-badge-claimed", piece });
+    } else {
+      earned.push({ id: "piece-badge-eligible", piece });
     }
   }
 

--- a/apps/web/src/lib/progression/repair-claimed-badges.ts
+++ b/apps/web/src/lib/progression/repair-claimed-badges.ts
@@ -1,0 +1,60 @@
+import type { PieceId } from "@/lib/game/types";
+import { getMilestoneStore, persistMilestoneStore } from "./milestone-storage";
+import { milestoneKey, type MilestoneStore } from "./types";
+
+/**
+ * Lays to rest a `piece-badge-eligible` event whose badge is already on chain.
+ *
+ * `deriveEarnedMilestones` used to emit the eligibility even for an owned
+ * badge, so profiles built before that fix carry a PENDING recognition for a
+ * badge they minted long ago. `selectPending` is global — it does not care
+ * which piece is on screen — so that one stuck event re-opened "Badge Ready to
+ * Claim" on every solve of every piece, over boards showing far fewer than ten
+ * stars. Tapping its CTA changed nothing: `handleClaimBadge` no-ops on an owned
+ * badge, so the event was never celebrated and the loop fed itself.
+ *
+ * Not deriving it any more stops NEW profiles from getting stuck; it does
+ * nothing for the ones already on disk. This does.
+ *
+ * Deliberately narrow: it consumes ONLY the recognition whose badge the chain
+ * says is minted. An earned-but-unclaimed badge is a celebration the player is
+ * still owed, and stamping that would swallow it in silence.
+ *
+ * Idempotent, and returns the SAME reference when there is nothing to do, so
+ * the caller can skip the write.
+ */
+export function computeRepairClaimedBadges(
+  store: MilestoneStore,
+  badgeClaimedByPiece: Partial<Record<PieceId, boolean>>,
+  now: string,
+): MilestoneStore {
+  const stuck = Object.values(store.events).filter(
+    (event) =>
+      event.id === "piece-badge-eligible" &&
+      !event.celebratedAt &&
+      event.piece !== undefined &&
+      badgeClaimedByPiece[event.piece] === true,
+  );
+  if (stuck.length === 0) return store;
+
+  const events = { ...store.events };
+  for (const event of stuck) {
+    events[milestoneKey(event.id, event.piece)] = {
+      ...event,
+      celebratedAt: now,
+    };
+  }
+  return { ...store, events };
+}
+
+/** IO wrapper. Safe to call on every mount: it writes only when a stuck event
+ *  is actually present. */
+export function repairClaimedBadges(
+  badgeClaimedByPiece: Partial<Record<PieceId, boolean>>,
+  now: string = new Date().toISOString(),
+): MilestoneStore {
+  const current = getMilestoneStore();
+  const next = computeRepairClaimedBadges(current, badgeClaimedByPiece, now);
+  if (next !== current) persistMilestoneStore(next);
+  return next;
+}

--- a/apps/web/src/lib/progression/use-milestone-seeding.ts
+++ b/apps/web/src/lib/progression/use-milestone-seeding.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { repairClaimedBadges } from "./repair-claimed-badges";
 import { seedMilestonesOnce, type SeedMilestonesArgs } from "./seed-milestones";
 
 export type UseMilestoneSeedingArgs = SeedMilestonesArgs & {
@@ -83,5 +84,12 @@ export function useMilestoneSeeding(args: UseMilestoneSeedingArgs): void {
       labyrinthIdsByPiece,
       giftAvailable,
     });
+    // Runs on EVERY ready mount, not once: the profiles this repairs were
+    // stamped migrated long before the defect was found, so a one-time marker
+    // would never reach them. It writes only when a stuck eligibility is
+    // actually on disk, and it needs the same known-badge-state gate the seed
+    // does — an unknown badge map would read as "not claimed" and repair
+    // nothing. See `repair-claimed-badges.ts`.
+    repairClaimedBadges(badgeClaimedByPiece);
   }, [args.ready]);
 }


### PR DESCRIPTION
## The bug (found on device)

"Badge Ready to Claim" re-opened every two or three exercises, on pieces showing **9 stars**, and its CTA did nothing — no transaction, no error, no claim pin.

## Root cause — three links

1. **The right to claim survived the claim.** `deriveEarnedMilestones` emitted `piece-badge-eligible` on `pieceStars >= 10` **without looking at `badgeClaimed`**, so an owned badge stayed permanently earned.
2. **The queue is global.** `selectPending` drains every pending event regardless of the piece on screen, so one stuck eligibility re-opened the overlay on every solve of *every* piece. The overlay never names its piece — so it read as a lie about the piece in front of the player. That is why a 9-star knight was told it had ten.
3. **The CTA could not clear it.** It calls `handleClaimBadge`, which returns a **silent `false`** on an owned badge (`exercises-screen.tsx:1735`). The caller reads `false` as "the player backed out" → `releaseAbsorbed`, never `dismissCurrent` — the only writer of `celebratedAt`. The event stayed pending. **The loop fed itself.**

## The fix

- `piece-badge-eligible` and `piece-badge-claimed` are now **exclusive states of one badge**, not a sequence.
- **`repair-claimed-badges.ts`** — profiles already carrying the stuck event were stamped migrated long ago, so a one-time seed marker can never reach them. The repair runs on every ready mount and writes only when a spent eligibility is actually on disk. Without this, existing devices (including the founder's) stay broken.
- The CTA **consumes** the recognition when the badge is already owned. Every other failure (cancelled, reverted, no wallet, wrong chain) still keeps it pending — that badge is genuinely owed and must be offered again.

## Verification

- Failing tests written first for links 1 and 2, verified red.
- `celebration-order` caught an early version of this fix dropping an absorbed Great Focus Session on a claim that did not complete. **Recognition still never depends on signing.**
- Suite: **5009 passing / 422 files**. `tsc --noEmit` clean.

Wolfcito 🐾 @akawolfcito