### PR TITLE
fix(arena): show the full rival portrait in the selector

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -10126,10 +10126,9 @@ button.hud-resource-chip:active:not(:disabled) {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  /* Zoom toward the character's face (upper-center) so the head reads big in
-   * the small framed slot; the parent's overflow:hidden crops the rest. */
-  transform: scale(1.85);
-  transform-origin: 50% 30%;
+  /* NO zoom transform. The rival art (2026-07-22) is already a square,
+   * face-forward portrait — scaling it up cropped everything but the snout.
+   * If a future avatar needs framing, crop the ASSET, not the slot. */
   filter: grayscale(1);
   transition: filter 160ms ease;
 }


### PR DESCRIPTION
## Qué pasaba

El slot de avatar del selector de `/arena` aplicaba `transform: scale(1.85)` con `transform-origin: 50% 30%` (`globals.css:10131`). Ese zoom se agregó para agrandar la cabeza del arte viejo de rivales.

Con los avatares nuevos —que ya son retratos cuadrados 80×80, de frente— el zoom recorta todo menos el hocico.

## Fix

Se quita el transform. Con `object-fit: cover` sobre una imagen 1:1 en un slot 1:1, el retrato completo entra en la ventana del marco.

- El rail de arena (`.arena-rail-avatar`) y el ribbon de matchup (`.arena-matchup-avatar`) nunca tuvieron el zoom, así que las tres superficies quedan con el mismo encuadre.
- No hay baseline VR de la pantalla de selección (los `vr9-arena-*` cubren solo end-state), así que no hay snapshots que regenerar.

## Verificación

Render before/after de los assets reales (`pipo`/`mara`/`kairo` + los tres marcos) a través de las reglas CSS exactas: el "después" muestra casco, armadura y fondo de ajedrez completos.

## Nota aparte (no incluida acá)

Los avatares son de 80×80 px y se dibujan en ~50 px CSS → en pantallas 3x quedan algo blandos. No los escalé (regla del repo: nunca upscalear); si querés nitidez, el camino es exportarlos a ~160 px.

Wolfcito 🐾 @akawolfcito