### PR TITLE
feat(observability): Lote 1 code — dims, app_opened, retention, /stats filters

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { DesktopAppFrame } from "@/components/chrome/desktop-app-frame"
 import { routing } from "@/i18n/routing"
 import { CHESSCITO_MODE } from "@/lib/feature-flags"
 import { ThemeCssVariables } from "@/components/themes/theme-css-variables"
+import { AnalyticsBoot } from "@/components/analytics/analytics-boot"
 
 const fredoka = Fredoka({
   subsets: ['latin'],
@@ -143,6 +144,7 @@ export default async function LocaleLayout({
             <div className="relative flex w-full flex-col text-foreground">
               <WalletProvider>
                 <ThemeCssVariables />
+                <AnalyticsBoot />
                 <main className="flex flex-1 flex-col">
                   <DesktopAppFrame>{children}</DesktopAppFrame>
                 </main>

--- a/apps/web/src/app/[locale]/stats/page.tsx
+++ b/apps/web/src/app/[locale]/stats/page.tsx
@@ -1,6 +1,8 @@
+import { unstable_cache } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import { StatsPage } from "@/components/stats/stats-page";
 import { getPublicStats } from "@/lib/stats/public-aggregator";
+import { parseStatsFilters, type StatsFilters } from "@/lib/stats/filters";
 import {
   nicknameTokensFromTranslator,
   type NicknameTranslator,
@@ -19,8 +21,25 @@ export const metadata = {
 // page never 500s on partial Supabase outages.
 export const revalidate = 3600;
 
-export default async function StatsRoute() {
-  const stats = await getPublicStats();
+// Per-filter-combination hourly cache. Reading searchParams makes the route
+// dynamic, but the Supabase aggregation still caches for an hour keyed by the
+// (surface, container) pair, so each querystring gets its own correct,
+// independently-revalidated snapshot instead of re-querying every request.
+function loadStats(filters: StatsFilters) {
+  return unstable_cache(
+    () => getPublicStats(filters),
+    ["public-stats", filters.surface, filters.container],
+    { revalidate: 3600, tags: ["public-stats"] },
+  )();
+}
+
+export default async function StatsRoute({
+  searchParams,
+}: {
+  searchParams: { surface?: string; container?: string };
+}) {
+  const filters = parseStatsFilters(searchParams);
+  const stats = await loadStats(filters);
   // Build the locale-aware nickname tokens server-side (the aggregator is
   // locale-agnostic + cached); StatsPage formats names from the row variants.
   const tIdentity = await getTranslations("IDENTITY_COPY");

--- a/apps/web/src/app/api/telemetry/__tests__/route.test.ts
+++ b/apps/web/src/app/api/telemetry/__tests__/route.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type Captured = {
+  inserts: Array<{ table: string; row: Record<string, unknown> }>;
+  upserts: Array<{
+    table: string;
+    row: Record<string, unknown>;
+    options: unknown;
+  }>;
+};
+
+const captured: Captured = { inserts: [], upserts: [] };
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseServer: () => ({
+    from(table: string) {
+      return {
+        insert: (row: Record<string, unknown>) => {
+          captured.inserts.push({ table, row });
+          return Promise.resolve({ error: null });
+        },
+        upsert: (row: Record<string, unknown>, options: unknown) => {
+          captured.upserts.push({ table, row, options });
+          return Promise.resolve({ error: null });
+        },
+      };
+    },
+  }),
+}));
+
+import { POST } from "../route";
+
+function makeReq(
+  body: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("http://localhost/api/telemetry", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  captured.inserts = [];
+  captured.upserts = [];
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/telemetry — dimension enrichment", () => {
+  it("writes sanitized dims + country from the edge header", async () => {
+    const res = await POST(
+      makeReq(
+        {
+          session_id: "anon1",
+          event: "hub_viewed",
+          dims: {
+            surface: "learn",
+            container: "minipay",
+            locale: "es",
+            source: "share_whatsapp",
+            campaign: "launch_2026",
+            app_version: "a1b2c3d",
+            visit_id: "v1",
+            country: "ZZ", // client-supplied geo must be ignored
+          },
+        },
+        { "x-vercel-ip-country": "br" },
+      ),
+    );
+    expect(res.status).toBe(204);
+    expect(captured.inserts).toHaveLength(1);
+    const row = captured.inserts[0].row;
+    expect(row).toMatchObject({
+      session_id: "anon1",
+      event: "hub_viewed",
+      surface: "learn",
+      container: "minipay",
+      locale: "es",
+      country: "BR", // from header, upper-cased; client "ZZ" ignored
+      source: "share_whatsapp",
+      campaign: "launch_2026",
+      app_version: "a1b2c3d",
+      visit_id: "v1",
+    });
+  });
+
+  it("nulls out off-allow-list dimensions", async () => {
+    await POST(
+      makeReq({
+        session_id: "anon1",
+        event: "x",
+        dims: {
+          surface: "marketing",
+          container: "metamask",
+          source: "affiliate_9",
+          campaign: "bad; drop",
+          app_version: "feature/x",
+        },
+      }),
+    );
+    const row = captured.inserts[0].row;
+    expect(row.surface).toBeNull();
+    expect(row.container).toBeNull();
+    expect(row.source).toBe("unknown");
+    expect(row.campaign).toBeNull();
+    expect(row.app_version).toBeNull();
+    expect(row.country).toBeNull(); // no header
+  });
+
+  it("upserts session_first_seen only on app_opened, idempotently", async () => {
+    await POST(
+      makeReq(
+        {
+          session_id: "anon2",
+          event: "app_opened",
+          dims: { surface: "play", container: "browser", source: "direct" },
+        },
+        { "x-vercel-ip-country": "US" },
+      ),
+    );
+    expect(captured.upserts).toHaveLength(1);
+    expect(captured.upserts[0].table).toBe("session_first_seen");
+    expect(captured.upserts[0].row).toMatchObject({
+      session_id: "anon2",
+      first_surface: "play",
+      first_country: "US",
+      first_source: "direct",
+    });
+    expect(captured.upserts[0].options).toMatchObject({
+      onConflict: "session_id",
+      ignoreDuplicates: true,
+    });
+  });
+
+  it("does NOT upsert first_seen for non-root events", async () => {
+    await POST(
+      makeReq({ session_id: "anon3", event: "exercise_started", dims: {} }),
+    );
+    expect(captured.upserts).toHaveLength(0);
+  });
+});

--- a/apps/web/src/app/api/telemetry/route.ts
+++ b/apps/web/src/app/api/telemetry/route.ts
@@ -1,16 +1,63 @@
 import { getSupabaseServer } from "@/lib/supabase/server";
+import {
+  normalizeAppVersion,
+  normalizeCampaign,
+  normalizeContainer,
+  normalizeCountry,
+  normalizeLocale,
+  normalizeSource,
+  normalizeSurface,
+} from "@/lib/analytics/dimensions";
 
 export const runtime = "nodejs";
 
 const MAX_EVENT_LEN = 64;
 const MAX_SESSION_LEN = 64;
 const MAX_PROPS_BYTES = 4_096;
+const MAX_VISIT_LEN = 64;
 
 type Payload = {
   session_id?: unknown;
   event?: unknown;
   props?: unknown;
+  dims?: unknown;
 };
+
+/** Server-authoritative dimensions written to analytics_events. Every value is
+ *  re-sanitized through the shared allow-lists (the client already stamped
+ *  them, but the server is the source of truth) and `country` is derived here
+ *  from the edge header — never trusted from the client. */
+type ServerDims = {
+  surface: string | null;
+  container: string | null;
+  locale: string | null;
+  country: string | null;
+  source: string | null;
+  campaign: string | null;
+  app_version: string | null;
+  visit_id: string | null;
+};
+
+function sanitizeDims(raw: unknown, country: string | null): ServerDims {
+  const d = (raw && typeof raw === "object" ? raw : {}) as Record<
+    string,
+    unknown
+  >;
+  const visit =
+    typeof d.visit_id === "string" && d.visit_id.length <= MAX_VISIT_LEN
+      ? d.visit_id
+      : null;
+  return {
+    surface: normalizeSurface(d.surface),
+    container: normalizeContainer(d.container),
+    locale: normalizeLocale(d.locale),
+    country, // from edge header only
+    source: normalizeSource(d.source),
+    campaign: normalizeCampaign(d.campaign),
+    app_version: normalizeAppVersion(d.app_version),
+    visit_id: visit,
+  };
+}
 
 function sanitizeProps(raw: unknown): Record<string, unknown> | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
@@ -50,6 +97,14 @@ export async function POST(req: Request) {
 
     const props = sanitizeProps(payload.props);
 
+    // Country comes ONLY from the edge geo header — never from the client
+    // payload. We keep ISO alpha-2 and nothing else: no IP, city, region,
+    // postal code, or coordinates is ever read or stored (privacy §7).
+    const country = normalizeCountry(
+      req.headers.get("x-vercel-ip-country"),
+    );
+    const dims = sanitizeDims(payload.dims, country);
+
     const supabase = getSupabaseServer();
     if (!supabase) return new Response(null, { status: 204 });
 
@@ -59,7 +114,25 @@ export async function POST(req: Request) {
       session_id: sessionId,
       event,
       props,
+      ...dims,
     });
+
+    // The app_opened root event also fixes the retention cohort. Idempotent:
+    // on conflict the first visit's day-0 + first-touch attribution stand.
+    if (event === "app_opened") {
+      await supabase
+        .from("session_first_seen")
+        .upsert(
+          {
+            session_id: sessionId,
+            first_surface: dims.surface,
+            first_container: dims.container,
+            first_country: dims.country,
+            first_source: dims.source,
+          },
+          { onConflict: "session_id", ignoreDuplicates: true },
+        );
+    }
   } catch {
     /* swallow — telemetry must never fail user-visible flows */
   }

--- a/apps/web/src/components/analytics/__tests__/analytics-boot.test.tsx
+++ b/apps/web/src/components/analytics/__tests__/analytics-boot.test.tsx
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { StrictMode } from "react";
+
+const trackMock = vi.fn();
+vi.mock("@/lib/telemetry", () => ({ track: (...a: unknown[]) => trackMock(...a) }));
+
+import { AnalyticsBoot } from "../analytics-boot";
+
+afterEach(() => {
+  cleanup();
+  trackMock.mockClear();
+  window.sessionStorage.clear();
+});
+
+describe("AnalyticsBoot", () => {
+  it("fires app_opened once on first mount", () => {
+    render(<AnalyticsBoot />);
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith("app_opened");
+  });
+
+  it("does not fire again on a second mount within the same visit", () => {
+    render(<AnalyticsBoot />);
+    cleanup();
+    render(<AnalyticsBoot />);
+    expect(trackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires only once under StrictMode double-invoke", () => {
+    render(
+      <StrictMode>
+        <AnalyticsBoot />
+      </StrictMode>,
+    );
+    expect(trackMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/analytics/analytics-boot.tsx
+++ b/apps/web/src/components/analytics/analytics-boot.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { claimAppOpenedForVisit } from "@/lib/analytics/identity";
+import { track } from "@/lib/telemetry";
+
+/**
+ * Fires the `app_opened` root event exactly once per visit (tab session),
+ * independent of wallet or connection. The once-per-visit guard lives in
+ * sessionStorage (claimAppOpenedForVisit), so StrictMode double-invoke,
+ * remounts, and client navigation cannot double-count. Renders nothing.
+ */
+export function AnalyticsBoot(): null {
+  useEffect(() => {
+    if (claimAppOpenedForVisit()) {
+      track("app_opened");
+    }
+  }, []);
+  return null;
+}

--- a/apps/web/src/components/stats/__tests__/stats-page.test.tsx
+++ b/apps/web/src/components/stats/__tests__/stats-page.test.tsx
@@ -76,6 +76,23 @@ const SAMPLE_STATS: PublicStats = {
     shares: 14,
     continueToLite: 11,
   },
+  filters: { surface: "all", container: "all" },
+  appOpens30d: 1500,
+  activation: [
+    { step: "app_opened", sessions: 1500 },
+    { step: "hub_viewed", sessions: 1200 },
+    { step: "exercise_started", sessions: 800 },
+    { step: "exercise_completed", sessions: 600 },
+    { step: "daily_focus_completed", sessions: 300 },
+  ],
+  topCountries: [
+    { country: "BR", sessions: 420 },
+    { country: "NG", sessions: 210 },
+  ],
+  retention: {
+    d1: { returned: 300, cohort: 1000 },
+    d7: { returned: 120, cohort: 900 },
+  },
 };
 
 describe("StatsPage", () => {
@@ -163,14 +180,19 @@ describe("StatsPage", () => {
     expect(screen.getByText("9.75")).toBeInTheDocument(); // cUSD
   });
 
-  it("keeps network fees + failed-tx + retention + countries in the Coming next lane", () => {
+  it("keeps indexer-gated metrics in the Coming next lane (retention D1/D7 + countries now ship)", () => {
     render(<StatsPage stats={SAMPLE_STATS} />);
     const comingNext = screen.getByText("Coming next").closest("div");
     expect(comingNext).not.toBeNull();
     expect(comingNext).toHaveTextContent(/network fees/i);
     expect(comingNext).toHaveTextContent(/failed transaction rate/i);
-    expect(comingNext).toHaveTextContent(/retention/i);
-    expect(comingNext).toHaveTextContent(/countries/i);
+    // Only the further-out D30 / D3 / D21 cohorts stay deferred.
+    expect(comingNext).toHaveTextContent(/retention d30/i);
+    // Top countries + D1/D7 are no longer deferred — they render in the
+    // Acquisition & Activation block above.
+    expect(comingNext).not.toHaveTextContent(/top countries/i);
+    expect(screen.getByText("App Opens (30d)")).toBeInTheDocument();
+    expect(screen.getByText(/Top countries · by sessions/)).toBeInTheDocument();
   });
 
   it("renders an em-dash for a null on-chain metric (failed query)", () => {
@@ -337,11 +359,12 @@ describe("StatsPage", () => {
     // Tracked today bullets (sample)
     expect(screen.getByText("App sessions")).toBeInTheDocument();
     expect(screen.getByText("Leaderboard scores")).toBeInTheDocument();
-    // Coming next bullets (sample) — network fees + failed-tx + retention
-    // + countries are the deliberately-deferred §8 metrics.
+    // Coming next bullets (sample) — network fees + failed-tx stay in the
+    // deferred lane (need an indexer). Retention D1/D7 + top countries now
+    // SHIP in the Acquisition & Activation block, so the deferred lane only
+    // mentions the further-out D30 / D3 / D21 cohorts.
     expect(screen.getByText(/Network fees paid/)).toBeInTheDocument();
-    expect(screen.getByText(/Retention cohorts/)).toBeInTheDocument();
-    expect(screen.getByText(/Top countries/)).toBeInTheDocument();
+    expect(screen.getByText(/Retention D30/)).toBeInTheDocument();
   });
 
   it("renders sections in visual-momentum order (Snapshot → Trend → Mix → Signals → Windows → Recent → Leaderboard → Tracked → Methodology)", () => {

--- a/apps/web/src/components/stats/stats-page.tsx
+++ b/apps/web/src/components/stats/stats-page.tsx
@@ -6,6 +6,227 @@ import type {
 import { StatCard } from "./stat-card";
 import { PlayerIdentityPill } from "@/components/identity/player-identity-pill";
 import { formatNickname, type NicknameTokens } from "@/lib/identity/identity-lite";
+import {
+  statsFiltersToQuery,
+  type ContainerFilter,
+  type StatsFilters,
+  type SurfaceFilter,
+} from "@/lib/stats/filters";
+import type {
+  ActivationFunnel,
+  CountryCount,
+  Retention,
+} from "@/lib/stats/funnels";
+
+const ACTIVATION_STEP_LABELS: Record<string, string> = {
+  app_opened: "App opened",
+  hub_viewed: "Hub viewed",
+  exercise_started: "Exercise started",
+  exercise_completed: "Exercise completed",
+  daily_focus_completed: "Daily Focus done",
+};
+
+const regionNames =
+  typeof Intl !== "undefined" && "DisplayNames" in Intl
+    ? new Intl.DisplayNames(["en"], { type: "region" })
+    : null;
+
+function countryLabel(code: string): string {
+  try {
+    return regionNames?.of(code) ?? code;
+  } catch {
+    return code;
+  }
+}
+
+/** Surface + container filters as plain links (no client JS, no global state):
+ *  each chip navigates to the same path with an updated querystring, keeping
+ *  the other filter intact. */
+function FilterControls({ filters }: { filters: StatsFilters }) {
+  const surfaceOptions: Array<{ value: SurfaceFilter; label: string }> = [
+    { value: "all", label: "All" },
+    { value: "learn", label: "Learn" },
+    { value: "play", label: "Play" },
+  ];
+  const containerOptions: Array<{ value: ContainerFilter; label: string }> = [
+    { value: "all", label: "All" },
+    { value: "minipay", label: "MiniPay" },
+    { value: "browser", label: "Browser" },
+  ];
+  const chip = (active: boolean, href: string, label: string, key: string) => (
+    <a
+      key={key}
+      href={href}
+      aria-current={active ? "true" : undefined}
+      className="rounded-full border px-3 py-1 text-xs font-semibold transition-colors"
+      style={{
+        borderColor: "var(--paper-divider)",
+        background: active ? "var(--paper-text)" : "rgba(255,255,255,0.6)",
+        color: active ? "var(--paper-bg, #fff)" : "var(--paper-text-muted)",
+      }}
+    >
+      {label}
+    </a>
+  );
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+      <div className="flex items-center gap-1.5">
+        <span
+          className="text-[0.625rem] font-semibold uppercase tracking-wide"
+          style={{ color: "var(--paper-text-subtle)" }}
+        >
+          Surface
+        </span>
+        {surfaceOptions.map((o) =>
+          chip(
+            filters.surface === o.value,
+            statsFiltersToQuery({ ...filters, surface: o.value }) || "?",
+            o.label,
+            `s-${o.value}`,
+          ),
+        )}
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span
+          className="text-[0.625rem] font-semibold uppercase tracking-wide"
+          style={{ color: "var(--paper-text-subtle)" }}
+        >
+          Container
+        </span>
+        {containerOptions.map((o) =>
+          chip(
+            filters.container === o.value,
+            statsFiltersToQuery({ ...filters, container: o.value }) || "?",
+            o.label,
+            `c-${o.value}`,
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Activation funnel: distinct sessions per canonical step, absolute counts
+ *  (no rates — a single session can read as 100% at early volume). */
+function ActivationFunnelChart({ funnel }: { funnel: ActivationFunnel }) {
+  const top = Math.max(1, ...funnel.map((s) => s.sessions));
+  return (
+    <div className="flex flex-col gap-1.5">
+      {funnel.map((s) => {
+        const pct = (s.sessions / top) * 100;
+        return (
+          <div key={s.step} className="flex items-center gap-2 text-xs">
+            <span
+              className="w-32 shrink-0"
+              style={{ color: "var(--paper-text-muted)" }}
+            >
+              {ACTIVATION_STEP_LABELS[s.step] ?? s.step}
+            </span>
+            <span
+              className="h-4 rounded"
+              style={{
+                width: `${Math.max(pct, s.sessions > 0 ? 3 : 0)}%`,
+                minWidth: s.sessions > 0 ? "0.5rem" : 0,
+                background: "rgba(58, 128, 148, 0.78)",
+              }}
+              aria-hidden
+            />
+            <span
+              className="tabular-nums font-semibold"
+              style={{ color: "var(--paper-text)" }}
+            >
+              {nf(s.sessions)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function TopCountriesList({ countries }: { countries: CountryCount[] }) {
+  if (countries.length === 0) {
+    return (
+      <p className="text-xs" style={{ color: "var(--paper-text-subtle)" }}>
+        No country data yet.
+      </p>
+    );
+  }
+  return (
+    <ul className="border-t" style={{ borderColor: "var(--paper-divider)" }}>
+      {countries.map((c) => (
+        <li
+          key={c.country}
+          className="flex items-center justify-between gap-2 border-b py-2 text-xs"
+          style={{
+            color: "var(--paper-text)",
+            borderColor: "var(--paper-divider)",
+          }}
+        >
+          <span>
+            {countryLabel(c.country)}{" "}
+            <span style={{ color: "var(--paper-text-subtle)" }}>
+              ({c.country})
+            </span>
+          </span>
+          <span
+            className="tabular-nums"
+            style={{ color: "var(--paper-text-muted)" }}
+          >
+            {nf(c.sessions)} {c.sessions === 1 ? "session" : "sessions"}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function retentionPct(returned: number, cohort: number): string {
+  if (cohort <= 0) return "—";
+  return `${Math.round((returned / cohort) * 100)}%`;
+}
+
+function RetentionCards({ retention }: { retention: Retention }) {
+  const cards: Array<{ label: string; b: Retention["d1"] }> = [
+    { label: "D1 retention", b: retention.d1 },
+    { label: "D7 retention", b: retention.d7 },
+  ];
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {cards.map(({ label, b }) => (
+        <div
+          key={label}
+          className="flex flex-col gap-1 rounded-xl border px-4 py-3"
+          style={{
+            background: "rgba(255,255,255,0.92)",
+            borderColor: "var(--paper-divider)",
+          }}
+        >
+          <span
+            className="text-[0.625rem] font-semibold uppercase tracking-wide"
+            style={{ color: "var(--paper-text-subtle)" }}
+          >
+            {label}
+          </span>
+          <span
+            className="text-xl font-bold tabular-nums"
+            style={{ color: "var(--paper-text)" }}
+          >
+            {retentionPct(b.returned, b.cohort)}
+          </span>
+          <span
+            className="text-[0.625rem]"
+            style={{ color: "var(--paper-text-subtle)" }}
+          >
+            {b.cohort > 0
+              ? `${nf(b.returned)} of ${nf(b.cohort)} installs returned`
+              : "Not enough cohort data yet"}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 type StatsPageProps = {
   stats: PublicStats;
@@ -304,8 +525,8 @@ const TRACKED_TODAY: ReadonlyArray<string> = [
 const COMING_NEXT: ReadonlyArray<string> = [
   "Network fees paid (needs indexer)",
   "Failed transaction rate (needs indexer)",
-  "Retention cohorts · D1 / D7 / D30 (needs web analytics)",
-  "Top countries (needs web analytics)",
+  "Retention D30 · D3 / D21 cohorts",
+  "Monetization funnel · server-confirmed purchases",
 ];
 
 /** §8 method-tx rows: label + the OnchainMethodTx key it reads. Column
@@ -366,6 +587,7 @@ export function StatsPage({ stats, nicknameTokens }: StatsPageProps) {
             {formatGeneratedAt(stats.generatedAt)}
           </span>
         </p>
+        <FilterControls filters={stats.filters} />
       </header>
 
       {/* Executive Snapshot — vital-signs cockpit. Three hero tiles
@@ -392,6 +614,90 @@ export function StatsPage({ stats, nicknameTokens }: StatsPageProps) {
           sublabel="Saves in the last 30 days"
           variant="hero"
         />
+      </section>
+
+      {/* Acquisition & Activation — the core "¿Llegan? ¿Entienden?
+          ¿Entrenan? ¿Vuelven?" block. All four sub-blocks honor the
+          surface/container filters above. Absolute counts, no rates on
+          the funnel (a single session reads as 100% at early volume). */}
+      <section className="space-y-5">
+        <div>
+          <h3
+            className="mb-1 text-base font-bold md:text-lg"
+            style={{ color: "var(--paper-text)" }}
+          >
+            Acquisition &amp; Activation
+          </h3>
+          <p
+            className="text-[0.6875rem] leading-tight"
+            style={{ color: "var(--paper-text-subtle)" }}
+          >
+            App opens, the activation funnel, top countries, and D1/D7
+            retention — last 30 days
+            {stats.filters.surface !== "all" || stats.filters.container !== "all"
+              ? `, filtered by ${[
+                  stats.filters.surface !== "all" ? stats.filters.surface : null,
+                  stats.filters.container !== "all"
+                    ? stats.filters.container
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}`
+              : ""}
+            .
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <StatCard
+            label="App Opens (30d)"
+            value={stats.appOpens30d}
+            sublabel="Distinct sessions that opened the app"
+            variant="hero"
+          />
+        </div>
+
+        {stats.activation ? (
+          <div>
+            <p
+              className="mb-2 text-[0.625rem] font-semibold uppercase tracking-wide"
+              style={{ color: "var(--paper-text-subtle)" }}
+            >
+              Activation funnel · distinct sessions
+            </p>
+            <ActivationFunnelChart funnel={stats.activation} />
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+          <div>
+            <p
+              className="mb-2 text-[0.625rem] font-semibold uppercase tracking-wide"
+              style={{ color: "var(--paper-text-subtle)" }}
+            >
+              Top countries · by sessions
+            </p>
+            <TopCountriesList countries={stats.topCountries} />
+          </div>
+          <div>
+            <p
+              className="mb-2 text-[0.625rem] font-semibold uppercase tracking-wide"
+              style={{ color: "var(--paper-text-subtle)" }}
+            >
+              Retention
+            </p>
+            {stats.retention ? (
+              <RetentionCards retention={stats.retention} />
+            ) : (
+              <p
+                className="text-xs"
+                style={{ color: "var(--paper-text-subtle)" }}
+              >
+                Retention data unavailable.
+              </p>
+            )}
+          </div>
+        </div>
       </section>
 
       {/* Activity trend chart — first visual right after Snapshot so

--- a/apps/web/src/lib/analytics/__tests__/attribution.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/attribution.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getAttribution } from "../attribution";
+
+const KEY = "chesscito:attribution";
+
+function setUrl(search: string) {
+  // jsdom lets us rewrite location.search via history.
+  window.history.replaceState({}, "", `/${search ? `?${search}` : ""}`);
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+  setUrl("");
+});
+
+describe("getAttribution", () => {
+  it("defaults to direct with no params and persists first-touch", () => {
+    expect(getAttribution()).toEqual({ source: "direct", campaign: null });
+    expect(window.localStorage.getItem(KEY)).toBe(
+      JSON.stringify({ source: "direct", campaign: null }),
+    );
+  });
+
+  it("normalizes utm params on first touch", () => {
+    setUrl("utm_source=whatsapp&utm_campaign=Launch_2026");
+    expect(getAttribution()).toEqual({
+      source: "share_whatsapp",
+      campaign: "launch_2026",
+    });
+  });
+
+  it("is first-touch: a later visit with new params keeps the original", () => {
+    setUrl("source=minipay");
+    getAttribution(); // persists minipay_discovery
+    setUrl("source=qr"); // second visit, different param
+    expect(getAttribution().source).toBe("minipay_discovery");
+  });
+
+  it("collapses unrecognized source to unknown and drops bad campaign", () => {
+    setUrl("source=affiliate_x9&campaign=drop%20table");
+    expect(getAttribution()).toEqual({ source: "unknown", campaign: null });
+  });
+});

--- a/apps/web/src/lib/analytics/__tests__/canonical-events.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/canonical-events.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVATION_FUNNEL,
+  ALL_FUNNEL_ALIASES,
+  canonicalEventFor,
+} from "../canonical-events";
+
+describe("canonicalEventFor", () => {
+  it("maps every completion alias to exercise_completed", () => {
+    for (const alias of [
+      "exercise_complete",
+      "training_exercise_completed",
+      "play_tactics_completed",
+      "exercise_completed",
+    ]) {
+      expect(canonicalEventFor(alias)).toBe("exercise_completed");
+    }
+  });
+
+  it("maps hub view aliases and daily focus alias", () => {
+    expect(canonicalEventFor("hub_view")).toBe("hub_viewed");
+    expect(canonicalEventFor("play_hub_view")).toBe("hub_viewed");
+    expect(canonicalEventFor("daily_tactic_completed")).toBe(
+      "daily_focus_completed",
+    );
+  });
+
+  it("returns null for non-funnel events (no accidental capture)", () => {
+    expect(canonicalEventFor("share_tile_tap")).toBeNull();
+    expect(canonicalEventFor("pro_purchase_confirmed")).toBeNull();
+  });
+});
+
+describe("funnel shape", () => {
+  it("has 5 ordered steps starting at app_opened", () => {
+    expect(ACTIVATION_FUNNEL).toEqual([
+      "app_opened",
+      "hub_viewed",
+      "exercise_started",
+      "exercise_completed",
+      "daily_focus_completed",
+    ]);
+  });
+
+  it("alias list is de-duplicated", () => {
+    expect(ALL_FUNNEL_ALIASES.length).toBe(new Set(ALL_FUNNEL_ALIASES).size);
+  });
+});

--- a/apps/web/src/lib/analytics/__tests__/client-dimensions.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/client-dimensions.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { localeFromPath } from "../client-dimensions";
+
+describe("localeFromPath", () => {
+  it("maps the first path segment to a locale, defaulting to en", () => {
+    expect(localeFromPath("/es/hub")).toBe("es");
+    expect(localeFromPath("/hub")).toBe("en"); // bare root = en
+    expect(localeFromPath("/")).toBe("en");
+    expect(localeFromPath("/fr/hub")).toBe("en"); // unknown locale → en
+  });
+});
+
+describe("clientDimensions fail-open", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@/lib/minipay");
+  });
+
+  it("returns a safe fallback and never throws when a source throws", async () => {
+    vi.doMock("@/lib/minipay", () => ({
+      isMiniPayEnv: () => {
+        throw new Error("boom");
+      },
+    }));
+    const { clientDimensions } = await import("../client-dimensions");
+    expect(() => clientDimensions()).not.toThrow();
+    const d = clientDimensions();
+    expect(d.container).toBe("browser");
+    expect(d.source).toBe("direct");
+    expect(d.app_version).toBe("dev");
+  });
+});

--- a/apps/web/src/lib/analytics/__tests__/dimensions.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/dimensions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeAppVersion,
+  normalizeCampaign,
+  normalizeContainer,
+  normalizeCountry,
+  normalizeLocale,
+  normalizeSource,
+  normalizeSurface,
+} from "../dimensions";
+
+describe("normalizeSurface", () => {
+  it("accepts learn/play/full, rejects anything else", () => {
+    expect(normalizeSurface("learn")).toBe("learn");
+    expect(normalizeSurface("play")).toBe("play");
+    expect(normalizeSurface("full")).toBe("full");
+    expect(normalizeSurface("marketing")).toBeNull();
+    expect(normalizeSurface(null)).toBeNull();
+    expect(normalizeSurface(42)).toBeNull();
+  });
+});
+
+describe("normalizeContainer", () => {
+  it("accepts only minipay/browser", () => {
+    expect(normalizeContainer("minipay")).toBe("minipay");
+    expect(normalizeContainer("browser")).toBe("browser");
+    expect(normalizeContainer("metamask")).toBeNull();
+  });
+});
+
+describe("normalizeLocale", () => {
+  it("allow-lists en/es case-insensitively", () => {
+    expect(normalizeLocale("en")).toBe("en");
+    expect(normalizeLocale("ES")).toBe("es");
+    expect(normalizeLocale("fr")).toBeNull();
+    expect(normalizeLocale("english")).toBeNull();
+  });
+});
+
+describe("normalizeCountry", () => {
+  it("returns ISO alpha-2 upper, rejects junk / placeholders", () => {
+    expect(normalizeCountry("us")).toBe("US");
+    expect(normalizeCountry("BR")).toBe("BR");
+    expect(normalizeCountry("XX")).toBeNull(); // edge unknown placeholder
+    expect(normalizeCountry("USA")).toBeNull();
+    expect(normalizeCountry("1.2.3.4")).toBeNull();
+    expect(normalizeCountry(null)).toBeNull();
+  });
+});
+
+describe("normalizeAppVersion", () => {
+  it("accepts short sha / dev, rejects long or symbol-laden", () => {
+    expect(normalizeAppVersion("a1b2c3d")).toBe("a1b2c3d");
+    expect(normalizeAppVersion("dev")).toBe("dev");
+    expect(normalizeAppVersion("feature/x")).toBeNull();
+    expect(normalizeAppVersion("0123456789abc")).toBeNull(); // 13 chars
+  });
+});
+
+describe("normalizeSource", () => {
+  it("maps aliases to canonical vocabulary", () => {
+    expect(normalizeSource("minipay")).toBe("minipay_discovery");
+    expect(normalizeSource("WhatsApp")).toBe("share_whatsapp");
+    expect(normalizeSource("challenge")).toBe("challenge_link");
+    expect(normalizeSource("qr")).toBe("qr");
+    expect(normalizeSource("direct")).toBe("direct");
+  });
+  it("returns null when absent, unknown when present-but-unrecognized", () => {
+    expect(normalizeSource(null)).toBeNull();
+    expect(normalizeSource("")).toBeNull();
+    expect(normalizeSource("weird-affiliate-123")).toBe("unknown");
+  });
+});
+
+describe("normalizeCampaign", () => {
+  it("sanitizes to a bounded slug or null", () => {
+    expect(normalizeCampaign("launch_2026")).toBe("launch_2026");
+    expect(normalizeCampaign("Summer-Push")).toBe("summer-push");
+    expect(normalizeCampaign("drop table users;")).toBeNull();
+    expect(normalizeCampaign("x".repeat(33))).toBeNull();
+    expect(normalizeCampaign(null)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/analytics/__tests__/identity.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/identity.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  claimAppOpenedForVisit,
+  getAnonymousId,
+  getVisitId,
+} from "../identity";
+
+const ANON_KEY = "chesscito:analytics-session";
+const VISIT_KEY = "chesscito:visit-id";
+const APP_OPENED_KEY = "chesscito:app-opened-fired";
+
+afterEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe("getAnonymousId", () => {
+  it("persists a stable id across calls", () => {
+    const a = getAnonymousId();
+    const b = getAnonymousId();
+    expect(a).not.toBe("");
+    expect(a).toBe(b);
+    expect(window.localStorage.getItem(ANON_KEY)).toBe(a);
+  });
+
+  it("reuses the pre-existing session_id value (backward compatible)", () => {
+    window.localStorage.setItem(ANON_KEY, "legacyvalue1234");
+    expect(getAnonymousId()).toBe("legacyvalue1234");
+  });
+
+  it("lives in localStorage, not sessionStorage (persists across visits)", () => {
+    const id = getAnonymousId();
+    expect(window.sessionStorage.getItem(ANON_KEY)).toBeNull();
+    expect(window.localStorage.getItem(ANON_KEY)).toBe(id);
+  });
+});
+
+describe("getVisitId", () => {
+  it("is stable within a visit", () => {
+    const a = getVisitId();
+    const b = getVisitId();
+    expect(a).not.toBe("");
+    expect(a).toBe(b);
+    expect(window.sessionStorage.getItem(VISIT_KEY)).toBe(a);
+  });
+
+  it("lives in sessionStorage so a new visit gets a fresh id", () => {
+    const first = getVisitId();
+    window.sessionStorage.clear(); // simulate new tab / visit
+    const second = getVisitId();
+    expect(second).not.toBe(first);
+  });
+
+  it("is independent from the anonymous id", () => {
+    const anon = getAnonymousId();
+    const visit = getVisitId();
+    expect(visit).not.toBe(anon);
+  });
+});
+
+describe("claimAppOpenedForVisit", () => {
+  it("returns true exactly once per visit, then false", () => {
+    expect(claimAppOpenedForVisit()).toBe(true);
+    expect(claimAppOpenedForVisit()).toBe(false);
+    expect(claimAppOpenedForVisit()).toBe(false);
+    expect(window.sessionStorage.getItem(APP_OPENED_KEY)).toBe("1");
+  });
+
+  it("re-arms for a new visit (sessionStorage cleared)", () => {
+    expect(claimAppOpenedForVisit()).toBe(true);
+    window.sessionStorage.clear();
+    expect(claimAppOpenedForVisit()).toBe(true);
+  });
+});

--- a/apps/web/src/lib/analytics/attribution.ts
+++ b/apps/web/src/lib/analytics/attribution.ts
@@ -1,0 +1,46 @@
+import { normalizeCampaign, normalizeSource, type Source } from "./dimensions";
+
+/**
+ * First-touch acquisition attribution.
+ *
+ * On the first call in an install, reads `utm_source`/`source` and
+ * `utm_campaign`/`campaign` from the current URL, normalizes them through the
+ * allow-list, and PERSISTS the result to localStorage so every later visit
+ * keeps the ORIGINAL acquisition source (first-touch, not last-touch). A total
+ * absence of params on first touch resolves to `direct`.
+ *
+ * We persist only the normalized {source, campaign} — never the raw referrer,
+ * URL, or arbitrary query params. SSR-safe and storage-error-safe.
+ */
+
+const ATTRIBUTION_KEY = "chesscito:attribution";
+
+export type Attribution = { source: Source; campaign: string | null };
+
+const DEFAULT: Attribution = { source: "direct", campaign: null };
+
+export function getAttribution(): Attribution {
+  if (typeof window === "undefined") return DEFAULT;
+  try {
+    const stored = window.localStorage.getItem(ATTRIBUTION_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored) as Partial<Attribution>;
+      return {
+        source: normalizeSource(parsed.source) ?? "direct",
+        campaign: normalizeCampaign(parsed.campaign),
+      };
+    }
+    const params = new URLSearchParams(window.location.search);
+    const source =
+      normalizeSource(params.get("utm_source") ?? params.get("source")) ??
+      "direct";
+    const campaign = normalizeCampaign(
+      params.get("utm_campaign") ?? params.get("campaign"),
+    );
+    const attribution: Attribution = { source, campaign };
+    window.localStorage.setItem(ATTRIBUTION_KEY, JSON.stringify(attribution));
+    return attribution;
+  } catch {
+    return DEFAULT;
+  }
+}

--- a/apps/web/src/lib/analytics/canonical-events.ts
+++ b/apps/web/src/lib/analytics/canonical-events.ts
@@ -1,0 +1,60 @@
+/**
+ * Canonical activation-funnel event vocabulary + backward-compatible shim.
+ *
+ * The catalog has ~120 historical event names and several that mean the same
+ * thing (`exercise_complete` vs `training_exercise_completed` vs
+ * `play_tactics_completed`). Rather than rename ~120 call sites (out of scope)
+ * or double-write canonical events (which would risk double-counting), we map
+ * aliases → canonical at READ time. The canonical names below are the query
+ * vocabulary for funnels; each one is fed by the union of its aliases.
+ *
+ * Only the 5 activation-funnel steps are normalized here. Everything else keeps
+ * its existing name.
+ */
+
+export const CANONICAL_EVENTS = {
+  app_opened: ["app_opened"],
+  hub_viewed: ["hub_viewed", "hub_view", "play_hub_view"],
+  exercise_started: [
+    "exercise_started",
+    "training_exercise_started",
+    "daily_tactic_started",
+    "play_tactics_opened",
+  ],
+  exercise_completed: [
+    "exercise_completed",
+    "exercise_complete",
+    "training_exercise_completed",
+    "play_tactics_completed",
+  ],
+  daily_focus_completed: ["daily_focus_completed", "daily_tactic_completed"],
+} as const;
+
+export type CanonicalEvent = keyof typeof CANONICAL_EVENTS;
+
+/** Ordered funnel steps (activation). */
+export const ACTIVATION_FUNNEL: readonly CanonicalEvent[] = [
+  "app_opened",
+  "hub_viewed",
+  "exercise_started",
+  "exercise_completed",
+  "daily_focus_completed",
+];
+
+/** Flat list of every raw event name that feeds any canonical step — for a
+ *  single `in (...)` query. */
+export const ALL_FUNNEL_ALIASES: readonly string[] = Array.from(
+  new Set(Object.values(CANONICAL_EVENTS).flat()),
+);
+
+const ALIAS_TO_CANONICAL: Record<string, CanonicalEvent> = Object.fromEntries(
+  Object.entries(CANONICAL_EVENTS).flatMap(([canonical, aliases]) =>
+    aliases.map((alias) => [alias, canonical as CanonicalEvent]),
+  ),
+);
+
+/** Raw event name → canonical funnel step, or `null` if it is not a funnel
+ *  event. */
+export function canonicalEventFor(event: string): CanonicalEvent | null {
+  return ALIAS_TO_CANONICAL[event] ?? null;
+}

--- a/apps/web/src/lib/analytics/client-dimensions.ts
+++ b/apps/web/src/lib/analytics/client-dimensions.ts
@@ -27,17 +27,33 @@ export function localeFromPath(pathname: string): Locale {
   return normalizeLocale(seg) ?? "en";
 }
 
+/** Safe fallback used if ANY dimension source throws. Telemetry is fail-open:
+ *  a broken dimension must never propagate into the business flow. */
+const FALLBACK_DIMENSIONS: ClientDimensions = {
+  visit_id: "",
+  surface: null,
+  container: "browser",
+  locale: "en",
+  source: "direct",
+  campaign: null,
+  app_version: "dev",
+};
+
 export function clientDimensions(): ClientDimensions {
-  const attribution = getAttribution();
-  const pathname =
-    typeof window === "undefined" ? "/" : window.location.pathname;
-  return {
-    visit_id: getVisitId(),
-    surface: normalizeSurface(CHESSCITO_MODE),
-    container: isMiniPayEnv() ? "minipay" : "browser",
-    locale: localeFromPath(pathname),
-    source: attribution.source,
-    campaign: attribution.campaign,
-    app_version: process.env.NEXT_PUBLIC_BUILD_SHA ?? "dev",
-  };
+  try {
+    const attribution = getAttribution();
+    const pathname =
+      typeof window === "undefined" ? "/" : window.location.pathname;
+    return {
+      visit_id: getVisitId(),
+      surface: normalizeSurface(CHESSCITO_MODE),
+      container: isMiniPayEnv() ? "minipay" : "browser",
+      locale: localeFromPath(pathname),
+      source: attribution.source,
+      campaign: attribution.campaign,
+      app_version: process.env.NEXT_PUBLIC_BUILD_SHA ?? "dev",
+    };
+  } catch {
+    return { ...FALLBACK_DIMENSIONS };
+  }
 }

--- a/apps/web/src/lib/analytics/client-dimensions.ts
+++ b/apps/web/src/lib/analytics/client-dimensions.ts
@@ -1,0 +1,43 @@
+import { CHESSCITO_MODE } from "@/lib/feature-flags";
+import { isMiniPayEnv } from "@/lib/minipay";
+import { getAttribution } from "./attribution";
+import { getVisitId } from "./identity";
+import { normalizeLocale, normalizeSurface, type Locale } from "./dimensions";
+
+/**
+ * Client-stamped analytics dimensions attached to every event.
+ *
+ * `country` is deliberately ABSENT — it is resolved server-side from the edge
+ * geo header (privacy: the client must never see or send geo). Everything here
+ * is cheap, synchronous, and SSR-safe via the underlying accessors.
+ */
+export type ClientDimensions = {
+  visit_id: string;
+  surface: string | null;
+  container: "minipay" | "browser";
+  locale: Locale;
+  source: string;
+  campaign: string | null;
+  app_version: string;
+};
+
+/** First path segment → locale; the bare root (no locale prefix) is `en`. */
+export function localeFromPath(pathname: string): Locale {
+  const seg = pathname.split("/")[1] ?? "";
+  return normalizeLocale(seg) ?? "en";
+}
+
+export function clientDimensions(): ClientDimensions {
+  const attribution = getAttribution();
+  const pathname =
+    typeof window === "undefined" ? "/" : window.location.pathname;
+  return {
+    visit_id: getVisitId(),
+    surface: normalizeSurface(CHESSCITO_MODE),
+    container: isMiniPayEnv() ? "minipay" : "browser",
+    locale: localeFromPath(pathname),
+    source: attribution.source,
+    campaign: attribution.campaign,
+    app_version: process.env.NEXT_PUBLIC_BUILD_SHA ?? "dev",
+  };
+}

--- a/apps/web/src/lib/analytics/dimensions.ts
+++ b/apps/web/src/lib/analytics/dimensions.ts
@@ -1,0 +1,108 @@
+/**
+ * Analytics dimension normalizers + allow-lists.
+ *
+ * PURE (no window, no env, no React) so the SAME rules run on the client (to
+ * stamp events) and on the server (to sanitize, defense-in-depth). Every
+ * normalizer returns a canonical low-cardinality value or `null` — never the
+ * raw input — which is what keeps the dimensions safe to index and group, and
+ * what keeps referrer/URL junk out of the database.
+ *
+ * Privacy: `country` is ISO-3166-1 alpha-2 ONLY. `source`/`campaign` are
+ * allow-listed; a raw referrer or arbitrary query string can never survive.
+ */
+
+export const SURFACES = ["learn", "play", "full"] as const;
+export type Surface = (typeof SURFACES)[number];
+
+export const CONTAINERS = ["minipay", "browser"] as const;
+export type Container = (typeof CONTAINERS)[number];
+
+/** Mirrors i18n/routing locales. Kept as a literal so this module stays pure
+ *  (importing routing would drag server-only deps into the client bundle). */
+export const LOCALES = ["en", "es"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+/** Small canonical source vocabulary. Anything recognized-but-off-list becomes
+ *  `unknown`; a total absence of attribution becomes `direct` (see attribution
+ *  module). This bounds cardinality by construction. */
+export const SOURCES = [
+  "direct",
+  "minipay_discovery",
+  "challenge_link",
+  "share_whatsapp",
+  "share_generic",
+  "qr",
+  "unknown",
+] as const;
+export type Source = (typeof SOURCES)[number];
+
+/** Raw utm/source aliases → canonical Source. */
+const SOURCE_ALIASES: Record<string, Source> = {
+  direct: "direct",
+  minipay: "minipay_discovery",
+  minipay_discovery: "minipay_discovery",
+  discovery: "minipay_discovery",
+  challenge: "challenge_link",
+  challenge_link: "challenge_link",
+  whatsapp: "share_whatsapp",
+  wa: "share_whatsapp",
+  share: "share_generic",
+  share_generic: "share_generic",
+  qr: "qr",
+};
+
+function asString(raw: unknown): string | null {
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+export function normalizeSurface(raw: unknown): Surface | null {
+  const s = asString(raw);
+  return s && (SURFACES as readonly string[]).includes(s) ? (s as Surface) : null;
+}
+
+export function normalizeContainer(raw: unknown): Container | null {
+  const s = asString(raw);
+  return s && (CONTAINERS as readonly string[]).includes(s)
+    ? (s as Container)
+    : null;
+}
+
+export function normalizeLocale(raw: unknown): Locale | null {
+  const s = asString(raw)?.toLowerCase();
+  return s && (LOCALES as readonly string[]).includes(s) ? (s as Locale) : null;
+}
+
+/** ISO-3166-1 alpha-2, upper-cased. `null` for anything else (incl. the edge's
+ *  "XX"/"T1" placeholders for unknown/anonymized geo). */
+export function normalizeCountry(raw: unknown): string | null {
+  const s = asString(raw)?.toUpperCase();
+  return s && /^[A-Z]{2}$/.test(s) && s !== "XX" ? s : null;
+}
+
+/** Build sha (7 hex) or 'dev'. Bounded to keep cardinality ~ number of deploys. */
+export function normalizeAppVersion(raw: unknown): string | null {
+  const s = asString(raw)?.toLowerCase();
+  return s && /^[a-z0-9]{1,12}$/.test(s) ? s : null;
+}
+
+/**
+ * Map a raw source token to the canonical vocabulary.
+ *  - absent  → `null` (caller decides direct vs unchanged)
+ *  - known   → canonical
+ *  - present but unrecognized → `unknown`
+ */
+export function normalizeSource(raw: unknown): Source | null {
+  const s = asString(raw)?.toLowerCase().trim();
+  if (!s) return null;
+  // Idempotent on already-canonical values (client stamps canonical, server
+  // re-sanitizes) — then alias mapping — then a bounded `unknown` fallback.
+  if ((SOURCES as readonly string[]).includes(s)) return s as Source;
+  return SOURCE_ALIASES[s] ?? "unknown";
+}
+
+/** Sanitized campaign slug: lowercase `[a-z0-9_-]`, ≤32 chars, else `null`.
+ *  Never stores a raw referrer or arbitrary query value. */
+export function normalizeCampaign(raw: unknown): string | null {
+  const s = asString(raw)?.toLowerCase().trim();
+  return s && /^[a-z0-9_-]{1,32}$/.test(s) ? s : null;
+}

--- a/apps/web/src/lib/analytics/identity.ts
+++ b/apps/web/src/lib/analytics/identity.ts
@@ -1,0 +1,79 @@
+/**
+ * Analytics identity primitives.
+ *
+ * Two distinct notions, resolved by the observability audit
+ * (docs/audits/2026-07-23-product-observability-audit.md):
+ *
+ *  - anonymousId — PERSISTENT, per-install identity. Lives in localStorage,
+ *    never rotates. Powers retention / cohorts (D1/D7/D30) and unique-user
+ *    counts. This is the SAME value historically written as `session_id`,
+ *    so existing rows stay comparable (no migration, no rename).
+ *  - visitId — per-VISIT identity. Lives in sessionStorage, so it is fresh
+ *    for each tab / visit and dies when the tab closes. Powers app_opened
+ *    (once-per-visit) and per-visit funnels.
+ *
+ * All accessors are SSR-safe (return "" on the server) and swallow storage
+ * errors (private mode / disabled storage) so analytics never throws into a
+ * user-visible flow.
+ */
+
+/** Unchanged from the original telemetry module — renaming would force a
+ *  migration and break comparability with historical rows. */
+const ANONYMOUS_ID_KEY = "chesscito:analytics-session";
+const VISIT_ID_KEY = "chesscito:visit-id";
+const APP_OPENED_KEY = "chesscito:app-opened-fired";
+
+function randomHex(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  window.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Persistent anonymous install id. Empty string on the server or when
+ *  storage is unavailable. */
+export function getAnonymousId(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const existing = window.localStorage.getItem(ANONYMOUS_ID_KEY);
+    if (existing) return existing;
+    const id = randomHex(8); // ~64 bits — fits well under the 64-char column
+    window.localStorage.setItem(ANONYMOUS_ID_KEY, id);
+    return id;
+  } catch {
+    return "";
+  }
+}
+
+/** Per-visit id (sessionStorage). Fresh for each tab / visit. Empty string on
+ *  the server or when storage is unavailable. */
+export function getVisitId(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const existing = window.sessionStorage.getItem(VISIT_ID_KEY);
+    if (existing) return existing;
+    const id = randomHex(8);
+    window.sessionStorage.setItem(VISIT_ID_KEY, id);
+    return id;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Returns `true` exactly once per visit (per tab session): the first call in a
+ * visit flips a sessionStorage guard and returns `true`; every later call in
+ * the same visit returns `false`. This survives React StrictMode double-invoke,
+ * remounts, and client navigation. On the server or when storage is
+ * unavailable it returns `false` (never emits) so `app_opened` can neither fire
+ * from SSR nor leak duplicates.
+ */
+export function claimAppOpenedForVisit(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (window.sessionStorage.getItem(APP_OPENED_KEY)) return false;
+    window.sessionStorage.setItem(APP_OPENED_KEY, "1");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/lib/stats/__tests__/funnels.test.ts
+++ b/apps/web/src/lib/stats/__tests__/funnels.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeActivation,
+  computeRetention,
+  computeTopCountries,
+} from "../funnels";
+import { parseStatsFilters, statsFiltersToQuery } from "../filters";
+
+describe("computeActivation", () => {
+  it("counts distinct sessions per canonical step (aliases folded in)", () => {
+    const funnel = computeActivation([
+      { event: "app_opened", session_id: "a" },
+      { event: "app_opened", session_id: "b" },
+      { event: "hub_view", session_id: "a" }, // alias → hub_viewed
+      { event: "play_hub_view", session_id: "b" }, // alias → hub_viewed
+      { event: "exercise_complete", session_id: "a" }, // alias
+      { event: "training_exercise_completed", session_id: "a" }, // same session, alias
+    ]);
+    const byStep = Object.fromEntries(funnel.map((s) => [s.step, s.sessions]));
+    expect(byStep.app_opened).toBe(2);
+    expect(byStep.hub_viewed).toBe(2);
+    expect(byStep.exercise_completed).toBe(1); // session a counted once
+    expect(byStep.daily_focus_completed).toBe(0);
+  });
+
+  it("ignores non-funnel events", () => {
+    const funnel = computeActivation([
+      { event: "share_tile_tap", session_id: "a" },
+    ]);
+    expect(funnel.every((s) => s.sessions === 0)).toBe(true);
+  });
+});
+
+describe("computeTopCountries", () => {
+  it("ranks distinct sessions per country, excludes null", () => {
+    const top = computeTopCountries([
+      { country: "BR", session_id: "a" },
+      { country: "BR", session_id: "b" },
+      { country: "BR", session_id: "a" }, // dup session
+      { country: "US", session_id: "c" },
+      { country: null, session_id: "d" }, // excluded
+    ]);
+    expect(top[0]).toEqual({ country: "BR", sessions: 2 });
+    expect(top[1]).toEqual({ country: "US", sessions: 1 });
+    expect(top.find((c) => c.country === null as never)).toBeUndefined();
+  });
+});
+
+describe("computeRetention", () => {
+  const now = new Date("2026-07-23T12:00:00.000Z");
+  it("counts D1 returns on the exact next calendar day", () => {
+    // cohort install first seen 2 days ago (age 2, within [1,8])
+    const firstSeen = [{ session_id: "a", first_seen: "2026-07-21T09:00:00Z" }];
+    const activity = [
+      { session_id: "a", created_at: "2026-07-21T09:00:00Z" }, // day 0
+      { session_id: "a", created_at: "2026-07-22T08:00:00Z" }, // day +1 → retained
+    ];
+    const r = computeRetention(firstSeen, activity, now);
+    expect(r.d1).toEqual({ returned: 1, cohort: 1 });
+  });
+
+  it("does not count an install too young for the offset", () => {
+    // first seen today (age 0) → not eligible for D1 cohort yet
+    const firstSeen = [{ session_id: "a", first_seen: "2026-07-23T09:00:00Z" }];
+    const r = computeRetention(firstSeen, [], now);
+    expect(r.d1.cohort).toBe(0);
+  });
+
+  it("D7 cohort requires 7+ days elapsed", () => {
+    const firstSeen = [
+      { session_id: "a", first_seen: "2026-07-15T09:00:00Z" }, // age 8 → in [7,14]
+    ];
+    const activity = [
+      { session_id: "a", created_at: "2026-07-22T09:00:00Z" }, // day +7 → retained
+    ];
+    const r = computeRetention(firstSeen, activity, now);
+    expect(r.d7).toEqual({ returned: 1, cohort: 1 });
+  });
+});
+
+describe("parseStatsFilters", () => {
+  it("allow-lists values with `all` fallback", () => {
+    expect(parseStatsFilters({ surface: "learn", container: "minipay" })).toEqual({
+      surface: "learn",
+      container: "minipay",
+    });
+    expect(parseStatsFilters({ surface: "hacker", container: "" })).toEqual({
+      surface: "all",
+      container: "all",
+    });
+    expect(parseStatsFilters({})).toEqual({ surface: "all", container: "all" });
+  });
+
+  it("serializes non-default filters, omits all", () => {
+    expect(statsFiltersToQuery({ surface: "learn", container: "all" })).toBe(
+      "?surface=learn",
+    );
+    expect(statsFiltersToQuery({ surface: "all", container: "all" })).toBe("");
+  });
+});

--- a/apps/web/src/lib/stats/filters.ts
+++ b/apps/web/src/lib/stats/filters.ts
@@ -1,0 +1,48 @@
+/**
+ * /stats surface + container filters (querystring, server-side re-aggregation).
+ *
+ * Allow-listed with an `all` fallback — an unknown value never leaks into a
+ * query; it collapses to `all`. The filters are applied CONSISTENTLY across
+ * every /stats block (app opens, activation, top countries, retention).
+ */
+
+export type SurfaceFilter = "all" | "learn" | "play";
+export type ContainerFilter = "all" | "minipay" | "browser";
+export type StatsFilters = { surface: SurfaceFilter; container: ContainerFilter };
+
+export const DEFAULT_STATS_FILTERS: StatsFilters = {
+  surface: "all",
+  container: "all",
+};
+
+const SURFACE_VALUES = new Set<SurfaceFilter>(["all", "learn", "play"]);
+const CONTAINER_VALUES = new Set<ContainerFilter>([
+  "all",
+  "minipay",
+  "browser",
+]);
+
+function firstStr(v: string | string[] | undefined): string {
+  return (Array.isArray(v) ? v[0] : v) ?? "";
+}
+
+export function parseStatsFilters(searchParams: {
+  surface?: string | string[];
+  container?: string | string[];
+}): StatsFilters {
+  const s = firstStr(searchParams.surface) as SurfaceFilter;
+  const c = firstStr(searchParams.container) as ContainerFilter;
+  return {
+    surface: SURFACE_VALUES.has(s) ? s : "all",
+    container: CONTAINER_VALUES.has(c) ? c : "all",
+  };
+}
+
+/** Build a `?surface=&container=` querystring, omitting `all` (the default) so
+ *  the canonical URL stays clean. */
+export function statsFiltersToQuery(filters: StatsFilters): string {
+  const parts: string[] = [];
+  if (filters.surface !== "all") parts.push(`surface=${filters.surface}`);
+  if (filters.container !== "all") parts.push(`container=${filters.container}`);
+  return parts.length ? `?${parts.join("&")}` : "";
+}

--- a/apps/web/src/lib/stats/funnels.ts
+++ b/apps/web/src/lib/stats/funnels.ts
@@ -1,0 +1,124 @@
+import {
+  ACTIVATION_FUNNEL,
+  canonicalEventFor,
+  type CanonicalEvent,
+} from "@/lib/analytics/canonical-events";
+
+/**
+ * Pure derivations for the /stats activation, top-countries, and retention
+ * blocks. All operate over already-fetched, already-filtered rows so they are
+ * trivially testable and carry no DB coupling.
+ *
+ * Counts are DISTINCT sessions (anonymous installs) per step — a proper funnel
+ * denominator-free absolute, matching the "conteos absolutos, sin rates"
+ * decision for funnels. Retention returns returned + cohort counts so the view
+ * can show "X of Y" and derive a rate without the aggregator asserting one.
+ */
+
+export type ActivationStep = { step: CanonicalEvent; sessions: number };
+export type ActivationFunnel = ActivationStep[];
+
+export function computeActivation(
+  rows: Array<{ event?: string | null; session_id?: string | null }>,
+): ActivationFunnel {
+  const byStep = new Map<CanonicalEvent, Set<string>>();
+  for (const step of ACTIVATION_FUNNEL) byStep.set(step, new Set());
+  for (const row of rows) {
+    const event = typeof row.event === "string" ? row.event : null;
+    const sid = typeof row.session_id === "string" ? row.session_id : null;
+    if (!event || !sid) continue;
+    const canonical = canonicalEventFor(event);
+    if (canonical) byStep.get(canonical)!.add(sid);
+  }
+  return ACTIVATION_FUNNEL.map((step) => ({
+    step,
+    sessions: byStep.get(step)!.size,
+  }));
+}
+
+export type CountryCount = { country: string; sessions: number };
+
+export function computeTopCountries(
+  rows: Array<{ country?: string | null; session_id?: string | null }>,
+  limit = 8,
+): CountryCount[] {
+  const byCountry = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const country = typeof row.country === "string" ? row.country : null;
+    const sid = typeof row.session_id === "string" ? row.session_id : null;
+    if (!country || !sid) continue; // null country excluded from the ranking
+    if (!byCountry.has(country)) byCountry.set(country, new Set());
+    byCountry.get(country)!.add(sid);
+  }
+  return Array.from(byCountry.entries())
+    .map(([country, sessions]) => ({ country, sessions: sessions.size }))
+    .sort((a, b) => b.sessions - a.sessions || a.country.localeCompare(b.country))
+    .slice(0, limit);
+}
+
+export type RetentionBucket = { returned: number; cohort: number };
+export type Retention = { d1: RetentionBucket; d7: RetentionBucket };
+
+function dayKey(ts: string): string {
+  return ts.slice(0, 10);
+}
+
+function addDays(dayKeyStr: string, days: number): string {
+  const d = new Date(`${dayKeyStr}T00:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Rolling D1/D7 retention. A cohort for offset N is every install whose
+ * first_seen day is old enough to have had a day-N chance to return AND recent
+ * enough to be meaningful:
+ *   - D1 cohort: first_seen in [today-8, today-1]
+ *   - D7 cohort: first_seen in [today-14, today-7]
+ * An install is "retained at N" if it produced ANY event on
+ * first_seen_day + N (exact calendar day, UTC). Returns absolute
+ * returned/cohort counts per offset (the view derives the %).
+ */
+export function computeRetention(
+  firstSeen: Array<{ session_id?: string | null; first_seen?: string | null }>,
+  activity: Array<{ session_id?: string | null; created_at?: string | null }>,
+  now: Date = new Date(),
+): Retention {
+  const activeDays = new Map<string, Set<string>>();
+  for (const row of activity) {
+    const sid = typeof row.session_id === "string" ? row.session_id : null;
+    const ts = typeof row.created_at === "string" ? row.created_at : null;
+    if (!sid || !ts) continue;
+    if (!activeDays.has(sid)) activeDays.set(sid, new Set());
+    activeDays.get(sid)!.add(dayKey(ts));
+  }
+
+  const today = new Date(now);
+  today.setUTCHours(0, 0, 0, 0);
+  const todayKey = today.toISOString().slice(0, 10);
+
+  const bucket = (offset: number, minAgo: number, maxAgo: number): RetentionBucket => {
+    let cohort = 0;
+    let returned = 0;
+    for (const row of firstSeen) {
+      const sid = typeof row.session_id === "string" ? row.session_id : null;
+      const fs = typeof row.first_seen === "string" ? row.first_seen : null;
+      if (!sid || !fs) continue;
+      const fsKey = dayKey(fs);
+      const ageDays = Math.round(
+        (Date.parse(`${todayKey}T00:00:00.000Z`) -
+          Date.parse(`${fsKey}T00:00:00.000Z`)) /
+          86_400_000,
+      );
+      if (ageDays < minAgo || ageDays > maxAgo) continue;
+      cohort += 1;
+      if (activeDays.get(sid)?.has(addDays(fsKey, offset))) returned += 1;
+    }
+    return { returned, cohort };
+  };
+
+  return {
+    d1: bucket(1, 1, 8),
+    d7: bucket(7, 7, 14),
+  };
+}

--- a/apps/web/src/lib/stats/public-aggregator.ts
+++ b/apps/web/src/lib/stats/public-aggregator.ts
@@ -14,6 +14,19 @@ import {
   type OnchainStats,
   type StatsDb,
 } from "./onchain";
+import {
+  computeActivation,
+  computeRetention,
+  computeTopCountries,
+  type ActivationFunnel,
+  type CountryCount,
+  type Retention,
+} from "./funnels";
+import { ALL_FUNNEL_ALIASES } from "@/lib/analytics/canonical-events";
+import {
+  DEFAULT_STATS_FILTERS,
+  type StatsFilters,
+} from "./filters";
 
 /**
  * Read-only aggregator that powers the public `/stats` page.
@@ -149,6 +162,20 @@ export type PublicStats = {
   /** B2.1 — challenge link funnel (last 30d, isLite events only).
    *  null when the underlying query fails. */
   challengeFunnel: ChallengeFunnel | null;
+  /** Echo of the applied surface/container filters (drives the UI controls
+   *  + the "as of, filtered by" label). */
+  filters: StatsFilters;
+  /** Distinct sessions that fired app_opened in the last 30d, under the
+   *  active filters. null on query failure. Equals activation[0].sessions. */
+  appOpens30d: number | null;
+  /** Activation funnel (last 30d, filtered): distinct sessions per canonical
+   *  step. null on query failure. */
+  activation: ActivationFunnel | null;
+  /** Top countries by distinct sessions (last 30d, filtered). Empty on
+   *  failure; null country is never included. */
+  topCountries: CountryCount[];
+  /** Rolling D1/D7 retention (filtered cohorts). null on query failure. */
+  retention: Retention | null;
 };
 
 export const EMPTY_PUBLIC_STATS: PublicStats = {
@@ -169,6 +196,11 @@ export const EMPTY_PUBLIC_STATS: PublicStats = {
   generatedAt: new Date(0).toISOString(),
   onchain: EMPTY_ONCHAIN_STATS,
   challengeFunnel: null,
+  filters: DEFAULT_STATS_FILTERS,
+  appOpens30d: null,
+  activation: null,
+  topCountries: [],
+  retention: null,
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -324,10 +356,16 @@ function extractChallengeFunnel(res: {
   };
 }
 
-export async function getPublicStats(): Promise<PublicStats> {
+export async function getPublicStats(
+  filters: StatsFilters = DEFAULT_STATS_FILTERS,
+): Promise<PublicStats> {
   const supabase = getSupabaseServer();
   if (!supabase) {
-    return { ...EMPTY_PUBLIC_STATS, generatedAt: new Date().toISOString() };
+    return {
+      ...EMPTY_PUBLIC_STATS,
+      filters,
+      generatedAt: new Date().toISOString(),
+    };
   }
 
   const now = new Date();
@@ -491,6 +529,77 @@ export async function getPublicStats(): Promise<PublicStats> {
     error: unknown;
   }>).then(extractChallengeFunnel, () => null);
 
+  // Observability blocks (activation / top countries / retention). These are
+  // the ONLY blocks the surface/container filters touch — headline platform
+  // stats (mints, welcome packs, sessions, trend) stay global. Two filtered
+  // reads: one event scan (feeds all three) + the cohort table. Separate
+  // awaits keep the giant allSettled tuple's type instantiation shallow.
+  const applyEventFilters = <T>(q: T): T => {
+    let out = q as unknown as {
+      eq: (col: string, val: string) => unknown;
+    };
+    if (filters.surface !== "all") out = out.eq("surface", filters.surface) as typeof out;
+    if (filters.container !== "all")
+      out = out.eq("container", filters.container) as typeof out;
+    return out as unknown as T;
+  };
+
+  const filteredEvents30d = await (applyEventFilters(
+    supabase
+      .from("analytics_events")
+      .select("event, session_id, created_at, country")
+      .gte("created_at", since30d)
+      .range(0, DISTINCT_QUERY_MAX_ROWS),
+  ) as unknown as Promise<{
+    data: Array<{
+      event: string;
+      session_id: string;
+      created_at: string;
+      country: string | null;
+    }> | null;
+    error: unknown;
+  }>).then(
+    (res) => (res.error || !Array.isArray(res.data) ? null : res.data),
+    () => null,
+  );
+
+  const cohortRows = await (((): unknown => {
+    let q = supabase
+      .from("session_first_seen")
+      .select("session_id, first_seen")
+      .gte("first_seen", since30d)
+      .range(0, DISTINCT_QUERY_MAX_ROWS) as unknown as {
+      eq: (col: string, val: string) => unknown;
+    };
+    if (filters.surface !== "all") q = q.eq("first_surface", filters.surface) as typeof q;
+    if (filters.container !== "all")
+      q = q.eq("first_container", filters.container) as typeof q;
+    return q;
+  })() as Promise<{
+    data: Array<{ session_id: string; first_seen: string }> | null;
+    error: unknown;
+  }>).then(
+    (res) => (res.error || !Array.isArray(res.data) ? null : res.data),
+    () => null,
+  );
+
+  const activation: ActivationFunnel | null = filteredEvents30d
+    ? computeActivation(
+        filteredEvents30d.filter((r) =>
+          (ALL_FUNNEL_ALIASES as readonly string[]).includes(r.event),
+        ),
+      )
+    : null;
+  const appOpens30d =
+    activation?.find((s) => s.step === "app_opened")?.sessions ?? null;
+  const topCountries: CountryCount[] = filteredEvents30d
+    ? computeTopCountries(filteredEvents30d)
+    : [];
+  const retention: Retention | null =
+    cohortRows && filteredEvents30d
+      ? computeRetention(cohortRows, filteredEvents30d)
+      : null;
+
   return {
     totalVictories: extractCount(totalVictoriesRes as PromiseSettledResult<CountResult>),
     victories7d: extractCount(victories7dRes as PromiseSettledResult<CountResult>),
@@ -545,5 +654,10 @@ export async function getPublicStats(): Promise<PublicStats> {
     generatedAt,
     onchain,
     challengeFunnel,
+    filters,
+    appOpens30d,
+    activation,
+    topCountries,
+    retention,
   };
 }

--- a/apps/web/src/lib/telemetry.ts
+++ b/apps/web/src/lib/telemetry.ts
@@ -12,6 +12,7 @@
  */
 
 import { getAnonymousId } from "@/lib/analytics/identity";
+import { clientDimensions } from "@/lib/analytics/client-dimensions";
 
 // Runaway-bug defense: cap events at a conservative 100 per 5-min window
 // per event name. If a render loop or malicious caller keeps firing the
@@ -45,6 +46,11 @@ export function track(event: string, props?: Record<string, unknown>): void {
   const session_id = getAnonymousId();
   if (!session_id) return;
 
+  // Client-stamped dimensions (surface/container/locale/source/campaign/
+  // app_version/visit_id). country is added server-side from the edge geo
+  // header — never sent from the client. The server re-sanitizes all of this.
+  const dims = clientDimensions();
+
   // Use keepalive + no-cache so the request survives page unload
   // (important for dock-tap → navigation flows) and doesn't share
   // anything with the browser cache.
@@ -53,7 +59,7 @@ export function track(event: string, props?: Record<string, unknown>): void {
       method: "POST",
       keepalive: true,
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ session_id, event, props }),
+      body: JSON.stringify({ session_id, event, props, dims }),
     }).catch(() => {
       /* swallow — telemetry must never fail user-visible flows */
     });

--- a/apps/web/src/lib/telemetry.ts
+++ b/apps/web/src/lib/telemetry.ts
@@ -11,7 +11,7 @@
  *   track("share_tile_tap", { tile: "whatsapp" });
  */
 
-const SESSION_KEY = "chesscito:analytics-session";
+import { getAnonymousId } from "@/lib/analytics/identity";
 
 // Runaway-bug defense: cap events at a conservative 100 per 5-min window
 // per event name. If a render loop or malicious caller keeps firing the
@@ -35,23 +35,6 @@ function shouldThrottle(event: string): boolean {
   return false;
 }
 
-function getSessionId(): string {
-  if (typeof window === "undefined") return "";
-  try {
-    const existing = window.localStorage.getItem(SESSION_KEY);
-    if (existing) return existing;
-    // 16 random hex chars (~64 bits) — plenty for our scale, short
-    // enough to stay under the 64-char session id column.
-    const bytes = new Uint8Array(8);
-    window.crypto.getRandomValues(bytes);
-    const id = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-    window.localStorage.setItem(SESSION_KEY, id);
-    return id;
-  } catch {
-    return "";
-  }
-}
-
 export function track(event: string, props?: Record<string, unknown>): void {
   if (typeof window === "undefined") return;
   // Local development renders can double-run effects under React StrictMode
@@ -59,7 +42,7 @@ export function track(event: string, props?: Record<string, unknown>): void {
   // local API/Supabase path unless explicitly opted in.
   if (!LOCAL_TELEMETRY_ENABLED) return;
   if (shouldThrottle(event)) return;
-  const session_id = getSessionId();
+  const session_id = getAnonymousId();
   if (!session_id) return;
 
   // Use keepalive + no-cache so the request survives page unload

--- a/apps/web/supabase/migrations/20260723040000_analytics_dimensions.sql
+++ b/apps/web/supabase/migrations/20260723040000_analytics_dimensions.sql
@@ -1,0 +1,51 @@
+-- Chesscito — Analytics event dimensions (additive, backward-compatible)
+--
+-- Adds low-cardinality dimension columns to analytics_events so a SINGLE
+-- event model answers "who / where / from where / which surface / which
+-- container / which build" without a second pipeline or a second dashboard.
+-- See docs/specs/2026-07-23-observability-lote-1-spec.md.
+--
+-- ALL columns are nullable: pre-existing rows keep NULL, and older clients
+-- that do not send dimensions keep inserting fine. No rename of session_id
+-- (its semantics are "anonymous install id" — documented in
+-- lib/analytics/identity.ts). visit_id is added for once-per-visit / per-visit
+-- funnels; it is high-cardinality and intentionally NOT indexed.
+--
+-- Privacy: `country` is ISO-3166-1 alpha-2 ONLY, resolved server-side from the
+-- edge geo header. NO full IP, city, region, postal code, lat/long is ever
+-- stored (see /api/telemetry). `source` / `campaign` are allow-listed +
+-- sanitized server-side; raw referrer / URL is never persisted.
+
+alter table analytics_events
+  add column if not exists surface     text,  -- 'learn' | 'play' | 'full'
+  add column if not exists container   text,  -- 'minipay' | 'browser'
+  add column if not exists locale      text,  -- 'en' | 'es' | ...
+  add column if not exists country     text,  -- ISO alpha-2, upper, or null
+  add column if not exists source      text,  -- canonical allow-list
+  add column if not exists campaign    text,  -- sanitized, allow-list, or null
+  add column if not exists app_version text,  -- build sha (7 chars) or 'dev'
+  add column if not exists visit_id    text;  -- per-visit id (NOT indexed)
+
+-- Defensive guard on the country dimension. NOT VALID so the migration never
+-- scans / rejects legacy NULL rows; new writes are checked. NULL always passes
+-- (dimension unknown is allowed). Guarded in a DO block because Postgres has no
+-- ADD CONSTRAINT IF NOT EXISTS — this keeps the migration re-runnable.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'analytics_events_country_iso2'
+  ) then
+    alter table analytics_events
+      add constraint analytics_events_country_iso2
+      check (country is null or country ~ '^[A-Z]{2}$') not valid;
+  end if;
+end $$;
+
+-- Indexes only for the dimensions the /stats MVP actually filters on.
+-- (event, created_at) already exists from the base migration.
+create index if not exists idx_analytics_events_surface
+  on analytics_events (surface, created_at desc);
+create index if not exists idx_analytics_events_container
+  on analytics_events (container, created_at desc);
+create index if not exists idx_analytics_events_country
+  on analytics_events (country, created_at desc);

--- a/apps/web/supabase/migrations/20260723041000_session_first_seen.sql
+++ b/apps/web/supabase/migrations/20260723041000_session_first_seen.sql
@@ -1,0 +1,31 @@
+-- Chesscito — session_first_seen cohort table
+--
+-- Retention (D1/D7, designed to reach D30 with NO further migration) needs a
+-- per-anonymous-id "day 0" that OUTLIVES the 90-day analytics_events prune.
+-- This table is intentionally excluded from prune_analytics_events(): one row
+-- per install, fixed on the first visit, never rewritten.
+--
+-- Idempotent: `on conflict (session_id) do nothing` — only the first visit
+-- fixes the cohort (first_seen + first-touch attribution). Later visits do NOT
+-- overwrite it, so D1/D7/D30 cohorts stay stable.
+--
+-- session_id here is the anonymous install id (lib/analytics/identity.ts),
+-- matching analytics_events.session_id. No wallet / PII. Writes go through the
+-- service role (/api/telemetry); RLS stays default-deny for anon.
+
+create table if not exists session_first_seen (
+  session_id      text primary key,
+  first_seen      timestamptz not null default now(),
+  first_surface   text,
+  first_container text,
+  first_country   text,  -- ISO alpha-2 or null (same privacy rule as events)
+  first_source    text
+);
+
+-- Cohort scans slice by day: "installs whose first_seen was on day D".
+create index if not exists idx_session_first_seen_first_seen
+  on session_first_seen (first_seen);
+
+alter table session_first_seen enable row level security;
+-- No policies => default-deny for anon / authenticated. Service role bypasses
+-- RLS, so only server-side telemetry can read/write. Mirrors analytics_events.

--- a/docs/audits/2026-07-23-product-observability-audit.md
+++ b/docs/audits/2026-07-23-product-observability-audit.md
@@ -1,0 +1,274 @@
+# Auditoría de Observabilidad de Producto — Pre-lanzamiento MiniPay
+
+**Fecha:** 2026-07-23 · **Fase:** 1 (auditoría, sin implementación) · **Autor:** Wolfcito 🐾 @akawolfcito
+
+> Alcance: auditar `/stats` (Learn + Play), toda la instrumentación existente, contrastar
+> con MiniPay/Celo oficial (Celopedia), y proponer un slice mínimo. **No se toca producción.**
+> No se implementa nada en esta fase.
+
+---
+
+## 0. TL;DR
+
+- **Modelo actual:** un único stream de eventos **client-only** (`track()` → `POST /api/telemetry`
+  fire-and-forget → tabla `analytics_events(session_id, event, props)`). ~120 nombres de evento
+  sin convención. **Cero dimensiones** (`surface`, `container`, `source`, `app_version`, `locale`,
+  `country`). Sin retención/cohortes. Sin país. Sin confirmación server-side de pagos/rewards.
+- **`/stats` es UNA sola ruta** (`app/[locale]/stats/page.tsx`) leyendo la MISMA Supabase. Learn y
+  Play "se ven casi iguales" porque **son el mismo código**; el único diferenciador es el env
+  `CHESSCITO_MODE` (learn|play) del deployment, que **no viaja a los datos**. No hay dos sistemas
+  que unificar: hay uno solo al que le falta la dimensión `surface`.
+- **Bloqueante para listing MiniPay:** el checklist oficial (§8) exige stats con **DAU/MAU,
+  retención D1/D7/D30, top countries, tx por stablecoin, network fees, failed-tx rate**. Hoy
+  faltan retención, país, y varias métricas on-chain están parciales.
+- **El slice que propone el founder es correcto y suficiente.** No hace falta Mixpanel casero.
+
+---
+
+## 1. Inventario actual
+
+### 1.1 Pipeline de telemetría (una sola vía)
+
+| Capa | Archivo | Qué hace |
+|------|---------|----------|
+| Emisor client | `apps/web/src/lib/telemetry.ts` | `track(event, props)`. SSR-safe. `session_id` de `localStorage` (`chesscito:analytics-session`, 64-bit hex). Throttle 100 ev / 5min / nombre. `fetch` con `keepalive`. Silencioso ante error. Desactivado en dev salvo `NEXT_PUBLIC_ENABLE_LOCAL_TELEMETRY=1`. |
+| Endpoint server | `apps/web/src/app/api/telemetry/route.ts` | `POST`. Valida `session_id`≤64, `event`≤64, `props`≤4KB, aplana props a 2 niveles y coacciona a primitivos. **Siempre responde 204**, inserta con service role. Sin auth, sin rate-limit server, sin dedupe. |
+| Persistencia | `supabase/migrations/20260424000000_analytics_events.sql` | `analytics_events(id, created_at, session_id, event, props jsonb)`. Índices por `created_at`, `(session_id,created_at)`, `(event,created_at)`. RLS default-deny; solo service role escribe. |
+| Retención | `20260424010000_analytics_cleanup.sql` + `..._schedule_analytics_cron.sql` | `prune_analytics_events()` borra >90 días. Cron mensual. **⚠️ ventana de 90 días = techo para cohortes.** |
+| Lectura `/stats` | `apps/web/src/lib/stats/public-aggregator.ts` (+ `onchain.ts`) | 14 queries en `Promise.allSettled` sobre `victories`, `welcome_pack_claims`, `analytics_events`, `coach_analyses`, `leaderboard_v`. Cada fallo → `null` (em-dash). `revalidate=3600`. |
+| Vista | `apps/web/src/components/stats/stats-page.tsx` | Render server-cached; nombres via Identity Lite (sin wallet). |
+
+### 1.2 `/stats` Learn vs Play — diferencias reales
+
+**Ninguna a nivel de datos.** Misma ruta, mismo aggregator, misma Supabase, mismo payload.
+La única bifurcación de producto vive en `apps/web/src/lib/feature-flags.ts`
+(`CHESSCITO_MODE` = learn|play|full; `CHESSCITO_LITE_MODE = mode==="learn"`), que cambia UI/gating
+pero **no** etiqueta los eventos. Por eso no se puede hoy responder "¿esto pasó en Learn o en Play?"
+salvo por el dominio del deployment — que no queda registrado.
+
+### 1.3 Detección de contenedor (MiniPay vs browser)
+
+`apps/web/src/lib/minipay.ts` → `isMiniPayEnv()` = `window.ethereum?.isMiniPay === true`
+(coincide con el patrón oficial de Celopedia, ver §5). **Existe pero NUNCA se adjunta a un evento.**
+El container es hoy invisible en analytics.
+
+### 1.4 Catálogo de eventos actuales (resumen; ~120 nombres)
+
+Todos son `track()` client-side. Familias:
+
+| Familia | Ejemplos | Nº aprox |
+|---------|----------|----------|
+| Arena (Play juego) | `arena_mount`, `arena_game_start`, `arena_game_end`, `arena_*_tap` | 15 |
+| Hub Learn | `hub_view`, `hub_start_focus_tap`, `hub_*_chip_tap`, `hub_tour_*` | 16 |
+| Hub Play | `play_hub_view`, `play_hub_arena_tap`, `play_hub_*_tap` | 8 |
+| Ejercicios/Training | `exercise_complete`, `exercise_fail`, `training_exercise_started/completed`, `training_stars_earned`, `labyrinth_complete` | 12 |
+| Daily / Tactics | `daily_tactic_started/completed`, `daily_streak_updated`, `play_tactics_opened/completed/failed` | 6 |
+| Coach | `coach_analyze_request`, `coach_analyze_failed`, `coach_viewer_*` | 20 |
+| PRO / Monetización | `pro_card_viewed`, `pro_cta_clicked`, `pro_purchase_started/confirmed/failed`, `pro_verify_retry_failed` | 12 |
+| Peones (economía) | `peones_earned`, `peones_spent`, `peones_spend_failed/blocked/bypassed`, `peones_cap_reached` | 8 |
+| Pagos/tx | `shop_buy_tx`, `badge_claim_tx`, `score_submit_tx`, `victory_claim_tx`, `tx_progress_*` | 10 |
+| Gift/Welcome | `claim_gift_tap/signing/success/failed/rejected`, `claim_attempted` | 6 |
+| Challenge / deep link | `challenge_link_opened`, `challenge_started`, `challenge_completed`, `challenge_shared`, `challenge_continue_to_lite` | 5 |
+| Share | `share_tile_tap` | 1 |
+| Infra/UX | `modal_open`, `dock_tap`, `splash_view`, `error_boundary_shown`, `landing_redirect`, `lite_session_started` | ~8 |
+
+Catálogo evento-por-evento con emisor/payload/persistencia/consumidor/confiabilidad:
+**pendiente de expandir en la Fase 2** (aquí se prioriza el diagnóstico). Regla observada:
+`props` es libre y no tipado; ningún consumidor los valida salvo `challenge_*` (lee `props.isLite`).
+
+### 1.5 Fuentes server-authoritative que YA existen (fuera de `analytics_events`)
+
+La verdad de pagos/rewards **sí** vive en tablas de dominio escritas por API/RPC, solo que no
+está unificada con el stream de eventos:
+
+- `victories` (mints on-chain confirmados) · `welcome_pack_claims` · `coach_analyses`
+- Ledger de Peones (`20260607…peones_ledger_init`, `…peones_v1_economy`)
+- `20260701140000_pro_treasury_payment.sql` (pago PRO a treasury)
+- `20260625120000_lite_season_passes.sql` (Season Pass)
+
+→ Los eventos `pro_purchase_confirmed`, `shop_buy_tx`, `peones_earned/spent` **duplican en
+client** algo que el servidor ya sabe con certeza. La conciliación es posible sin inventar tablas.
+
+---
+
+## 2. Matriz de gaps priorizada
+
+### 🔴 Bloqueante para MiniPay (listing §8 + preguntas del founder)
+
+| # | Gap | Evidencia | Impacto |
+|---|-----|-----------|---------|
+| B1 | **Sin dimensión `surface`** (learn/play) en los eventos | `analytics_events` no la tiene; `/stats` es una ruta única | No se responde "¿Learn o Play?" |
+| B2 | **Sin `container`** (minipay/browser) | `isMiniPayEnv()` existe pero no se emite | No se responde "¿vienen de MiniPay?" |
+| B3 | **Sin retención D1/D7/D30 ni cohortes** | No hay `first_seen`; poda a 90 días | §8 exige retención — requisito de listing |
+| B4 | **Sin país** | No se captura geo; MiniPay no lo entrega | §8 pide "top countries" (targeting por país) |
+| B5 | **Sin `app_opened` / page_view explícito** | `activeSessions` se deriva de distinct `session_id`; no hay evento raíz | El funnel de activación no tiene tope de embudo fiable |
+| B6 | **Pagos/rewards solo client-confirmed** | `pro_purchase_confirmed` etc. son `track()` | Pérdida/spoof; §8 pide tx por stablecoin + revenue |
+
+### 🟠 Alto valor
+
+| # | Gap |
+|---|-----|
+| A1 | **Naming inconsistente** — `exercise_complete` vs `training_exercise_completed` vs `daily_tactic_completed` vs `play_tactics_completed` miden lo mismo con nombres distintos → funnels imposibles de agregar |
+| A2 | **Duplicados hub** — `hub_view`/`play_hub_view` y `hub_*_tap`/`play_hub_*_tap` (la dimensión `surface` los colapsa) |
+| A3 | **Sin `source`/`campaign`** — no hay atribución de origen (referrer/utm/deep-link) más allá de `challenge_*` |
+| A4 | **Sin `app_version`** — imposible correlacionar una regresión con un deploy |
+| A5 | **`props` no tipado ni versionado** — cualquier typo entra silencioso |
+
+### 🟢 Nice-to-have
+
+| # | Gap |
+|---|-----|
+| N1 | Rollup de agregados antes de la poda de 90 días (hoy "not implemented yet" en el SQL) |
+| N2 | Rate-limit server-side en `/api/telemetry` (hoy solo throttle client, evadible) |
+| N3 | `locale` explícito en eventos (derivable del path pero no guardado) |
+| N4 | Métricas on-chain §8 completas: network fees pagados, failed-tx rate, volumen por stablecoin |
+
+---
+
+## 3. Marco canónico propuesto (validado)
+
+**Sí basta un único modelo con dimensiones.** No dupliquemos dashboards. Extender el payload,
+no el pipeline:
+
+```
+event: string                      // nombre canónico normalizado
+session_id: string                 // ya existe (localStorage, opaco)
+dims:
+  surface:    "learn" | "play"     // de CHESSCITO_MODE (build-time)
+  container:  "minipay" | "browser"// de isMiniPayEnv() (runtime)
+  locale:     string               // del path [locale]
+  country:    string               // edge geo (Vercel header), NO de MiniPay
+  source:     string               // referrer/utm/deep-link, normalizado
+  campaign:   string | null
+  app_version:string               // del build (NEXT_PUBLIC_APP_VERSION / commit)
+props: jsonb                       // específicos del evento (tipados en TS)
+```
+
+Decisión de esquema (a validar en Fase 2): añadir estas dims como **columnas** en
+`analytics_events` (indexables, baratas de filtrar) en vez de enterrarlas en `props`. Migración
+aditiva, backward-compatible (columnas nullable). `surface` NO puede ir solo en env: hay que
+estamparlo en cada evento.
+
+> **country:** capturar server-side en `/api/telemetry` desde el header de geo del edge
+> (p.ej. `x-vercel-ip-country`), **nunca** IP completa (ver §7). MiniPay no entrega país.
+
+---
+
+## 4. Funnels y métricas derivadas
+
+### Activación
+`app_opened` → `hub_viewed` → `exercise_started` → `exercise_completed` → `daily_focus_completed`
+- Faltan hoy: `app_opened` (B5), y unificar `exercise_started/completed` (A1).
+- `hub_viewed` = colapsar `hub_view`/`play_hub_view` con `surface`.
+
+### Monetización
+`offer_viewed` → `purchase_started` → `purchase_succeeded | purchase_failed` → `paid_feature_used`
+- Mapeo actual: `pro_card_viewed`→`pro_purchase_started`→`pro_purchase_confirmed`/`_failed`.
+- Falta `paid_feature_used` y **confirmación server-side** de `purchase_succeeded` (B6): la fuente
+  de verdad debe ser `pro_treasury_payment` / `victories` / ledger, no el evento client.
+
+### Retención
+D1 / D3 / D7 / D21, cohortes por primera visita, y por `source` / `surface` / `container`.
+- Necesita `first_seen` por `session_id` (B3) y que la poda de 90 días no borre la fila de cohorte
+  (rollup N1 o tabla `session_first_seen` liviana).
+
+Todos los funnels se resuelven **con filtros sobre un solo modelo** — no requieren dashboards
+separados Learn/Play.
+
+---
+
+## 5. Contraste con MiniPay / Celo oficial (Celopedia)
+
+| Tema | Oficial (Celopedia) | Estado en Chesscito |
+|------|---------------------|---------------------|
+| Detección MiniPay | `window.ethereum.isMiniPay === true` (`minipay-guide.md` §Detection) | ✅ `isMiniPayEnv()` idéntico — pero no se emite (B2) |
+| **MiniPay entrega analytics** | **No.** Debes montar tu propia stats page (Plausible/PostHog/Umami/GA4). Distingue: MiniPay NO da métricas | ✅ Confirmado: tenemos pipeline propio. No asumir analytics de MiniPay |
+| Requisito de listing §8 | Stats públicas: DAU, MAU, **retención D1/D7/D30**, **top countries**, tx/stablecoin, network fees, protocol revenue, **failed-tx rate**, tx counts/día/semana/vida | ⚠️ Parcial: hay sesiones/mints/coach; faltan retención, país, fees, failed-tx |
+| País | MiniPay **no** expone país; su disponibilidad ES por país → métrica útil. Capturar via edge geo | ❌ No se captura (B4) |
+| Deep links | `add_cash` (`minipay.opera.com/add_cash`); lista canónica en docs.minipay.xyz | ✅ Ya usado (`minipay_add_cash_click`); atribución de deep-link de entrada no medida (A3) |
+| Signing / tx | No `personal_sign`, legacy tx, fee en USDm | (fuera de scope analytics) |
+| Privacidad | ToS + Privacy Policy in-app obligatorio para listing | Verificar `/privacy` y `/terms` existen (rutas presentes) |
+| Copy MiniPay | "Deposit" no "Add Cash"/"Onramp"; nunca CELO en UI | Revisar labels en Fase 2 (no es analytics pero es gate de listing) |
+
+**Conclusión de contraste:** la arquitectura actual (Supabase propio, sin SaaS) es compatible con
+lo que MiniPay pide. El gap es de **cobertura de métricas**, no de plataforma.
+
+---
+
+## 6. Propuesta mínima para `/stats`
+
+Mantener una sola ruta; añadir **filtros** en vez de una segunda página:
+
+- Filtro `surface` (Learn | Play | Ambos) — resuelve la necesidad sin duplicar dashboard.
+- Filtro `container` (MiniPay | Browser | Ambos).
+- Bloque **Activación** (funnel §4) y **Monetización** (funnel §4) con conteos absolutos
+  (sin rates a bajo volumen, como ya hace `ChallengeFunnel`).
+- Bloque **Retención** D1/D7 (arrancar con D1/D7; D3/D21 después).
+- Completar bloque on-chain §8 (failed-tx rate, fees) — reusa `onchain.ts`.
+- Etiqueta "as of" ya existe (`generatedAt`). Mantener `revalidate=3600`.
+
+---
+
+## 7. Red-team (privacidad · pérdida · duplicados · idempotencia)
+
+**Privacidad**
+- ✅ Bien hoy: sin wallet/PII en `analytics_events`; `session_id` opaco; wallet se hashea a
+  Identity Lite server-side y se descarta.
+- ⚠️ Al añadir `country`: guardar **solo código de país** (`x-vercel-ip-country`), **nunca IP
+  completa, teléfono, email**. No derivar ciudad. Confirmar en Privacy Policy antes de shippear.
+- ⚠️ `source`/`campaign`: normalizar allow-list; no volcar el referrer crudo (puede traer query
+  params sensibles).
+- ✅ Wallet: si alguna vez se necesita en analytics, usar **hash estable** (patrón `deriveRowId`
+  ya existe), nunca texto plano.
+
+**Pérdida de eventos**
+- ⚠️ Client-only + `keepalive`: una recarga, red caída, o cierre del WebView de MiniPay pierde el
+  evento sin rastro (204 siempre, sin ACK). Aceptable para UX/engagement; **inaceptable para
+  pagos/rewards** → B6 (confirmar desde tablas de dominio).
+- ⚠️ Throttle 100/5min/nombre es client-side: se resetea en cada navegación → subcuenta posible en
+  navegación intensa; y es evadible (N2).
+
+**Duplicados**
+- ⚠️ StrictMode/doble-efecto puede emitir 2× el mismo evento (mitigado en dev por gate, no en prod).
+- ⚠️ `exercise_complete` vs `training_exercise_completed` vs `daily_tactic_completed` vs
+  `play_tactics_completed`: **cuádruple contabilidad** del mismo hecho conceptual (A1).
+- ✅ La dimensión `surface` elimina los duplicados hub/play_hub por diseño.
+
+**Idempotencia**
+- ❌ `analytics_events` no tiene clave de idempotencia; un retry de red inserta fila nueva.
+  Para eventos de pago confirmados server-side, usar la **tx_hash / intent_id** como clave única
+  (ya existen en las tablas de dominio) en lugar de contar eventos.
+
+---
+
+## 8. Plan de implementación por commits pequeños (Fase 2 — NO ejecutar aún)
+
+1. `feat(analytics): add surface + container dims to track()` — estampar `CHESSCITO_MODE` y
+   `isMiniPayEnv()` en cada evento (client). Migración aditiva de columnas nullable.
+2. `feat(analytics): capture country + app_version server-side` — leer geo header en
+   `/api/telemetry`; inyectar `NEXT_PUBLIC_APP_VERSION`. (Privacidad: solo país.)
+3. `refactor(analytics): normalize event names` — mapa canónico + shim de compatibilidad; colapsar
+   los 4 `*_completed` y hub/play_hub. Tests que fijan el catálogo.
+4. `feat(analytics): app_opened + session first_seen` — evento raíz + tabla/columna `first_seen`
+   para cohortes (sobrevive a la poda de 90d).
+5. `feat(analytics): server-confirm payments/rewards` — reconciliar `purchase_succeeded` y
+   `peones_earned/spent` contra `pro_treasury_payment` / `victories` / ledger (idempotente por
+   tx_hash/intent_id).
+6. `feat(stats): surface + container filters` — un dashboard, filtros.
+7. `feat(stats): activation + monetization funnels` — conteos absolutos.
+8. `feat(stats): retention D1/D7` — cohortes por first_seen.
+9. `feat(stats): complete on-chain §8 block` — failed-tx rate, fees, volumen/stablecoin.
+
+Cada uno con TDD (SDD→TDD→EDD), suite verde reportada en el commit, atómico.
+
+---
+
+## 9. Preguntas abiertas para el founder
+
+1. ¿`country` a nivel código de país es aceptable para la Privacy Policy actual, o hay que
+   actualizarla antes?
+2. ¿`source`/`campaign` entran en el MVP, o basta `surface`+`container`+`app_version` para el
+   listing y dejamos atribución para después?
+3. Retención: ¿arrancamos D1/D7 y sumamos D3/D21 luego, o el listing exige D30 desde día 1?
+4. ¿Confirmación server-side de pagos como reconciliación batch (cron) o inline en cada tx?
+```

--- a/docs/handoffs/2026-07-23-observability-lote-1-handoff.md
+++ b/docs/handoffs/2026-07-23-observability-lote-1-handoff.md
@@ -1,0 +1,80 @@
+# Handoff — Observabilidad Lote 1
+
+**Fecha:** 2026-07-23 · **Rama:** `feat/observability-lote-1` · **Autor:** Wolfcito 🐾 @akawolfcito
+**Base:** audit `docs/audits/2026-07-23-product-observability-audit.md` + spec
+`docs/specs/2026-07-23-observability-lote-1-spec.md` (ambos aprobados).
+
+> ⛔ **STOP alcanzado a propósito:** NO se aplicaron migraciones a producción.
+> El merge a `main` local y el push a `origin/main` los hace el founder.
+
+---
+
+## Estado — LISTO (10 commits atómicos en la rama)
+
+1. `feat(analytics): split anonymousId vs visitId session semantics`
+2. `feat(db): additive analytics dimension columns` (migración)
+3. `feat(db): session_first_seen cohort table` (migración)
+4. `feat(analytics): enrich events with dims + server-side country`
+5. `feat(analytics): app_opened once-per-visit root event`
+6. `feat(analytics): canonical activation-funnel event map (read-time shim)`
+7. `feat(stats): surface/container filters + app opens + activation funnel`
+8. `feat(stats): top countries + D1/D7 retention UI + filter controls`
+9. `docs(privacy): declare anonymous product analytics (EN/ES)`
+10. `fix(analytics): make clientDimensions fail-open (never throw into track)`
+
+### Verificación
+- **Suite completa:** 5739 passing / 510 files, **0 fallas, sin ELIFECYCLE** (job verde limpio).
+- **Typecheck:** `pnpm exec tsc --noEmit` limpio.
+- **Migraciones:** ensayadas contra **Supabase local** (docker `supabase_db_web`): aplican
+  limpio, idempotentes (constraint DO-guarded), CHECK de country rechaza `us`/acepta `US`/null,
+  `on conflict do nothing` conserva la cohorte original.
+- **Visual /stats:** capturado default + `?surface=learn&container=minipay`. Filtros con estado
+  activo, sección Acquisition & Activation, degradación graceful (em-dash) cuando la DB no tiene
+  aún las columnas nuevas → confirma el fail-open. (Capturas en scratchpad, efímeras.)
+
+---
+
+## Qué quedó implementado
+
+- **Sesión:** `session_id` = anonymous_id persistente (retención). `visit_id` nuevo
+  (sessionStorage). `lib/analytics/identity.ts`.
+- **Dimensiones** (columnas nullable en `analytics_events`): surface, container, locale, country,
+  source, campaign, app_version, visit_id. Normalizadores puros allow-list compartidos
+  client+server (`lib/analytics/dimensions.ts`). **country solo server-side** desde
+  `x-vercel-ip-country` (ISO-2, nunca IP/ciudad).
+- **Atribución first-touch** persistida (`lib/analytics/attribution.ts`).
+- **`app_opened`** once-per-visit (`components/analytics/analytics-boot.tsx` en `layout.tsx`) +
+  upsert idempotente de `session_first_seen`.
+- **Funnel canónico** read-time (`lib/analytics/canonical-events.ts`) — sin renombrar los ~120.
+- **/stats:** filtros server-side por querystring (`unstable_cache` keyed, revalidate 3600),
+  App Opens, activación, top countries, retención D1/D7. Una sola página.
+- **Privacy Policy EN/ES** declara analytics anónima, país aproximado, no-IP-completa, retención.
+
+---
+
+## Próximos pasos (founder / próxima sesión) — EN ORDEN
+
+1. **Revisar la rama** y mergear a `main` local; push a `origin/main` (founder).
+2. **⚠️ GATE DE PRIVACIDAD:** publicar la Privacy Policy actualizada (deploy) **ANTES** de
+   activar la captura de `country` en prod. El commit 9 ya trae la copy; solo debe estar **live**.
+3. **Aplicar las 2 migraciones a producción** (`20260723040000_analytics_dimensions.sql`,
+   `20260723041000_session_first_seen.sql`). Aditivas y probadas en local. **Yo NO las apliqué.**
+4. **Env de prod:** confirmar `NEXT_PUBLIC_BUILD_SHA` (ya seteado en `next.config.js` desde
+   `VERCEL_GIT_COMMIT_SHA`). El país depende de que Vercel inyecte `x-vercel-ip-country` (default
+   en el edge).
+5. Verificar visualmente `/stats` con datos reales una vez propaguen los primeros `app_opened`.
+
+---
+
+## Fuera de alcance (confirmado, para Lote 2)
+
+Reconciliación server-authoritative de pagos/rewards · métricas on-chain §8 completas (network
+fees, failed-tx) · retención D30/D3/D21 · renombrar todo el catálogo · SaaS · warehouse.
+
+## Open questions
+
+- ¿La captura de `country` requiere además una nota en la pantalla de consentimiento in-app, o
+  basta la Privacy Policy? (El listing MiniPay exige links a ToS/Privacy accesibles in-app —
+  ya existen `/privacy` y `/terms`.)
+- Retención: los umbrales de cohorte (D1 en edad [1,8], D7 en [7,14]) son un default razonable a
+  bajo volumen; revisar cuando haya datos reales por si conviene ampliar la ventana.

--- a/docs/ops/2026-07-23-lote-1-migration-runbook.md
+++ b/docs/ops/2026-07-23-lote-1-migration-runbook.md
@@ -1,0 +1,184 @@
+# Runbook — Observabilidad Lote 1: migraciones + smoke de producción
+
+**Fecha:** 2026-07-23 · **PR de código:** `feat/observability-lote-1-code`
+**Migraciones:** `20260723040000_analytics_dimensions.sql`, `20260723041000_session_first_seen.sql`
+
+> ⛔ **NO aplicar a producción sin aprobación humana explícita.** Este documento deja el
+> dry-run y las consultas pre/post listas; la ejecución la autoriza y corre un humano.
+>
+> **Orden obligatorio de release:**
+> 1. PR de Privacy Policy (#270) **live en producción**.
+> 2. Aplicar estas 2 migraciones (aditivas) — **requiere aprobación humana**.
+> 3. Mergear el PR de código.
+
+Ambas migraciones son **aditivas y backward-compatible**: `ADD COLUMN ... IF NOT EXISTS`
+(metadata-only en PG11+, sin reescribir la tabla), `CREATE INDEX` no concurrente (toma un SHARE
+lock breve durante el build — a volumen actual es trivial; `analytics_events` está podada a 90d),
+CHECK `NOT VALID` (no escanea filas viejas), y `CREATE TABLE IF NOT EXISTS`. Sin `DROP`, sin
+`ALTER TYPE`, sin backfill. Reversibilidad: ver §5.
+
+---
+
+## 1. Dry-run (sin persistir)
+
+Correr contra una **copia**, nunca contra prod directo. Dos opciones:
+
+**A. Supabase branch / snapshot restaurado (preferida).** Aplicar los dos archivos con el CLI
+sobre una branch de preview o un restore del snapshot de prod, y correr las consultas POST (§4).
+
+**B. Transacción con ROLLBACK** sobre una copia (valida sintaxis + que aplican sobre el schema
+actual, sin dejar cambios):
+
+```sql
+begin;
+\i supabase/migrations/20260723040000_analytics_dimensions.sql
+\i supabase/migrations/20260723041000_session_first_seen.sql
+-- correr las consultas POST (§4) aquí adentro para verificar el estado resultante
+rollback;
+```
+
+> Ya ensayado localmente (docker `supabase_db_web`, 2026-07-23): ambas aplican limpio, son
+> idempotentes (constraint DO-guarded), el CHECK rechaza `us` / acepta `US`/`null`, y el
+> `on conflict do nothing` conserva la cohorte original.
+
+---
+
+## 2. Consultas PRE (estado esperado ANTES de aplicar)
+
+```sql
+-- (a) Las 8 columnas NO deben existir todavía → 0 filas
+select column_name from information_schema.columns
+where table_name = 'analytics_events'
+  and column_name in ('surface','container','locale','country',
+                      'source','campaign','app_version','visit_id');
+
+-- (b) El CHECK de country NO debe existir → 0 filas
+select conname from pg_constraint where conname = 'analytics_events_country_iso2';
+
+-- (c) La tabla de cohortes NO debe existir → NULL
+select to_regclass('public.session_first_seen');
+
+-- (d) Baseline de filas (para comparar POST y descartar pérdida de datos)
+select count(*) as analytics_events_rows_pre from analytics_events;
+```
+
+---
+
+## 3. Aplicar (SOLO con aprobación humana)
+
+```sql
+\i supabase/migrations/20260723040000_analytics_dimensions.sql
+\i supabase/migrations/20260723041000_session_first_seen.sql
+```
+
+(o `supabase db push` apuntando al proyecto de prod, según el flujo del founder.)
+
+---
+
+## 4. Consultas POST (estado esperado DESPUÉS de aplicar)
+
+```sql
+-- (a) Las 8 columnas presentes, todas nullable, text → 8 filas is_nullable='YES'
+select column_name, is_nullable, data_type from information_schema.columns
+where table_name = 'analytics_events'
+  and column_name in ('surface','container','locale','country',
+                      'source','campaign','app_version','visit_id')
+order by column_name;
+
+-- (b) Los 3 índices nuevos → 3 filas
+select indexname from pg_indexes
+where tablename = 'analytics_events'
+  and indexname in ('idx_analytics_events_surface',
+                    'idx_analytics_events_container',
+                    'idx_analytics_events_country');
+
+-- (c) CHECK presente y NOT VALID → 1 fila, convalidated = false
+select conname, convalidated from pg_constraint
+where conname = 'analytics_events_country_iso2';
+
+-- (d) Tabla de cohortes + índice + PK + RLS habilitada
+select to_regclass('public.session_first_seen');                 -- session_first_seen
+select indexname from pg_indexes where tablename = 'session_first_seen';
+select relrowsecurity from pg_class where relname = 'session_first_seen';  -- t
+
+-- (e) Sin pérdida de datos: igual al baseline PRE (d)
+select count(*) as analytics_events_rows_post from analytics_events;
+
+-- (f) El CHECK funciona (test seguro, con rollback)
+begin;
+  insert into analytics_events(session_id, event, country) values ('runbook','post_check','US'); -- OK
+  -- La línea siguiente DEBE fallar con SQLSTATE 23514 (country lowercase):
+  -- insert into analytics_events(session_id, event, country) values ('runbook','post_check','us');
+rollback;
+```
+
+---
+
+## 5. Rollback (si hiciera falta)
+
+Aditivo ⇒ reversible sin pérdida de datos de negocio (las columnas nuevas están vacías en filas
+existentes):
+
+```sql
+drop index if exists idx_analytics_events_surface;
+drop index if exists idx_analytics_events_container;
+drop index if exists idx_analytics_events_country;
+alter table analytics_events drop constraint if exists analytics_events_country_iso2;
+alter table analytics_events
+  drop column if exists surface, drop column if exists container,
+  drop column if exists locale, drop column if exists country,
+  drop column if exists source, drop column if exists campaign,
+  drop column if exists app_version, drop column if exists visit_id;
+drop table if exists session_first_seen;
+```
+
+> Solo tiene sentido si aún no se escribieron dimensiones. Una vez que hay datos en las columnas,
+> el rollback los descarta — evaluar antes.
+
+---
+
+## 6. Smoke checklist de producción (tras deploy del PR de código)
+
+Correr con el código ya desplegado y las migraciones aplicadas.
+
+### 6.1 Dimensiones
+- [ ] Abrir la app live y disparar un evento (p.ej. ver el hub). Luego:
+```sql
+select event, surface, container, locale, source, app_version, visit_id, country, created_at
+from analytics_events order by created_at desc limit 10;
+```
+- [ ] `surface` ∈ {learn, play}; `container` ∈ {minipay, browser}; `locale` seteado;
+      `app_version` = sha de 7 chars (no `dev`); `visit_id` seteado; `country` = código de 2
+      letras (o `null` si el edge no mandó el header).
+
+### 6.2 `app_opened` once-per-visit
+- [ ] Pestaña nueva → exactamente **un** `app_opened` para ese `visit_id`. Verificar que ninguno
+      se duplique:
+```sql
+select visit_id, count(*) from analytics_events
+where event = 'app_opened' and created_at > now() - interval '1 hour'
+group by visit_id having count(*) > 1;   -- esperado: 0 filas
+```
+
+### 6.3 `session_first_seen`
+- [ ] Primer `app_opened` de un install nuevo inserta una fila; una segunda visita NO la sobrescribe:
+```sql
+select session_id, first_seen, first_surface, first_container, first_country, first_source
+from session_first_seen order by first_seen desc limit 10;
+```
+- [ ] `first_seen` estable para el mismo `session_id` entre visitas.
+
+### 6.4 Filtros `/stats`
+- [ ] Cargar `/stats`, `/stats?surface=learn`, `/stats?surface=play&container=minipay`, y un
+      inválido `/stats?surface=bogus`.
+- [ ] Los chips reflejan el filtro activo; el inválido cae a **All**; los números cambian por
+      filtro (App Opens, activación, top countries, retención D1/D7); la página nunca 500ea;
+      el sello "as of" está presente.
+
+### 6.5 Privacidad + fail-open
+- [ ] En `country` solo aparecen códigos de 2 letras — ningún IP/ciudad/coordenada en ninguna
+      columna ni en `props`.
+- [ ] Bloquear `/api/telemetry` (outage simulado) NO rompe ninguna acción de usuario.
+- [ ] Dentro del WebView de MiniPay (device real) `container` = `minipay`.
+
+Wolfcito 🐾 @akawolfcito

--- a/docs/specs/2026-07-23-observability-lote-1-spec.md
+++ b/docs/specs/2026-07-23-observability-lote-1-spec.md
@@ -1,0 +1,174 @@
+# Spec — Observabilidad Lote 1 (dimensiones + app_opened + retención D1/D7 + /stats)
+
+**Fecha:** 2026-07-23 · **Base:** `docs/audits/2026-07-23-product-observability-audit.md` (aprobado)
+**Regla dura:** analytics NUNCA hace fallar el negocio. Migración **aditiva y backward-compatible**.
+**Stop:** no aplicar migraciones a producción en esta fase.
+
+---
+
+## 1. Semántica de sesión (resuelta por diagnóstico)
+
+| Concepto | Fuente | Vida | Uso |
+|----------|--------|------|-----|
+| `session_id` (**= anonymous_id**) | `localStorage` `chesscito:analytics-session` (ya existe) | Persistente, nunca rota | Retención/cohortes (D1/D7/D30), unique users |
+| `visit_id` (**nuevo**) | `sessionStorage` `chesscito:visit-id` | Por pestaña/visita | `app_opened` once-per-visit, funnels por visita |
+
+**No se renombra `session_id`** (evita migración grande). Se documenta que su semántica es
+anonymous_id y se **añade** `visit_id` como columna nullable.
+
+---
+
+## 2. Contrato de datos (SDD — tipos primero)
+
+### 2.1 Migración aditiva `20260723xxxxxx_analytics_dimensions.sql`
+Columnas nullable en `analytics_events` (todas backward-compatible; filas viejas quedan `null`):
+
+```
+surface      text        -- 'learn' | 'play'  (CHECK opcional, ver red-team cardinalidad)
+container    text        -- 'minipay' | 'browser'
+locale       text        -- 'en' | 'es' | ...  (del path)
+country      text        -- ISO-3166-1 alpha-2, MAYÚS, 2 chars, o null
+source       text        -- allow-list canónica (ver 2.3)
+campaign     text        -- sanitizado, allow-list de params, o null
+app_version  text        -- NEXT_PUBLIC_BUILD_SHA (7 chars) o 'dev'
+visit_id     text        -- id de visita (sessionStorage), o null
+```
+Índices nuevos (solo los que el MVP consulta): `(surface, created_at desc)`,
+`(container, created_at desc)`, `(country, created_at desc)`, `(event, created_at desc)` ya existe.
+
+### 2.2 Tabla de cohortes `session_first_seen` (sobrevive a la poda de 90 días)
+```
+session_first_seen (
+  session_id   text primary key,
+  first_seen   timestamptz not null default now(),   -- día 0 de la cohorte
+  first_surface   text,        -- surface de la primera visita
+  first_container text,
+  first_country   text,
+  first_source    text
+)
+```
+Diseñada para D1/D7/**D30** sin otra migración (la fila NO se poda). Upsert idempotente:
+`insert ... on conflict (session_id) do nothing` → solo la primera visita fija la cohorte.
+
+### 2.3 Allow-lists (server-side, en `/api/telemetry`)
+- `surface`: `{learn, play}` — otro valor → `null`.
+- `container`: `{minipay, browser}`.
+- `country`: regex `^[A-Z]{2}$` — cualquier otra cosa → `null`.
+- `source` canónica (pequeña): `{direct, minipay_discovery, challenge_link, share_whatsapp,
+  share_generic, qr, unknown}`. Fuera de lista → `unknown`.
+- `campaign`: solo si `source` la permite; `[a-z0-9_-]{1,32}` sanitizado; si no → `null`.
+- `app_version`: `[a-z0-9]{1,12}`.
+
+### 2.4 Payload cliente extendido (`track()`)
+`track(event, props)` agrega automáticamente `session_id`, `visit_id`, `surface`, `container`,
+`locale`, `app_version`, `source`, `campaign`. `country` se resuelve **server-side** (nunca cliente).
+
+---
+
+## 3. Enriquecimiento (de dónde sale cada dimensión)
+
+| Dim | Origen | Capa |
+|-----|--------|------|
+| `surface` | `CHESSCITO_MODE` (`lib/feature-flags.ts`) → learn/play | build/client |
+| `container` | `isMiniPayEnv()` (`lib/minipay.ts`) | client (runtime) |
+| `locale` | primer segmento del path (`useParams`/`usePathname`) | client |
+| `app_version` | `NEXT_PUBLIC_BUILD_SHA` | build/client |
+| `source`/`campaign` | URL params en el **primer** load → persistidos en `localStorage` (allow-list) | client |
+| `country` | header `x-vercel-ip-country` en `/api/telemetry` | **server** |
+| `visit_id` | `sessionStorage` (crea si falta) | client |
+
+---
+
+## 4. Evento raíz `app_opened`
+
+- Se emite **exactamente una vez por visita**: guard en `sessionStorage`
+  (`chesscito:app-opened-fired`). Si ya está, no re-emite (cubre navegación, StrictMode, remount).
+- **No depende de wallet** ni de conexión.
+- Punto de montaje: componente cliente en `layout.tsx` (persiste; NO en `template.tsx`).
+- En el mismo tick, upsert de `session_first_seen` (vía `/api/telemetry` o endpoint dedicado).
+
+---
+
+## 5. Normalización mínima (con shim backward-compatible)
+
+Solo 4 canónicos. **No se tocan los ~120.** Shim: los alias siguen emitiéndose Y se emite el
+canónico (o el canónico reemplaza y se mantiene el alias como no-op documentado — decisión en impl).
+
+| Canónico | Alias existentes que lo alimentan |
+|----------|-----------------------------------|
+| `hub_viewed` | `hub_view`, `play_hub_view` |
+| `exercise_started` | `exercise` starts, `training_exercise_started`, `daily_tactic_started`, `play_tactics_opened` |
+| `exercise_completed` | `exercise_complete`, `training_exercise_completed`, `play_tactics_completed` |
+| `daily_focus_completed` | `daily_tactic_completed` (Daily Focus) |
+
+Mapa canónico en `lib/analytics/canonical-events.ts` (nuevo), testeado.
+
+---
+
+## 6. `/stats` (una sola página, con filtros)
+
+Añadir al aggregator + vista existentes (sin ruta nueva):
+- Filtros `surface` (Learn|Play|Ambos) y `container` (MiniPay|Browser|Ambos) — client-side sobre
+  datos pre-agregados por dimensión, o querystring que re-agrega server-side (decisión en impl;
+  preferir server para no exponer filas crudas).
+- **App opens** (conteo de `app_opened`, por día).
+- **Activación** (funnel `app_opened → hub_viewed → exercise_started → exercise_completed →
+  daily_focus_completed`), conteos absolutos (sin rates, como `ChallengeFunnel`).
+- **Top countries** (conteo por `country`, top N, excluye `null`).
+- **Retención D1/D7** (cohortes desde `session_first_seen`).
+- **as-of** (`generatedAt`, ya existe).
+
+---
+
+## 7. Red-team
+
+### Privacidad
+- ✅ `country` solo ISO alpha-2 (regex `^[A-Z]{2}$`); jamás IP/ciudad/región/postal/lat/long.
+- ✅ IP nunca se persiste; se lee el header ya resuelto por el edge y se descarta.
+- ✅ `source`/`campaign` por allow-list — nunca referrer/URL cruda ni query params arbitrarios.
+- ✅ `session_id`/`visit_id` opacos, sin wallet/PII.
+- ⚠️ **Gate de producción:** Privacy Policy EN/ES actualizada ANTES de activar captura de `country`.
+
+### Duplicados / idempotencia
+- `app_opened`: guard `sessionStorage` → once-per-visit aun con StrictMode/remount/navegación.
+- `session_first_seen`: `on conflict do nothing` → la cohorte no se re-fija en visitas posteriores.
+- Normalización: el shim NO debe hacer doble-conteo del canónico (test que lo fija).
+
+### Definición de sesión
+- `session_id` = persistente (anonymous). `visit_id` = por pestaña. Documentado en código y spec.
+- Cerrar/reabrir la pestaña → nuevo `visit_id`, mismo `session_id` → nuevo `app_opened`, misma
+  cohorte. Correcto.
+
+### Cardinalidad
+- Dimensiones de **baja cardinalidad** (surface 2, container 2, country ~O(100), source ~7,
+  app_version O(deploys), locale O(pocos)). Seguras para indexar y agrupar.
+- `campaign`/`source` fuera de allow-list colapsan a `unknown` → evita explosión de cardinalidad.
+- `visit_id` es alta cardinalidad pero **no se indexa** (no se agrupa por él en el MVP).
+
+---
+
+## 8. Plan por commits atómicos
+
+1. `feat(analytics): session semantics + visit_id (sessionStorage)` — helpers + tests. Sin schema.
+2. `feat(db): additive analytics dimension columns (migration)` — solo SQL + tipos. Nullable.
+3. `feat(db): session_first_seen cohort table (migration)` — SQL + upsert helper + tests.
+4. `feat(analytics): enrich track() with dims + server-side country` — client dims + `/api/telemetry`
+   allow-lists + header. Tests de sanitización/allow-list.
+5. `feat(analytics): app_opened once-per-visit + first_seen upsert` — mount en layout + guard. Tests.
+6. `feat(analytics): canonical event map + shim` — `hub_viewed`/`exercise_*`/`daily_focus_completed`.
+7. `feat(stats): surface/container filters + app opens + activation` — aggregator + vista.
+8. `feat(stats): top countries + retention D1/D7` — cohortes desde `session_first_seen`.
+9. `docs(privacy): EN/ES analytics disclosure` — identificador anónimo, país aprox. de IP, no IP
+   completa, finalidad agregada producto/seguridad, retención (90d eventos / cohortes persistentes).
+
+Cada commit: TDD, suite verde reportada, atómico.
+
+## 9. Verificación (antes de prod)
+- Ensayar migraciones 2/3 contra réplica local (Supabase local), no prod.
+- Tests focalizados por commit + suite completa + `pnpm exec tsc --noEmit`.
+- Verificación visual de `/stats` (filtros, funnel, top countries, retención, as-of).
+- **STOP antes de aplicar migraciones a producción.**
+
+## 10. Fuera de alcance (confirmado)
+Reconciliación de pagos/rewards · métricas on-chain completas · D3/D21 · renombrar catálogo ·
+SaaS · warehouse · ciudad/geo precisa · página Learn/Play separada · cron reconciliador.


### PR DESCRIPTION
## Observability Lote 1 — code (dimensions, app_opened, retention, /stats filters)

The rest of Observability Lote 1, **excluding** the Privacy Policy commit (shipped separately in #270). Prepared now; **merge only after #270 is live and the migrations are applied with human approval**.

### ⚠️ Merge order (hard requirement)
1. **#270 (Privacy Policy) → live in production first.**
2. Apply the two additive migrations — **human approval required** (`docs/ops/2026-07-23-lote-1-migration-runbook.md`).
3. **Then** merge this PR.

Merging this before #270 would ship analytics code while the policy still says "no analytics". Merging before the migrations means the new columns don't exist yet — the code is fail-open (blocks degrade to em-dash), but the data isn't captured until the migrations land.

### What's in it (10 atomic commits)
- **Session semantics:** `session_id` = persistent anonymous id; new per-visit `visit_id` (sessionStorage).
- **Migrations (additive, nullable):** 8 dimension columns on `analytics_events` (surface, container, locale, country, source, campaign, app_version, visit_id) + `session_first_seen` cohort table (survives the 90-day prune).
- **Enrichment:** client stamps dims; server re-sanitizes via shared allow-lists and derives `country` **only** from `x-vercel-ip-country` (ISO alpha-2, never IP/city). First-touch attribution.
- **`app_opened`:** fires once per visit (sessionStorage guard) + idempotent `session_first_seen` upsert.
- **Canonical funnel map:** read-time alias folding (`hub_viewed` / `exercise_started` / `exercise_completed` / `daily_focus_completed`) — no rename of the ~120 events, no double-write.
- **/stats:** server-side surface/container filters (querystring, `unstable_cache` keyed, revalidate 3600), app opens, activation funnel, top countries, D1/D7 retention. Single page.
- **Fail-open fix:** `track()` never throws from dimension gathering — analytics can't break a user action.
- **Docs:** audit, spec, handoff, and the migration runbook + production smoke checklist.

### Migrations & smoke
Dry-run, pre/post verification queries, rollback, and the production smoke checklist (dimensions, `app_opened` once-per-visit, `session_first_seen`, `/stats` filters) live in `docs/ops/2026-07-23-lote-1-migration-runbook.md`. **Migrations are NOT applied by this PR.**

### Verification
- Full suite green on the combined branch (5739 passing / 510 files, 0 failures, no ELIFECYCLE).
- This branch: `tsc --noEmit` clean; analytics + stats + content tests 343/343.
- Migrations rehearsed idempotently on local Supabase.
- `/stats` visually verified (default + filtered), fail-open confirmed.

### Out of scope (Lote 2)
Server-authoritative payment/reward reconciliation, full on-chain §8 metrics, D30/D3/D21, full catalog rename, external SaaS, warehouse.

Wolfcito 🐾 @akawolfcito
