### PR TITLE
docs(privacy): analytics disclosure EN/ES (ship first)

### DIFF
--- a/apps/web/src/lib/content/editorial.ts
+++ b/apps/web/src/lib/content/editorial.ts
@@ -2126,7 +2126,7 @@ export const LEGAL_COPY = {
   },
   privacy: {
     title: "Privacy Policy",
-    lastUpdated: "March 15, 2026",
+    lastUpdated: "July 23, 2026",
     sections: [
       {
         heading: "Data We Handle",
@@ -2134,23 +2134,27 @@ export const LEGAL_COPY = {
       },
       {
         heading: "Data We Do Not Collect",
-        body: "Chesscito does not collect passwords, seed phrases, government-issued identification, personal identifiable information (PII), or analytics and tracking cookies.",
+        body: "Chesscito does not collect passwords, seed phrases, government-issued identification, personal identifiable information (PII), your full IP address, precise location, phone number, or email. We use no advertising or cross-site tracking cookies.",
       },
       {
         heading: "Local Storage",
         body: "Tutorial state, gameplay preferences, streak shields, and UX settings are stored on your device for UX purposes. On-chain actions and related blockchain data are public by nature and may be transmitted through wallet and network infrastructure required to operate the app.",
       },
       {
+        heading: "Product Analytics",
+        body: "Chesscito records anonymous, first-party usage analytics to understand how the app is used and to keep it secure. For example, we record which screens are viewed, whether training exercises are started and completed, and whether the app runs inside MiniPay or a regular browser. These events are tied to a random, device-generated anonymous identifier stored on your device, never to your wallet address, name, phone, or email. We derive an approximate country (a two-letter country code only) from the network request; we never store your full IP address, city, or coordinates. Analytics are used only in aggregate for product and security decisions, not to profile individuals.",
+      },
+      {
         heading: "Third-Party Infrastructure",
-        body: "Chesscito uses Celo RPC providers for blockchain reads and writes, and WalletConnect for wallet connection. We do not use analytics vendors or ad networks.",
+        body: "Chesscito uses Celo RPC providers for blockchain reads and writes, and WalletConnect for wallet connection. Anonymous usage analytics are first-party and stored in our own database (Supabase); we do not use third-party analytics vendors or ad networks.",
       },
       {
         heading: "Purpose of Data Use",
-        body: "Data is used solely to operate the game: validate moves, record scores, process purchases, and mint collectibles.",
+        body: "Data is used solely to operate the game and keep it secure: validate moves, record scores, process purchases, mint collectibles, and measure aggregate product usage.",
       },
       {
         heading: "Data Retention",
-        body: "On-chain data is permanent by nature of blockchain. Local data stored on your device can be cleared by you at any time through your browser settings.",
+        body: "On-chain data is permanent by nature of blockchain. Raw anonymous analytics events are retained for up to 90 days; anonymous first-visit records used to measure retention are kept longer in aggregated form. Local data stored on your device can be cleared by you at any time through your browser settings.",
       },
       {
         heading: "Contact",

--- a/apps/web/src/lib/content/messages/es.ts
+++ b/apps/web/src/lib/content/messages/es.ts
@@ -174,7 +174,7 @@ const messages = {
     },
     privacy: {
       title: "Política de Privacidad",
-      lastUpdated: "15 de marzo de 2026",
+      lastUpdated: "23 de julio de 2026",
       sections: [
         {
           heading: "Datos que manejamos",
@@ -182,23 +182,27 @@ const messages = {
         },
         {
           heading: "Datos que NO recolectamos",
-          body: "Chesscito no recolecta contraseñas, frases semilla, identificaciones emitidas por gobiernos, información de identificación personal (PII), ni cookies de analítica o tracking.",
+          body: "Chesscito no recolecta contraseñas, frases semilla, identificaciones emitidas por gobiernos, información de identificación personal (PII), tu dirección IP completa, ubicación precisa, número de teléfono ni email. No usamos cookies de publicidad ni de rastreo entre sitios.",
         },
         {
           heading: "Almacenamiento local",
           body: "El estado de tutoriales, preferencias de juego, escudos de racha y ajustes de UX se almacenan en tu dispositivo con fines de experiencia. Las acciones on-chain y los datos blockchain relacionados son públicos por naturaleza y pueden transmitirse a través de la infraestructura de wallet y red necesaria para operar la app.",
         },
         {
+          heading: "Analítica de producto",
+          body: "Chesscito registra analítica de uso anónima y propia (first-party) para entender cómo se usa la app y mantenerla segura. Por ejemplo, registramos qué pantallas se ven, si los ejercicios de entrenamiento se inician y completan, y si la app corre dentro de MiniPay o de un navegador normal. Estos eventos se asocian a un identificador anónimo aleatorio generado en tu dispositivo, nunca a tu dirección de wallet, nombre, teléfono o email. Derivamos un país aproximado (solo un código de dos letras) a partir de la solicitud de red; nunca almacenamos tu dirección IP completa, ciudad ni coordenadas. La analítica se usa solo de forma agregada para decisiones de producto y seguridad, no para perfilar individuos.",
+        },
+        {
           heading: "Infraestructura de terceros",
-          body: "Chesscito utiliza proveedores RPC de Celo para lecturas y escrituras blockchain, y WalletConnect para conexión de wallets. No usamos proveedores de analítica ni redes de publicidad.",
+          body: "Chesscito utiliza proveedores RPC de Celo para lecturas y escrituras blockchain, y WalletConnect para conexión de wallets. La analítica de uso anónima es propia y se almacena en nuestra propia base de datos (Supabase); no usamos proveedores de analítica de terceros ni redes de publicidad.",
         },
         {
           heading: "Propósito del uso de datos",
-          body: "Los datos se usan únicamente para operar el juego: validar movimientos, registrar scores, procesar compras y mintear coleccionables.",
+          body: "Los datos se usan únicamente para operar el juego y mantenerlo seguro: validar movimientos, registrar scores, procesar compras, mintear coleccionables y medir el uso agregado del producto.",
         },
         {
           heading: "Retención de datos",
-          body: "Los datos on-chain son permanentes por la naturaleza de la blockchain. Los datos locales en tu dispositivo pueden ser borrados por ti en cualquier momento desde la configuración del navegador.",
+          body: "Los datos on-chain son permanentes por la naturaleza de la blockchain. Los eventos de analítica anónima se conservan hasta 90 días; los registros anónimos de primera visita usados para medir retención se conservan más tiempo de forma agregada. Los datos locales en tu dispositivo pueden ser borrados por ti en cualquier momento desde la configuración del navegador.",
         },
         {
           heading: "Contacto",


### PR DESCRIPTION
## Privacy Policy — analytics disclosure (must ship FIRST)

Independent PR carrying **only** the Privacy Policy EN/ES update from Observability Lote 1. It ships on its own, ahead of any analytics code or database migration.

### Why this is separate and first
The prior policy falsely claimed Chesscito collects **no analytics**. Lote 1 introduces anonymous, first-party product analytics. The policy must be **live in production** before the analytics code and the DB migrations are activated. This PR is the privacy gate.

### What changes
- `apps/web/src/lib/content/editorial.ts` (EN) and `apps/web/src/lib/content/messages/es.ts` (ES):
  - Corrects "Data We Don't Collect" (no full IP, precise location, phone, email; no ad/tracking cookies).
  - New **Product Analytics** section: anonymous device identifier, approximate country (two-letter ISO code only, derived from IP), **never** full IP/city/coordinates, aggregate product+security purpose.
  - Updates Third-Party Infrastructure (first-party analytics in our own Supabase, no third-party analytics vendors) and Data Retention (90-day raw events; aggregated first-visit records for retention).
  - `lastUpdated` → July 23, 2026.

### Scope
- **Only** the two content files. No code, no schema, no migrations.
- Does **not** enable analytics collection by itself.

### Merge order (hard requirement)
1. **This PR → live in production first.**
2. Then apply the two additive migrations (separate runbook, human approval required).
3. Then the code PR (`feat/observability-lote-1-code`).

### Verification
- `anti-ai-prose` + `privacy` content tests pass (11/11) on this branch.

Wolfcito 🐾 @akawolfcito
