### PR TITLE
fix(copy): retire Coach PRO for Chesscito PRO (plan) / Coach Review (tool)

### DIFF
--- a/apps/landing/src/components/onboarding/__tests__/onboarding-carousel.test.tsx
+++ b/apps/landing/src/components/onboarding/__tests__/onboarding-carousel.test.tsx
@@ -60,7 +60,7 @@ describe("OnboardingCarousel", () => {
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     expect(screen.getByText("3 / 4")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: /coach pro includes the season pass/i }),
+      screen.getByRole("heading", { name: /chesscito pro includes the season pass/i }),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
@@ -93,7 +93,7 @@ describe("OnboardingCarousel", () => {
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
     fireEvent.click(screen.getByRole("button", { name: "NEXT" }));
 
-    expect(screen.getByText("Coach PRO, $1.99")).toBeInTheDocument();
+    expect(screen.getByText("Chesscito PRO, $1.99")).toBeInTheDocument();
     expect(screen.queryByText(/free/i)).not.toBeInTheDocument();
   });
 
@@ -152,7 +152,7 @@ describe("OnboardingCarousel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /previous slide/i }));
     expect(
-      screen.getByRole("heading", { name: /coach pro includes the season pass/i }),
+      screen.getByRole("heading", { name: /chesscito pro includes the season pass/i }),
     ).toBeInTheDocument();
   });
 

--- a/apps/landing/src/lib/content/messages/en.ts
+++ b/apps/landing/src/lib/content/messages/en.ts
@@ -35,11 +35,11 @@ const messages = {
     slide3: {
       // The inclusion is the whole argument for PRO, so it is the headline.
       // It used to be the label of a gold pill.
-      headline: "Coach PRO includes the Season Pass.",
+      headline: "Chesscito PRO includes the Season Pass.",
       support: "Your games get reviewed, and the 21 Day Challenge comes with it.",
       savedGamesPill: "Saved games",
       coachReviewPill: "Coach review",
-      price: "Coach PRO, $1.99",
+      price: "Chesscito PRO, $1.99",
       cta: "NEXT",
     },
     slide4: {

--- a/apps/landing/src/lib/content/messages/es.ts
+++ b/apps/landing/src/lib/content/messages/es.ts
@@ -3,7 +3,7 @@ import type { OnboardingMessages } from "./en";
 /**
  * Real ES copy for the onboarding slides. Typed against
  * `OnboardingMessages` so it can never silently drift out of shape
- * from the EN source. Branded product names (Season Pass, Coach PRO,
+ * from the EN source. Branded product names (Season Pass, Chesscito PRO,
  * PRO, Focus Passport, 21 Day Challenge) stay in English; everything else
  * is natural Spanish. No em/en-dashes per the anti-AI-prose rule.
  */
@@ -29,11 +29,11 @@ const messages: OnboardingMessages = {
       cta: "SIGUIENTE",
     },
     slide3: {
-      headline: "Coach PRO incluye el Season Pass.",
+      headline: "Chesscito PRO incluye el Season Pass.",
       support: "Tus partidas se revisan, y el 21 Day Challenge viene incluido.",
       savedGamesPill: "Partidas guardadas",
       coachReviewPill: "Revisión del Coach",
-      price: "Coach PRO, $1.99",
+      price: "Chesscito PRO, $1.99",
       cta: "SIGUIENTE",
     },
     slide4: {

--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -2426,13 +2426,13 @@ export const PRO_COPY = {
   chipGetAriaLabel: "Get {label}",
   /** <CoachProCard /> ARIA + kicker copy. Kicker flips between
    *  active/inactive subscription states. */
-  coachCardAriaLabel: "Coach PRO training",
-  coachChipsAriaLabel: "Coach PRO includes",
+  coachCardAriaLabel: "Chesscito PRO training",
+  coachChipsAriaLabel: "Coach Review includes",
   coachKickerActive: "Training Pass",
   coachKickerInactive: "Personal Coach",
   hubCoachCard: {
     inactive: {
-      title: "Coach PRO",
+      title: "Chesscito PRO",
       body: "Get feedback after games and practice.",
       chips: ["Insights", "Tips", "History"] as const,
       cta: "COACH",

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -319,13 +319,13 @@ const messages = {
     },
     chipActiveAriaLabel: "{label} activo",
     chipGetAriaLabel: "Activar {label}",
-    coachCardAriaLabel: "Entrenamiento Coach PRO",
-    coachChipsAriaLabel: "Coach PRO incluye",
+    coachCardAriaLabel: "Entrenamiento Chesscito PRO",
+    coachChipsAriaLabel: "Coach Review incluye",
     coachKickerActive: "Pase de entrenamiento",
     coachKickerInactive: "Coach personal",
     hubCoachCard: {
       inactive: {
-        title: "Coach PRO",
+        title: "Chesscito PRO",
         body: "Recibe feedback después de partidas y prácticas.",
         chips: ["Análisis", "Consejos", "Historial"],
         cta: "COACH",


### PR DESCRIPTION
## Cierre del split de nombre (copy-only)

Resuelve el drift #2 reportado en la auditoría de beneficios: retira **"Coach PRO"** y lo divide según a qué se refiere.

| Ocurrencia | Se refiere a | After |
|---|---|---|
| `hubCoachCard.inactive.title` (activo ya dice "PRO Active") | plan | **Chesscito PRO** |
| `coachCardAriaLabel` | plan | **Chesscito PRO** training |
| `coachChipsAriaLabel` (chips = Insights/Tips/History = salidas del review) | herramienta | **Coach Review** includes |
| Onboarding slide 3 headline (EN+ES, landing) | plan | **Chesscito PRO** includes the Season Pass |
| Onboarding slide 3 price (EN+ES, landing) | plan | **Chesscito PRO**, $1.99 |

EN via `editorial.ts` (web) + landing `en.ts`; ES en los `es.ts` de ambas apps. Test `onboarding-carousel` actualizado.

### Fuera de alcance (intencional)
- `dev/button-gallery` conserva "Coach PRO card" (dev-only, gateado por NODE_ENV, describe el componente `CoachProCard` por su nombre; no es copy user-facing).
- No se tocan componentes, entitlements ni layout. "Chesscito PRO" (13 ch) entra donde ya cabe "PRO Active · 30d" (16 ch), así que no hay riesgo de layout en el card.

## Verificación
- Focused: web (anti-ai-prose + pro + hub-scaffold) **106/106**, landing (onboarding-carousel) **12/12**.
- Typecheck limpio en **web y landing**.

Copy-only. Con esto la línea de limpieza de benefits queda cerrada.

Wolfcito 🐾 @akawolfcito
