### PR TITLE
fix(benefits): PRO Sheet perks aligned to canonical Season Pass hierarchy

### DIFF
--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -2449,18 +2449,19 @@ export const PRO_COPY = {
     journal: "JOURNAL",
     journalSubline: "Review your coach history and pick the next lesson.",
   },
-  /** M1 funnel (Commit 5) — value bullets rendered before the price
-   *  card so PRO is framed as "what you get" before "what you pay".
-   *  Full sentences, canonical order: Luz access → Training Journal →
-   *  Special Trainings → PRO identity. Only entitlement-backed perks:
-   *  Special Trainings is gated by the training_pass, which PRO grants
-   *  (source "pro"); Arena / VictoryNFT stay roadmap-only, never here.
-   *  Category-level wording ("new games added over time") stays valid
-   *  as more Special Trainings ship — do not list individual games. */
+  /** Value bullets rendered before the price card so PRO is framed as
+   *  "what you get" before "what you pay". Canonical hierarchy (founder,
+   *  2026-07-23): PRO includes the full Season Pass, then adds unlimited
+   *  Coach Review, the Training Journal and PRO identity. Season Pass is
+   *  the entitlement PRO grants (source "pro" → training_pass), and it
+   *  subsumes Special Trainings, so those are NOT a separate bullet here.
+   *  "Play Chess" is folded into "every game you play": Arena is free
+   *  (progression-gated), never a PRO-exclusive entitlement, so it must
+   *  not read as one. Arena / VictoryNFT stay roadmap-only, never here. */
   perksActive: [
-    "Luz unlimited. Coach review on every game.",
+    "The full Season Pass, included.",
+    "Luz unlimited. Coach review on every game you play.",
     "Full Training Journal. Every match kept.",
-    "Special Trainings. New games added over time.",
     "PRO identity on your profile.",
   ] as const,
   errors: {

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -344,9 +344,9 @@ const messages = {
         "Revisa tu historial con el Coach y elige la próxima lección.",
     },
     perksActive: [
-      "Luz ilimitada. Análisis de cada partida.",
+      "El Season Pass completo, incluido.",
+      "Luz ilimitada. Análisis de cada partida que juegas.",
       "Training Journal completo. Toda tu historia guardada.",
-      "Special Trainings: nuevos juegos con el tiempo.",
       "Identidad PRO en tu perfil.",
     ],
     errors: {

--- a/docs/product/2026-07-23-benefits-consistency-audit.md
+++ b/docs/product/2026-07-23-benefits-consistency-audit.md
@@ -1,0 +1,57 @@
+# Auditoría de consistencia de beneficios — copy-only (2026-07-23)
+
+## Fuente canónica (dada por el founder)
+- **Season Pass**: 21-Day Challenge · Daily Focus · Special Trainings · new games over time.
+- **PRO**: incluye Season Pass · Play Chess · unlimited Coach Review · Training Journal · PRO identity.
+
+Reglas: no prometer Arena/NFT/roadmap; solo beneficios respaldados por entitlements reales;
+no tocar layout/backend/entitlements; corregir solo copy inconsistente.
+
+## Superficies auditadas y drift
+
+| Superficie | Estado vs canónico | Acción |
+|---|---|---|
+| Onboarding slide Season Pass (`landing slide2`) | "Decide better in 21 days" + Focus Passport + "Season Pass, $0.99". Minimalista por diseño ("one idea per screen"). Alineado. | Sin cambio |
+| Onboarding slide PRO (`landing slide3`) | "Coach PRO includes the Season Pass" + Saved games + Coach review. Contenido alineado (inclusión de Season Pass ✓). | Sin cambio de contenido; ver naming abajo |
+| Challenge Card (`CHALLENGE_CARD_COPY`) | 21-Day Mind Challenge, Focus, etc. Alineado. | Sin cambio |
+| Season Pass Sheet (`offer*`) | 21-Day Challenge · Daily Focus habit · Special Trainings · "growing over time". **Alineado** (quedó así en #266). | Sin cambio |
+| **PRO Sheet (`PRO_COPY.perksActive`)** | **DRIFT**: no menciona "incluye Season Pass"; tiene un bullet suelto "Special Trainings" que en el nuevo canónico vive **bajo** Season Pass. | **CORREGIR** |
+| Paywalls/CTAs (`COACH_COPY.paywallProCta`, `HUB_V2_TRAINING_COPY`, pro chip) | CTAs de acción ("Train with Luz every day"), no listas de beneficios. Sin promesas falsas. | Sin cambio |
+
+## Conflictos reportados (NO corregidos a ciegas)
+
+### ⚠️ 1. "Play Chess" no es un entitlement PRO
+- Arena/Play se entra libre: `router.push("/arena")` sin gate; el Mini Arena del hub Learn
+  se desbloquea **por progresión** (`miniArenaUnlocked = rook stars >= threshold`), no por PRO/pass.
+- El único upsell PRO en la superficie de juego es el **Coach Review** post-partida.
+- Listar "Play Chess" como beneficio **exclusivo** de PRO sería una promesa no respaldada por
+  entitlement → viola tu propia regla.
+- **Resolución tomada:** se reconcilia truthfully — "Play Chess" se pliega dentro de
+  "Coach review on **every game you play**" (cubre el concepto sin afirmar exclusividad).
+  Si querés listarlo como bullet propio igual (framing "PRO = experiencia completa"), decímelo
+  y lo agrego en una línea.
+
+### ⚠️ 2. Nombre del producto inconsistente
+- `PRO_COPY.label` = **"Chesscito PRO"**; pero `hubCoachCard.title`, `coachKicker*` y la
+  landing slide3 usan **"Coach PRO"**.
+- Probablemente intencional en superficies coach (framing por la lente del Coach), pero el
+  nuevo canónico posiciona PRO como más que coach (incluye Season Pass + Play).
+- **No corregido** en este commit: renombrar el producto tiene blast radius grande y requiere
+  tu decisión de nombre canónico ("Chesscito PRO" vs "Coach PRO" vs "PRO"). Reportado para follow-up.
+
+## Corrección aplicada (copy-only, commit pequeño)
+
+`PRO_COPY.perksActive` (EN `editorial.ts` + ES `es.ts`):
+
+| Before | After |
+|---|---|
+| Luz unlimited. Coach review on every game. | **The full Season Pass, included.** |
+| Full Training Journal. Every match kept. | Luz unlimited. Coach review on every game you play. |
+| **Special Trainings. New games added over time.** | Full Training Journal. Every match kept. |
+| PRO identity on your profile. | PRO identity on your profile. |
+
+- ✅ Lidera con la inclusión de Season Pass (entitlement real: `source:"pro"` concede `training_pass`).
+- ✅ Special Trainings deja de ser bullet suelto (ahora vive bajo Season Pass, per canónico).
+- ✅ "Play Chess" reconciliado en "every game you play" sin afirmar exclusividad.
+- ✅ Coach Review, Training Journal, PRO identity conservados.
+- ✅ Sin em-dashes (guard anti-AI-prose). Sin cambios de layout/backend/entitlements.


### PR DESCRIPTION
## Auditoría copy-only de consistencia de beneficios

Auditadas **todas** las superficies públicas contra el canónico (founder):
- **Season Pass**: 21-Day Challenge · Daily Focus · Special Trainings · new games over time.
- **PRO**: incluye Season Pass · Play Chess · unlimited Coach Review · Training Journal · PRO identity.

Reporte completo: `docs/product/2026-07-23-benefits-consistency-audit.md`.

### Drift encontrado y corregido
Solo el **PRO Sheet** (`PRO_COPY.perksActive`) estaba desalineado: no lideraba con la inclusión del Season Pass y arrastraba un bullet suelto "Special Trainings" que en el nuevo canónico vive **bajo** Season Pass.

| Before | After |
|---|---|
| Luz unlimited. Coach review on every game. | **The full Season Pass, included.** |
| Full Training Journal. Every match kept. | Luz unlimited. Coach review on every game you play. |
| **Special Trainings. New games added over time.** | Full Training Journal. Every match kept. |
| PRO identity on your profile. | PRO identity on your profile. |

EN (`editorial.ts`) + ES (`es.ts`). Season Pass sheet, Challenge Card y las slides de onboarding ya estaban alineadas (sin cambios).

### Reportado, NO cambiado (requiere tu decisión)
1. **"Play Chess" no es un entitlement PRO.** Arena se entra libre (`router.push('/arena')`); el Mini Arena del hub Learn se desbloquea por **progresión** (`rook stars >= threshold`), no por PRO/pass. Listarlo como beneficio exclusivo violaría la regla "solo entitlements reales". → Lo plegué en "every game you play" sin afirmar exclusividad. Si querés bullet propio (framing PRO = experiencia completa), es una línea.
2. **Nombre inconsistente**: `Chesscito PRO` (label) vs `Coach PRO` (coach card, landing slide3). Blast radius grande → follow-up con tu decisión de nombre canónico.

## Verificación
- Focused: anti-ai-prose + pro-sheet + season-pass-sheet → **56/56 green**.
- Typecheck limpio.
- Suite completa: 5691 passing; 6 flakes por timeout en `queens`/`asset-triplet` (game-logic/asset, ajenos al copy) que **pasan aislados** (27/27).

Copy-only. No layout/backend/entitlements. No implementa Slice A.

Wolfcito 🐾 @akawolfcito
